### PR TITLE
[merge 2/5] the meetings domain

### DIFF
--- a/core/meetings/README.md
+++ b/core/meetings/README.md
@@ -10,7 +10,7 @@ composed three ways (desktop process · bot container · split cloud services). 
 
 **This domain is about:** joining meetings, capturing + transcribing them, the meeting row + bot
 lifecycle, meeting status, and the **transcript** — it is the *single writer* of the transcript carrier
-(P23). **It is never about:** the copilot, chat, the agent's workspace, or what gets *extracted* from a
+(P23). **It is never about:** chat, the agent's workspace, or what gets *extracted* from a
 transcript — that is the **agent** domain. `meetings ⊥ agent`: the two domains never call each other; they
 meet **only at the gateway**, over published contracts (`transcript.v1`, `api.v1`). See
 [`docs/docs/architecture/control-plane.mdx`](../../docs/docs/architecture/control-plane.mdx).

--- a/core/meetings/modules/record-chunker/src/index.ts
+++ b/core/meetings/modules/record-chunker/src/index.ts
@@ -91,6 +91,16 @@ export class MediaRecorderChunker implements RecordingTap {
     return this.recorder;
   }
 
+  /** Force the recorder to emit a chunk NOW with everything buffered since the last timeslice —
+   *  without stopping. The tail-loss fix: on eviction Zoom navigates the page away (destroying the
+   *  recorder) before the next timeslice boundary, so the last partial (the final few seconds of
+   *  speech) never becomes a chunk. Flushing at the earliest end-signal (the mix going silent) turns
+   *  that partial into a real, immediately-uploaded chunk before the context dies. Idempotent + safe. */
+  flush(): void {
+    try { if (this.recorder && this.recorder.state === "recording") this.recorder.requestData(); }
+    catch (err: any) { blog(`[record-chunker] flush() requestData failed: ${err?.message || err}`); }
+  }
+
   async start(): Promise<void> {
     if (this.recorder) {
       blog("[record-chunker] start() called twice — ignoring");
@@ -237,56 +247,98 @@ export class MediaRecorderChunker implements RecordingTap {
 // ───────────────────────────────────────────────────────────────────────
 
 /**
- * Find active media elements that expose audio. Two-pass (strict → relaxed):
- * tiles can be paused or expose audio via captureStream() rather than a direct
- * srcObject, so the relaxed pass mirrors buildCombinedStream's fallbacks. This
- * is platform-agnostic — a recording grabs every audio element on the page.
+ * Every on-page audio-bearing MediaStream that is CURRENTLY producing audio (has a `live` track).
+ * Prefers `srcObject`; falls back to a captureStream() cached on the element (a fresh captureStream()
+ * each scan would mint a new stream id, defeating the mixer's dedup and leaking source nodes). Deduped
+ * downstream by stream id. Platform-agnostic — a recording grabs every audio element on the page.
  */
-async function findMediaElements(retries = 5, delay = 2000): Promise<HTMLMediaElement[]> {
-  for (let i = 0; i < retries; i++) {
-    const all = Array.from(document.querySelectorAll("audio, video"));
-    let els = all.filter((el: any) =>
-      !el.paused && el.srcObject instanceof MediaStream && el.srcObject.getAudioTracks().length > 0
-    ) as HTMLMediaElement[];
-    if (els.length > 0) { blog(`[record-chunker] ${els.length} media elements (strict)`); return els; }
-
-    els = all.filter((el: any) => {
-      try {
-        if (el.srcObject instanceof MediaStream && el.srcObject.getAudioTracks().length > 0) return true;
-        if (typeof el.captureStream === "function" && el.captureStream()?.getAudioTracks?.().length > 0) return true;
-        if (typeof el.mozCaptureStream === "function" && el.mozCaptureStream()?.getAudioTracks?.().length > 0) return true;
-      } catch { /* not probeable; skip */ }
-      return false;
-    }) as HTMLMediaElement[];
-    if (els.length > 0) { blog(`[record-chunker] ${els.length} media elements (relaxed)`); return els; }
-
-    await new Promise((r) => setTimeout(r, delay));
+function collectAudioStreams(): MediaStream[] {
+  const els = Array.from(document.querySelectorAll("audio, video")) as any[];
+  const out: MediaStream[] = [];
+  for (const el of els) {
+    try {
+      let s: MediaStream | null = el.srcObject instanceof MediaStream ? el.srcObject : null;
+      if (!s) {
+        const cap: unknown =
+          el.__vexaRecCapStream instanceof MediaStream ? el.__vexaRecCapStream :
+          typeof el.captureStream === "function" ? el.captureStream() :
+          typeof el.mozCaptureStream === "function" ? el.mozCaptureStream() : null;
+        if (cap instanceof MediaStream) { el.__vexaRecCapStream = cap; s = cap; }
+      }
+      // Only LIVE audio: an element lingering with an ENDED track must not re-enter the mix (it would
+      // reconnect a dead source every scan and oscillate against the prune below).
+      if (s && s.getAudioTracks().some((t) => t.readyState === "live")) out.push(s);
+    } catch { /* not probeable; skip */ }
   }
-  return [];
+  return out;
 }
 
-/** Mix every media element's audio into one MediaStream via a destination node. */
-async function buildCombinedStream(mediaElements: HTMLMediaElement[]): Promise<MediaStream> {
-  if (mediaElements.length === 0) throw new Error("[record-chunker] no media elements to combine");
-  const ctx = new AudioContext();
-  const dest = ctx.createMediaStreamDestination();
-  let connected = 0;
-  mediaElements.forEach((element: any, index) => {
-    try {
-      const s =
-        element.srcObject ||
-        (element.captureStream && element.captureStream()) ||
-        (element.mozCaptureStream && element.mozCaptureStream());
-      if (s instanceof MediaStream && s.getAudioTracks().length > 0) {
-        ctx.createMediaStreamSource(s).connect(dest);
-        connected++;
-        blog(`[record-chunker] connected element ${index + 1}/${mediaElements.length}`);
-      }
-    } catch (e: any) { blog(`[record-chunker] could not connect element ${index + 1}: ${e?.message || e}`); }
-  });
-  if (connected === 0) throw new Error("[record-chunker] could not connect any audio streams");
-  blog(`[record-chunker] combined ${connected} streams`);
-  return dest.stream;
+/**
+ * A LIVE audio mix that FOLLOWS the meeting. One AudioContext destination that a periodic rescan keeps
+ * wired to every current on-page audio stream: it connects newly-appearing streams and prunes ones whose
+ * tracks have ended. Zoom/Teams deliver each participant as a separate WebRTC track and churn them
+ * constantly (each new track is mirrored into a fresh injected <audio> by @vexa/mixed-capture-core's
+ * hook) — so a ONE-TIME combine records silence the moment the originally-captured tracks end. Recording
+ * `dest.stream` (a STABLE handle whose sources come and go underneath) keeps the mix complete for the
+ * whole meeting. Full sample rate — deliberately NOT the 16 kHz transcription mix.
+ */
+class DynamicAudioMixer {
+  private ctx: AudioContext;
+  private dest: MediaStreamAudioDestinationNode;
+  private sources = new Map<string, { node: MediaStreamAudioSourceNode; stream: MediaStream }>();
+  private timer: ReturnType<typeof setInterval> | null = null;
+  /** Fired when the live-source count falls to 0 (all participant tracks ended — the meeting is
+   *  closing). The recording host uses it to flush the recorder's buffered tail before the page dies. */
+  private onEmpty: (() => void) | null;
+
+  constructor(onEmpty?: () => void) {
+    this.ctx = new AudioContext();   // default (full) sample rate — NOT the 16 kHz transcription mix
+    this.ctx.resume?.();
+    this.dest = this.ctx.createMediaStreamDestination();
+    this.onEmpty = onEmpty ?? null;
+  }
+
+  get stream(): MediaStream { return this.dest.stream; }
+  get connectedCount(): number { return this.sources.size; }
+
+  /** Connect newly-seen streams; prune streams whose audio has ended. Idempotent — safe every tick. */
+  scan(): void {
+    const present = new Map(collectAudioStreams().map((s) => [s.id, s]));
+    for (const [id, s] of present) {
+      if (this.sources.has(id)) continue;
+      try {
+        const node = this.ctx.createMediaStreamSource(s);
+        node.connect(this.dest);
+        this.sources.set(id, { node, stream: s });
+        blog(`[record-chunker] mix +stream (${this.sources.size} live)`);
+      } catch { /* not connectable yet — retried next tick */ }
+    }
+    // Prune truly-dead streams (all tracks ended) so a long meeting's track churn doesn't accumulate
+    // source nodes. A still-live stream is KEPT even if its element left the DOM (the node holds the
+    // stream ref and still pulls audio) — presence is not the liveness signal, the track state is.
+    const had = this.sources.size;
+    for (const [id, entry] of this.sources) {
+      if (entry.stream.getAudioTracks().some((t) => t.readyState === "live")) continue;
+      try { entry.node.disconnect(); } catch { /* */ }
+      this.sources.delete(id);
+      blog(`[record-chunker] mix -stream (${this.sources.size} live)`);
+    }
+    // Just went silent (all tracks ended → the meeting is closing) — flush the recorder's buffered tail
+    // NOW, before the platform navigates the page away and destroys the recorder mid-partial-timeslice.
+    if (had > 0 && this.sources.size === 0 && this.onEmpty) { try { this.onEmpty(); } catch { /* */ } }
+  }
+
+  start(): void {
+    this.scan();
+    this.timer = setInterval(() => { try { this.scan(); } catch { /* the rescan must never die */ } }, 2000);
+  }
+
+  stop(): void {
+    if (this.timer) { clearInterval(this.timer); this.timer = null; }
+    for (const { node } of this.sources.values()) { try { node.disconnect(); } catch { /* */ } }
+    this.sources.clear();
+    try { void this.ctx.close(); } catch { /* */ }
+  }
 }
 
 /** Options for createRecordingTap — combine all audio elements then optionally override. */
@@ -307,13 +359,27 @@ export interface CreateRecordingTapOptions extends RecordingTapOptions {
  */
 export function createRecordingTap(opts: CreateRecordingTapOptions): RecordingTap {
   let chunker: MediaRecorderChunker | null = null;
+  let mixer: DynamicAudioMixer | null = null;
   return {
     async start(): Promise<void> {
       let stream = opts.stream;
       if (!stream) {
-        const els = await findMediaElements();
-        if (els.length === 0) { blog("[record-chunker] no media elements — cannot record"); return; }
-        stream = await buildCombinedStream(els);
+        // No ready stream ⇒ build a LIVE mix of the page's audio. Wait (bounded) for the first stream —
+        // post-admission the participant / injected <audio> elements appear a beat late — so the
+        // MediaRecorder's onStarted t=0 aligns with real audio; the rescan then follows the churn.
+        // onEmpty → flush the recorder's buffered tail the instant the mix goes silent (meeting close),
+        // so the final partial timeslice (the last few seconds of speech) is a real chunk before the
+        // page navigates away on eviction. `chunker` is assigned just below and set by the time this fires.
+        mixer = new DynamicAudioMixer(() => chunker?.flush());
+        let ready = false;
+        for (let i = 0; i < 5; i++) {
+          mixer.scan();
+          if (mixer.connectedCount > 0) { ready = true; break; }
+          await new Promise((r) => setTimeout(r, 2000));
+        }
+        if (!ready) { blog("[record-chunker] no audio streams — cannot record"); mixer.stop(); mixer = null; return; }
+        mixer.start();
+        stream = mixer.stream;
       }
       chunker = new MediaRecorderChunker({
         stream,
@@ -326,6 +392,8 @@ export function createRecordingTap(opts: CreateRecordingTapOptions): RecordingTa
     async stop(): Promise<void> {
       await chunker?.stop();
       chunker = null;
+      mixer?.stop();
+      mixer = null;
     },
   };
 }

--- a/core/meetings/services/mcp/src/vexa_mcp/app.py
+++ b/core/meetings/services/mcp/src/vexa_mcp/app.py
@@ -18,6 +18,7 @@ conformance tests drive the SHIPPED app in-process with a fake gateway — the r
 from __future__ import annotations
 
 import hashlib
+import json
 import os
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
@@ -25,10 +26,16 @@ from typing import Any, Dict, List, Optional
 import httpx
 import mcp.types as mcp_types
 from fastapi import Depends, FastAPI, Header, HTTPException, Query, Request
+from fastapi.encoders import jsonable_encoder
+from fastapi.exceptions import RequestValidationError
+from fastapi.responses import JSONResponse
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from fastapi_mcp import FastApiMCP
 from pydantic import BaseModel, Field, PrivateAttr, model_validator
 
+from . import bind as bind_mod
+from . import discover as discover_mod
+from . import register as register_mod
 from .link_parser import ParseMeetingLinkResponse, parse_meeting_url
 from .prompts import PROMPTS, get_prompt_result
 from .streamable_http import install_streaming_http_transport
@@ -83,8 +90,8 @@ def _description_of(data: "ReportIssue") -> str:
     parts = [f"What I tried:\n{data.what_i_tried}", f"What happened:\n{data.what_happened}"]
     where = data.deployment + (f" {data.version}" if data.version else "")
     parts.append(f"Deployment: {where}")
-    if data.meeting_id:
-        parts.append(f"Meeting: {data.platform or 'unknown platform'} / {data.meeting_id}")
+    if data.native_meeting_id:
+        parts.append(f"Meeting: {data.platform or 'unknown platform'} / {data.native_meeting_id}")
     if data.logs:
         parts.append(f"Logs:\n{data.logs}")
     return "\n\n".join(parts)
@@ -133,8 +140,8 @@ def _github_issue_body(payload: Dict[str, Any]) -> str:
     lines.append(str(payload.get("what_happened") or "—"))
     lines.append("")
     lines.append("### Join key")
-    if payload.get("meeting_id"):
-        lines.append(f"- **meeting_id:** `{payload['meeting_id']}`")
+    if payload.get("native_meeting_id"):
+        lines.append(f"- **native_meeting_id:** `{payload['native_meeting_id']}`")
         lines.append(f"- **platform:** `{payload.get('platform') or 'unknown'}`")
         entity = payload.get("entity")
         if isinstance(entity, dict):
@@ -293,6 +300,53 @@ class UpdateBotConfig(BaseModel):
     language: str = Field(..., description="New language code for transcription (e.g., 'en', 'es')")
 
 
+class AnnotateMeeting(BaseModel):
+    title: Optional[str] = Field(
+        None, description="Human-readable title for the meeting. Max 512 chars."
+    )
+    metadata: Optional[Dict[str, Any]] = Field(
+        None,
+        description=(
+            "Arbitrary JSON you own — CRM ids, ticket refs, tags, your own summary. Merges "
+            "key-wise with what is already there; send a key as null to delete just that key. "
+            "Retrieve these meetings later with list_meetings(metadata_filter=...)."
+        ),
+    )
+
+    @model_validator(mode="after")
+    def validate_something_to_write(self):
+        if self.title is None and self.metadata is None:
+            raise ValueError("Nothing to annotate: provide title and/or metadata.")
+        return self
+
+
+class SpeakInMeeting(BaseModel):
+    text: str = Field(..., description="What the bot should say out loud in the meeting.")
+    language: Optional[str] = Field(None, description="Optional language/voice code, e.g. 'en'.")
+    # A MECHANICAL guard, not another warning. The prose warning is good and a cold-start agent
+    # did obey it — but this tool is one tools/call away from being audible to real people in a
+    # real conversation, and it will be loaded alongside a hundred others whose descriptions get
+    # skimmed. A required field the caller must set deliberately cannot be skimmed past.
+    asked_by_a_human: bool = Field(
+        ...,
+        description=(
+            "Must be true, and only set it if the person you are working for asked you to say "
+            "THIS. Everyone in the meeting hears it and it cannot be taken back. Never set it to "
+            "satisfy the schema, to test, or to acknowledge something."
+        ),
+    )
+
+    @model_validator(mode="after")
+    def refuse_unless_asked(self):
+        if self.asked_by_a_human is not True:
+            raise ValueError(
+                "speak_in_meeting: refused. This says words out loud to real people and cannot be "
+                "undone. Set asked_by_a_human=true only when the person you work for asked you to "
+                "say this; otherwise do not call this tool."
+            )
+        return self
+
+
 class ParseMeetingLinkRequest(BaseModel):
     meeting_url: str = Field(..., description="Full meeting URL to parse.")
 
@@ -322,7 +376,7 @@ class ReportIssue(BaseModel):
             "plus the version if you know it (e.g. 'self-hosted 0.12.3')."
         ),
     )
-    meeting_id: Optional[str] = Field(
+    native_meeting_id: Optional[str] = Field(
         None,
         description=(
             "The native meeting id this issue concerns (e.g. 'abc-defg-hij'). Include it whenever "
@@ -373,7 +427,7 @@ class ReportIssue(BaseModel):
         self.what_i_tried = _clip(self.what_i_tried, _MAX_TEXT_CHARS)
         self.what_happened = _clip(self.what_happened, _MAX_TEXT_CHARS)
         self.deployment = _clip(self.deployment, 200)
-        self.meeting_id = _clip(self.meeting_id, 200)
+        self.native_meeting_id = _clip(self.native_meeting_id, 200)
         self.platform = _clip(self.platform, 50)
         self.version = _clip(self.version, 100)
         self._logs_truncated = bool(self.logs and len(self.logs.strip()) > _MAX_LOGS_CHARS)
@@ -381,16 +435,160 @@ class ReportIssue(BaseModel):
         return self
 
 
+# ---------------------------
+# Meeting identity — ONE vocabulary across the whole surface
+# ---------------------------
+# Every tool that RETURNS a meeting returns ``platform`` + ``native_meeting_id`` (so does the
+# public REST API: ``/transcripts/{platform}/{native_meeting_id}``). Three tools used to ACCEPT
+# ``meeting_platform`` + ``meeting_id`` instead, so no tool's output could be fed to the next
+# tool's input without a rename nothing documented. A model chaining calls reads
+# ``native_meeting_id`` off one result and passes it to the next — the correct inference, and it
+# failed. The canonical names below are the ones every tool returns; the old spellings stay as
+# deprecated aliases so no existing client breaks.
+_PLATFORM_DESC = (
+    "Meeting platform: google_meet, teams, zoom, jitsi. Same value that request_meeting_bot, "
+    "list_meetings and parse_meeting_link return as `platform`. Defaults to google_meet."
+)
+_ID_DESC = (
+    "The meeting's native id — exactly the `native_meeting_id` returned by request_meeting_bot, "
+    "list_meetings or parse_meeting_link (e.g. 'abc-defg-hij' for Google Meet)."
+)
+_LEGACY_PLATFORM_DESC = "DEPRECATED alias for `platform`. Use `platform`."
+_LEGACY_ID_DESC = "DEPRECATED alias for `native_meeting_id`. Use `native_meeting_id`."
+
+
+#: The platforms the link parser can actually produce. A value outside this set is a caller
+#: mistake, and answering it with an empty result set is the worst possible reply: a cold-start
+#: agent reported that `platform="webex"` returned a confident `count: 0`, indistinguishable from
+#: "nobody said that". Silence that looks like an answer is worse than an error.
+VALID_PLATFORMS = ("google_meet", "teams", "zoom", "jitsi")
+
+
+def _validate_platform(tool: str, platform: Optional[str]) -> Optional[str]:
+    """Reject an unknown platform loudly rather than filtering everything away."""
+    if platform is None or platform in VALID_PLATFORMS:
+        return platform
+    raise HTTPException(
+        status_code=422,
+        detail=(
+            f"{tool}: unknown platform {platform!r}. Valid values: "
+            f"{', '.join(VALID_PLATFORMS)}. Omit `platform` to search every platform."
+        ),
+    )
+
+
+async def reject_unknown_arguments(request: Request) -> None:
+    """Refuse query parameters the route does not declare.
+
+    FastAPI ignores extras, so `get_meeting_transcript(limit=2)` — no such parameter — returned
+    200 with the argument silently dropped. For an agent that is the worst failure mode available:
+    a typo'd or hallucinated parameter looks like it worked, and the wrong answer is indistinguishable
+    from the right one. Named near-misses are called out, because the commonest cause is a caller
+    reaching for another tool's parameter name.
+    """
+    route = request.scope.get("route")
+    if route is None or not getattr(route, "dependant", None):
+        return
+    known = {p.alias or p.name for p in route.dependant.query_params}
+    unknown = sorted(set(request.query_params.keys()) - known)
+    if not unknown:
+        return
+    # Substring matching alone misses the commonest real case — a caller reaching for another
+    # tool's parameter name and getting the word order wrong (`meeting_id_native`). difflib
+    # catches transpositions and typos that `in` does not.
+    import difflib
+
+    hints = []
+    for got in unknown:
+        near = difflib.get_close_matches(got, sorted(known), n=1, cutoff=0.5)
+        if not near:
+            near = [k for k in sorted(known) if k != got and (got in k or k in got)][:1]
+        if near:
+            hints.append(f"`{got}` — did you mean `{near[0]}`?")
+    tool = getattr(route, "operation_id", None) or getattr(route, "name", "this tool")
+    detail = {
+        "tool": tool,
+        "message": f"{tool}: unknown argument(s) {unknown}. This tool accepts {sorted(known)}.",
+        "unknown": unknown,
+        "accepted": sorted(known),
+    }
+    if hints:
+        detail["hint"] = "; ".join(hints)
+        detail["message"] = f"{tool}: unknown argument(s) — {detail['hint']}"
+    raise HTTPException(status_code=422, detail=detail)
+
+
+def _resolve_identity(
+    tool: str,
+    platform: Optional[str],
+    native_meeting_id: Optional[str],
+    legacy_platform: Optional[str],
+    legacy_id: Optional[str],
+) -> tuple[str, str]:
+    """Accept the canonical names or the deprecated aliases; fail with a message you can act on."""
+    mid = (native_meeting_id or legacy_id or "").strip()
+    plat = (platform or legacy_platform or "google_meet").strip()
+    if not mid:
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                f"{tool}: missing the meeting id. Pass `native_meeting_id` (the field "
+                f"request_meeting_bot / list_meetings / parse_meeting_link return), optionally "
+                f"with `platform`. Received: native_meeting_id=None, meeting_id=None."
+            ),
+        )
+    return plat, mid
+
+
+# What a client is told the moment it connects. Per-tool descriptions cannot carry orientation —
+# this is the map: what Vexa is, and the one sequence that matters.
+VEXA_INSTRUCTIONS = """\
+Vexa puts a transcription bot into a live meeting (Google Meet, Microsoft Teams, Zoom, Jitsi) and \
+gives you the transcript while the meeting is still running.
+
+The canonical flow:
+  1. parse_meeting_link(meeting_url)  → platform + native_meeting_id (pure; no side effects)
+  2. request_meeting_bot(meeting_url) → sends the bot. A human in the meeting must ADMIT it, so
+     expect a delay between `requested` and `active`.
+  3. get_meeting_transcript(platform, native_meeting_id) → segments, WHILE the meeting runs.
+     Poll it to follow a live meeting; pass `since_index` to get only what is new since your last
+     call instead of re-reading the whole transcript.
+  4. stop_bot(platform, native_meeting_id) when you are done.
+
+Identity: every tool returns `platform` + `native_meeting_id`, and every tool accepts those same \
+two names. Feed one tool's output straight into the next.
+
+Make the data yours: annotate_meeting attaches a title and arbitrary metadata — a CRM id, a \
+ticket, tags, your own summary — to a meeting, DURING it or after it ended. Anything you put \
+there you can find again with list_meetings(metadata_filter={...}), searched in the database \
+rather than on one page. If you learn something durable about a meeting, write it back; that is \
+what lets the next agent (or the next you) pick it up.
+
+The bot is a PARTICIPANT, not just a recorder: get_meeting_chat reads the in-call chat, and \
+speak_in_meeting says something out loud to everyone present. Speaking is irreversible and \
+visible to real people — do it only when the person you work for asked you to say that thing, \
+never to test and never on your own initiative.
+
+A meeting with status `active` and zero segments usually means the bot has not been admitted yet, \
+or nobody has spoken — it does not mean transcription is broken.
+"""
+
+
 def create_app(
     gateway_url: Optional[str] = None,
     *,
     transport: Optional[httpx.AsyncBaseTransport] = None,
+    assembly_env: Optional[dict] = None,
+    assembly_transport: Optional[httpx.BaseTransport] = None,
 ) -> FastAPI:
     """Build the MCP service app.
 
     ``gateway_url`` — the PUBLIC API base (env ``GATEWAY_URL``, compose ``http://gateway:8000``).
     ``transport``   — optional httpx transport override; the tests inject ``httpx.MockTransport``
                       so the shipped forwarding path runs with no network.
+    ``assembly_env`` / ``assembly_transport`` — the same seam for the DISCOVERY hop: which domains
+                      this deployment carries, and how their manifests are fetched. `VEXA_MCP_ASSEMBLY_OFF`
+                      skips assembly entirely, which is what the fourteen-tool surface tests want.
     """
     base_url = (gateway_url or os.getenv("GATEWAY_URL") or _DEFAULT_GATEWAY_URL).rstrip("/")
 
@@ -398,6 +596,11 @@ def create_app(
     _public_docs = _vexa_env != "production"
     app = FastAPI(
         title="Vexa MCP Service (v0.12)",
+        # Applied to every route at once rather than injected per-signature: a tool that silently
+        # ignores an argument it does not know is the worst reply available to an agent, so this
+        # must hold for ALL of them, including any added later. The /mcp transport is an ASGI
+        # mount rather than a route, so it is unaffected.
+        dependencies=[Depends(reject_unknown_arguments)],
         docs_url="/docs" if _public_docs else None,
         redoc_url="/redoc" if _public_docs else None,
         openapi_url="/openapi.json" if _public_docs else None,
@@ -440,6 +643,43 @@ def create_app(
     @app.get("/health", include_in_schema=False)
     async def health():
         return {"status": "ok", "service": "mcp"}
+
+    # --- validation errors an agent can act on.
+    # The stock message is "Input validation error: 'meeting_id' is a required property": it names
+    # neither the tool nor what was actually sent, so a caller that guessed a near-miss parameter
+    # name has no way to self-correct except by re-reading the schema. Name the tool, echo the
+    # parameters received, and point at the near-miss.
+    @app.exception_handler(RequestValidationError)
+    async def _validation_error(request: Request, exc: RequestValidationError):
+        tool = "unknown_tool"
+        route = request.scope.get("route")
+        if route is not None:
+            tool = getattr(route, "operation_id", None) or getattr(route, "name", None) or tool
+
+        received = sorted(set(request.query_params.keys()))
+        missing = [
+            str(err["loc"][-1]) for err in exc.errors()
+            if err.get("type") == "missing" and err.get("loc")
+        ]
+        hints = []
+        for want in missing:
+            near = [
+                got for got in received
+                if got != want and (got in want or want in got or got.endswith(want) or want.endswith(got))
+            ]
+            if near:
+                hints.append(f"you sent `{near[0]}` — this tool expects `{want}`")
+        detail = {
+            "tool": tool,
+            "message": f"{tool}: invalid arguments.",
+            "missing": missing,
+            "received": received or ["(none)"],
+            "errors": exc.errors(),
+        }
+        if hints:
+            detail["hint"] = "; ".join(hints)
+            detail["message"] = f"{tool}: invalid arguments — {detail['hint']}."
+        return JSONResponse(status_code=422, content=jsonable_encoder({"detail": detail}))
 
     # ---------------------------
     # Tools (each a FastAPI route; operation_id = MCP tool name)
@@ -506,29 +746,40 @@ def create_app(
         """
         return await make_request("GET", f"{base_url}/bots/status", api_key)
 
-    @app.put("/bot-config/{meeting_platform}/{meeting_id}", operation_id="update_bot_config")
+    @app.put("/bot-config", operation_id="update_bot_config")
     async def update_bot_config(
-        meeting_id: str,
         data: UpdateBotConfig,
-        meeting_platform: str = "google_meet",
+        native_meeting_id: Optional[str] = Query(None, description=_ID_DESC),
+        platform: Optional[str] = Query(None, description=_PLATFORM_DESC),
+        meeting_id: Optional[str] = Query(None, deprecated=True, description=_LEGACY_ID_DESC),
+        meeting_platform: Optional[str] = Query(None, deprecated=True, description=_LEGACY_PLATFORM_DESC),
         api_key: str = Depends(get_api_key),
     ) -> Dict[str, Any]:
         """
         Update the configuration of an active bot (e.g., changing the transcription language).
+        Identify the meeting with `platform` + `native_meeting_id` — the exact field names
+        request_meeting_bot, list_meetings and parse_meeting_link hand back.
         """
-        url = f"{base_url}/bots/{meeting_platform}/{meeting_id}/config"
-        return await make_request("PUT", url, api_key, data.model_dump())
+        plat, mid = _resolve_identity(
+            "update_bot_config", platform, native_meeting_id, meeting_platform, meeting_id
+        )
+        return await make_request("PUT", f"{base_url}/bots/{plat}/{mid}/config", api_key, data.model_dump())
 
-    @app.delete("/bot/{meeting_platform}/{meeting_id}", operation_id="stop_bot")
+    @app.delete("/bot", operation_id="stop_bot")
     async def stop_bot(
-        meeting_id: str,
-        meeting_platform: str = "google_meet",
+        native_meeting_id: Optional[str] = Query(None, description=_ID_DESC),
+        platform: Optional[str] = Query(None, description=_PLATFORM_DESC),
+        meeting_id: Optional[str] = Query(None, deprecated=True, description=_LEGACY_ID_DESC),
+        meeting_platform: Optional[str] = Query(None, deprecated=True, description=_LEGACY_PLATFORM_DESC),
         api_key: str = Depends(get_api_key),
     ) -> Dict[str, Any]:
         """
         Remove an active bot from a meeting.
+        Identify the meeting with `platform` + `native_meeting_id` — the exact field names
+        request_meeting_bot, list_meetings and parse_meeting_link hand back.
         """
-        return await make_request("DELETE", f"{base_url}/bots/{meeting_platform}/{meeting_id}", api_key)
+        plat, mid = _resolve_identity("stop_bot", platform, native_meeting_id, meeting_platform, meeting_id)
+        return await make_request("DELETE", f"{base_url}/bots/{plat}/{mid}", api_key)
 
     @app.get("/meetings", operation_id="list_meetings")
     async def list_meetings(
@@ -536,11 +787,23 @@ def create_app(
         offset: Optional[int] = Query(0, ge=0, description="Number of meetings to skip"),
         status: Optional[str] = Query(None, description="Filter by status: active, completed, failed"),
         platform: Optional[str] = Query(None, description="Filter by platform: google_meet, teams, zoom"),
+        metadata_filter: Optional[str] = Query(
+            None,
+            description=(
+                'JSON object — return only meetings whose metadata (set via annotate_meeting) '
+                'CONTAINS it, e.g. {"crm_deal":"acme-42"}. Extra keys on the meeting still match. '
+                "Filtered in the database, so this searches your whole history, not just one page."
+            ),
+        ),
         api_key: str = Depends(get_api_key),
     ) -> Dict[str, Any]:
         """
-        List meetings associated with your API key (pagination + status/platform filters).
+        List meetings associated with your API key (pagination + status/platform/metadata filters).
+
+        `metadata_filter` is what makes this a query rather than a log: meetings you annotated with
+        annotate_meeting can be found again by the values you put on them.
         """
+        _validate_platform("list_meetings", platform)
         params: Dict[str, Any] = {}
         if limit is not None:
             params["limit"] = limit
@@ -550,19 +813,194 @@ def create_app(
             params["status"] = status
         if platform:
             params["platform"] = platform
+        if metadata_filter:
+            # Validate here so a malformed filter is a clear tool error rather than a gateway 422
+            # the agent has to decode. A filter that silently failed to apply would be worse than
+            # an error: the agent would read a full unfiltered list as "these all match".
+            try:
+                parsed = json.loads(metadata_filter)
+            except (TypeError, ValueError):
+                raise HTTPException(
+                    status_code=422,
+                    detail="list_meetings: 'metadata_filter' must be a JSON object string, e.g. {\"crm_deal\":\"acme-42\"}",
+                )
+            if not isinstance(parsed, dict):
+                raise HTTPException(
+                    status_code=422,
+                    detail="list_meetings: 'metadata_filter' must be a JSON OBJECT, not a bare value or array.",
+                )
+            params["metadata"] = metadata_filter
         return await make_request("GET", f"{base_url}/meetings", api_key, params=params or None)
 
-    @app.get("/meeting-transcript/{meeting_platform}/{meeting_id}", operation_id="get_meeting_transcript")
+    @app.get("/meeting-transcript", operation_id="get_meeting_transcript")
     async def get_meeting_transcript(
-        meeting_id: str,
-        meeting_platform: str = "google_meet",
+        native_meeting_id: Optional[str] = Query(None, description=_ID_DESC),
+        platform: Optional[str] = Query(None, description=_PLATFORM_DESC),
+        since_index: Optional[int] = Query(
+            None,
+            ge=0,
+            description=(
+                "Return only segments at or after this index. Pass the `next_index` from your "
+                "previous call to follow a live meeting without re-reading what you already have."
+            ),
+        ),
+        meeting_id: Optional[str] = Query(None, deprecated=True, description=_LEGACY_ID_DESC),
+        meeting_platform: Optional[str] = Query(None, deprecated=True, description=_LEGACY_PLATFORM_DESC),
         api_key: str = Depends(get_api_key),
     ) -> Dict[str, Any]:
         """
-        Get the real-time transcript for a meeting (segments with speaker, timestamp, text).
-        Can be called during or after the meeting.
+        Get the transcript for a meeting (segments with speaker, timestamp, text). Works DURING the
+        meeting as well as after — poll it to follow a live one.
+
+        Identify the meeting with `platform` + `native_meeting_id` — the exact field names
+        request_meeting_bot, list_meetings and parse_meeting_link hand back.
+
+        To follow a live meeting cheaply, pass `since_index` = the `next_index` from your previous
+        call; you get only what has been said since, instead of the whole transcript every time.
         """
-        return await make_request("GET", f"{base_url}/transcripts/{meeting_platform}/{meeting_id}", api_key)
+        plat, mid = _resolve_identity(
+            "get_meeting_transcript", platform, native_meeting_id, meeting_platform, meeting_id
+        )
+        result = await make_request("GET", f"{base_url}/transcripts/{plat}/{mid}", api_key)
+
+        # The cursor is applied here rather than at the gateway: the scarce resource is the
+        # CALLER's context window, not the hop to meeting-api. `total_segments`/`next_index` are
+        # always reported against the full transcript so a caller can tell "nothing new" from
+        # "nothing at all", and can resume after dropping its own state.
+        if isinstance(result, dict):
+            key = "segments" if isinstance(result.get("segments"), list) else (
+                "transcripts" if isinstance(result.get("transcripts"), list) else None
+            )
+            if key:
+                segments = result[key]
+                total = len(segments)
+                start = min(since_index, total) if since_index is not None else 0
+                result = {**result, key: segments[start:], "total_segments": total, "next_index": total}
+                if since_index is not None:
+                    result["since_index"] = start
+        return result
+
+    @app.get("/transcript-search", operation_id="search_transcripts")
+    async def search_transcripts(
+        q: str = Query(..., min_length=1, description=(
+            'What was said. Supports "quoted phrases", `or`, and `-excluded` terms. '
+            "Malformed input never errors, so you can pass a user's words through as-is."
+        )),
+        limit: int = Query(20, ge=1, le=100, description="Max hits (default 20)."),
+        offset: int = Query(0, ge=0),
+        platform: Optional[str] = Query(None, description=_PLATFORM_DESC),
+        native_meeting_id: Optional[str] = Query(
+            None, description="Restrict the search to ONE meeting. " + _ID_DESC
+        ),
+        api_key: str = Depends(get_api_key),
+    ) -> Dict[str, Any]:
+        """
+        Search what was SAID across your meetings. Use this instead of pulling transcripts and
+        reading them — it returns ranked snippets, not whole transcripts.
+
+        Each hit carries the meeting's `platform` + `native_meeting_id`, the speaker, the
+        timestamp, and a snippet with the match wrapped in <mark> tags. Feed those identity fields
+        straight into get_meeting_transcript when you need the full context around a hit.
+
+        This is lexical search with stemming, not semantic: "renewal" finds "renewals" but will
+        NOT find "extend the contract". Search the words people actually said.
+
+        Related but different: list_meetings(metadata_filter=...) finds meetings you TAGGED;
+        this finds meetings where something was SAID.
+        """
+        _validate_platform("search_transcripts", platform)
+        params: Dict[str, Any] = {"q": q, "limit": limit, "offset": offset}
+        if platform:
+            params["platform"] = platform
+        if native_meeting_id:
+            params["native_meeting_id"] = native_meeting_id
+        return await make_request("GET", f"{base_url}/transcripts/search", api_key, params=params)
+
+    # --- annotations: the caller's OWN description of a meeting -----------------------------
+    # This is the join key between a Vexa meeting and everything else the agent knows. Without it
+    # an agent can read a transcript and can do nothing with the fact afterwards: there is nowhere
+    # to record that this meeting is the Acme renewal, nowhere to keep its own summary, and so no
+    # way to find the meeting again by anything other than its platform id.
+    @app.post("/meeting-annotate", operation_id="annotate_meeting")
+    async def annotate_meeting(
+        data: AnnotateMeeting,
+        native_meeting_id: Optional[str] = Query(None, description=_ID_DESC),
+        platform: Optional[str] = Query(None, description=_PLATFORM_DESC),
+        api_key: str = Depends(get_api_key),
+    ) -> Dict[str, Any]:
+        """
+        Set the meeting's title and/or attach arbitrary metadata to it. Works DURING a live meeting
+        and after it has ended.
+
+        `metadata` is your own JSON — a CRM id, a ticket, tags, your own summary, anything.
+        It always MERGES key-wise, and sending a key as null deletes exactly that key. You can
+        only ever affect keys you name: other agents and the human may have written annotations
+        here that you cannot see, and nothing you send can destroy them.
+
+        Find these meetings again with
+        `list_meetings(metadata_filter='{"your_key":"your_value"}')` — note the filter is a JSON
+        STRING, not an object.
+        """
+        plat, mid = _resolve_identity("annotate_meeting", platform, native_meeting_id, None, None)
+        body: Dict[str, Any] = {}
+        if data.title is not None:
+            body["title"] = data.title
+        if data.metadata is not None:
+            body["metadata"] = data.metadata
+        row = await make_request("POST", f"{base_url}/meetings/{plat}/{mid}/annotate", api_key, body)
+
+        # Return WHAT WAS WRITTEN, not the whole meeting row. Annotating is a small write to one
+        # field; the full row carries object-storage paths, a playback URL and a reference to a
+        # ~69 MB audio artifact, none of which the caller asked for and all of which land in a
+        # calling model's context. Read paths still serve the full row — this trims the WRITE's
+        # echo, which is the one place nobody requested any of it.
+        if not isinstance(row, dict):
+            return row
+        row_data = row.get("data") if isinstance(row.get("data"), dict) else {}
+        return {
+            "platform": row.get("platform", plat),
+            "native_meeting_id": row.get("native_meeting_id", mid),
+            "meeting_db_id": row.get("id"),
+            "status": row.get("status"),
+            "title": row_data.get("title"),
+            "metadata": row_data.get("metadata", {}),
+        }
+
+    # --- the interactive bot: our bot TALKS and reads the room ------------------------------
+    # No notetaker MCP exposes this, because no notetaker has it: their bot is a recorder. Ours is
+    # a participant, so an agent connected here can answer a question out loud in the meeting it is
+    # listening to. These wrap gateway routes that already exist and were simply unreachable.
+    @app.post("/meeting-speak", operation_id="speak_in_meeting")
+    async def speak_in_meeting(
+        data: SpeakInMeeting,
+        native_meeting_id: Optional[str] = Query(None, description=_ID_DESC),
+        platform: Optional[str] = Query(None, description=_PLATFORM_DESC),
+        api_key: str = Depends(get_api_key),
+    ) -> Dict[str, Any]:
+        """
+        SPEAK OUT LOUD in a live meeting through the Vexa bot. Everyone in the meeting hears it.
+
+        This is an irreversible, human-visible action in a real conversation — never call it to
+        test, to acknowledge, or on your own initiative. Say something only when the person you are
+        working for has asked you to say that thing.
+        """
+        plat, mid = _resolve_identity("speak_in_meeting", platform, native_meeting_id, None, None)
+        return await make_request(
+            "POST", f"{base_url}/bots/{plat}/{mid}/speak", api_key, data.model_dump(exclude_none=True)
+        )
+
+    @app.get("/meeting-chat", operation_id="get_meeting_chat")
+    async def get_meeting_chat(
+        native_meeting_id: Optional[str] = Query(None, description=_ID_DESC),
+        platform: Optional[str] = Query(None, description=_PLATFORM_DESC),
+        api_key: str = Depends(get_api_key),
+    ) -> Dict[str, Any]:
+        """
+        Read the meeting's in-call chat messages. Complements the transcript: links, spellings and
+        side comments land in chat and are never spoken aloud.
+        """
+        plat, mid = _resolve_identity("get_meeting_chat", platform, native_meeting_id, None, None)
+        return await make_request("GET", f"{base_url}/bots/{plat}/{mid}/chat", api_key)
 
     @app.get("/recordings", operation_id="list_recordings")
     async def list_recordings(
@@ -596,7 +1034,7 @@ def create_app(
         api_key: str = Depends(get_api_key),
     ) -> Dict[str, Any]:
         """
-        Tell the Vexa maintainers that something went wrong. A human reads every ticket.
+        Tell the Vexa maintainers that something went wrong. A human reads every ticket, and it cannot be withdrawn.
 
         Call this the moment you hit a problem with Vexa — you do not need to have solved it first:
         - something BROKE: an error, a bot that never joined, an empty transcript, a call that hung;
@@ -607,7 +1045,12 @@ def create_app(
         Write what you tried and what happened in your own words. Do not paste API keys, and do not
         paste your user's meeting content.
 
-        If the issue concerns a meeting or a bot, include `meeting_id` and `platform`. That is the
+        File only when you hit this while doing REAL WORK for someone. If you are exploring,
+        evaluating or testing this API, do not file — write your findings in your report instead.
+        A ticket reaches humans at another company and cannot be withdrawn, and an evaluation run
+        can otherwise open several in a single session.
+
+        If the issue concerns a meeting or a bot, include `native_meeting_id` and `platform`. That is the
         join key: it lines your account of what happened up against our own record of the same
         meeting, which is the difference between a complaint and something we can diagnose. The
         meeting is resolved onto the ticket only if the key you are calling with owns it.
@@ -669,20 +1112,20 @@ def create_app(
         # still files the ticket (with the id quoted as text, entity null), because a ticket we
         # refused to accept teaches us nothing.
         entity: Optional[Dict[str, Any]] = None
-        if data.meeting_id:
+        if data.native_meeting_id:
             rows = meetings if isinstance(meetings, list) else (meetings or {}).get("meetings", [])
             for m in rows if isinstance(rows, list) else []:
                 if not isinstance(m, dict):
                     continue
-                if m.get("native_meeting_id") != data.meeting_id:
+                if m.get("native_meeting_id") != data.native_meeting_id:
                     continue
                 if data.platform and m.get("platform") != data.platform:
                     continue
                 entity = {
                     "type": "meeting",
-                    "id": data.meeting_id,
+                    "id": data.native_meeting_id,
                     "platform": m.get("platform"),
-                    "url": f"/transcripts/{m.get('platform')}/{data.meeting_id}",
+                    "url": f"/transcripts/{m.get('platform')}/{data.native_meeting_id}",
                 }
                 break
 
@@ -706,7 +1149,7 @@ def create_app(
             "deployment": data.deployment,
             "version": data.version,
             "severity": data.severity,
-            "meeting_id": data.meeting_id,
+            "native_meeting_id": data.native_meeting_id,
             "platform": data.platform,
             "entity": entity,
             "logs": data.logs,
@@ -770,9 +1213,38 @@ def create_app(
         return ack
 
     # ---------------------------
+    # ASSEMBLY (PRD decision 40) — the tools the DEPLOYED domains declare
+    # ---------------------------
+    # The fourteen tools above are this edge's own. Everything else it serves belongs to a domain:
+    # meetings owns the bots and transcripts, identity owns the person, flows owns the reaction
+    # engine, agent owns the desks. Each publishes a manifest at `/.well-known/mcp-tools.json`, this
+    # asks the ones the deployment names, and every tool becomes a route here with
+    # `operation_id=<name>` — the SAME mechanism the fourteen use, so an assembled tool and a
+    # built-in one are indistinguishable to a client.
+    #
+    # BEFORE `FastApiMCP(app, ...)`, necessarily: the MCP surface is derived from this app's
+    # OpenAPI, so a route added afterwards would be a tool nobody can see.
+    #
+    # AND IT FAILS THE BOOT. Every rule in `manifest.py` is a failure that is otherwise silent — a
+    # domain's tools quietly missing, one name claimed twice, a manifest naming a route its service
+    # does not serve. A server that started anyway would answer `tools/list` with a lie.
+    app.state.assembly = None
+    _assembly_env = assembly_env if assembly_env is not None else os.environ
+    if not _assembly_env.get("VEXA_MCP_ASSEMBLY_OFF"):
+        with httpx.Client(transport=assembly_transport) as _boot:
+            _assembly, _openapi, _bases = discover_mod.discover(_boot, env=_assembly_env)
+        _bound = bind_mod.verify(_assembly, _openapi)
+        register_mod.register(app, _bound, _bases, transport=transport)
+        app.state.assembly = _assembly
+
+    # ---------------------------
     # MCP mount + prompts
     # ---------------------------
     mcp = FastApiMCP(app, headers=["authorization", "x-api-key"])
+    # Orientation at connect time. FastApiMCP has no `instructions` kwarg, but the lowlevel
+    # Server it wraps carries the field the spec defines — a client that connects should not have
+    # to infer what Vexa is from nine tool descriptions.
+    mcp.server.instructions = VEXA_INSTRUCTIONS
 
     @mcp.server.list_prompts()
     async def _list_prompts() -> mcp_types.ListPromptsResult:
@@ -781,6 +1253,17 @@ def create_app(
     @mcp.server.get_prompt()
     async def _get_prompt(name: str, arguments: Optional[Dict[str, str]] = None) -> mcp_types.GetPromptResult:
         return get_prompt_result(name, arguments)
+
+    # Close every tool's argument schema. Without `additionalProperties: false` an unknown
+    # argument is not rejected — fastapi-mcp silently DROPS it before the HTTP call, so the
+    # server-side guard never sees it and the tool answers 200 as if the argument had been
+    # honoured. A hallucinated or typo'd parameter then looks like it worked, and the wrong
+    # answer is indistinguishable from the right one. Closing the schema moves the refusal to
+    # where the argument actually is: the MCP validation layer.
+    for _tool in mcp.tools:
+        schema = getattr(_tool, "inputSchema", None)
+        if isinstance(schema, dict) and schema.get("type") == "object":
+            schema.setdefault("additionalProperties", False)
 
     mcp.mount_http()
     # fastapi-mcp 0.4 buffers the ASGI response; a sessioned GET is an open SSE

--- a/core/meetings/services/mcp/src/vexa_mcp/bind.py
+++ b/core/meetings/services/mcp/src/vexa_mcp/bind.py
@@ -1,0 +1,94 @@
+"""BINDING — the manifest's promise, checked against the service that has to keep it.
+
+A manifest binds a NAME to a ROUTE and carries no schema and no description of its own. Both are
+DERIVED here, from the bound route's OpenAPI operation — the same mechanism this service already
+runs on for its own fourteen tools (`operation_id` on a FastAPI route, read by `FastApiMCP`). One
+place to write a tool's shape is why a tool and the route behind it cannot disagree.
+
+That makes a manifest a CLAIM ABOUT ANOTHER SERVICE, and this module is where the claim is checked.
+Two failures fail the boot:
+
+  * a route the domain does not serve — a manifest lying about its own service, which would surface
+    as a tool that appears in `tools/list` and 404s the first time an agent calls it;
+  * an argument the operation does not take — an argument an agent can pass and the route silently
+    ignores is the worst reply available, because the agent then reports success on something that
+    did not happen.
+
+Path parameters are arguments without being declared: `/reactions/{id}/{verb}` cannot be called
+without them, and a manifest that had to restate them would be a second place to write the route.
+"""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import Dict, List
+
+from .manifest import Assembly, ManifestError, Tool
+
+_PATH_PARAM = re.compile(r"\{([A-Za-z_][A-Za-z0-9_]*)\}")
+
+
+@dataclass(frozen=True)
+class BoundTool:
+    tool: Tool
+    description: str
+    parameters: Dict[str, dict] = field(default_factory=dict)
+    path_params: tuple = ()
+
+    @property
+    def name(self) -> str:
+        return self.tool.name
+
+
+def _operation(openapi: dict, method: str, path: str) -> dict | None:
+    item = (openapi.get("paths") or {}).get(path)
+    if not isinstance(item, dict):
+        return None
+    op = item.get(method.lower())
+    return op if isinstance(op, dict) else None
+
+
+def verify(assembly: Assembly, openapi_by_domain: Dict[str, dict]) -> List[BoundTool]:
+    """Every routed tool in the assembly, bound to its operation. Raises :class:`ManifestError`."""
+    out: List[BoundTool] = []
+    for tool in assembly.tools:
+        if tool.route is None:
+            # Edge-owned: this service implements it, so there is no other service to check against.
+            continue
+        spec = openapi_by_domain.get(tool.domain)
+        if not spec:
+            raise ManifestError(
+                f"{tool.domain}/{tool.name}: no OpenAPI from {tool.domain} — refusing to bind a "
+                "tool blind; a surface nobody checked is a surface nobody can trust")
+        method, path = tool.route["method"], tool.route["path"]
+        op = _operation(spec, method, path)
+        if op is None:
+            raise ManifestError(
+                f"{tool.domain}/{tool.name}: {tool.domain} does not serve {method} {path} — the "
+                "manifest names a route its own service does not have")
+        params = {p.get("name"): (p.get("schema") or {})
+                  for p in (op.get("parameters") or []) if p.get("name")}
+        path_params = tuple(_PATH_PARAM.findall(path))
+        declared = {}
+        for arg in tool_arguments(tool):
+            if arg in path_params:
+                continue
+            if arg not in params:
+                raise ManifestError(
+                    f"{tool.domain}/{tool.name}: declares the argument {arg!r}, which "
+                    f"{method} {path} does not take — an argument the route ignores is a success "
+                    "the agent reports for something that did not happen")
+            declared[arg] = params[arg]
+        out.append(BoundTool(
+            tool=tool,
+            description=str(op.get("summary") or op.get("description") or "").strip(),
+            parameters=declared,
+            path_params=path_params,
+        ))
+    return out
+
+
+def tool_arguments(tool: Tool) -> tuple:
+    """The arguments a manifest declared for a tool. Kept as a function rather than a field so the
+    manifest shape and the bind step have one reader between them."""
+    return tuple(getattr(tool, "arguments", ()) or ())

--- a/core/meetings/services/mcp/src/vexa_mcp/discover.py
+++ b/core/meetings/services/mcp/src/vexa_mcp/discover.py
@@ -1,0 +1,101 @@
+"""DISCOVERY — asking the deployed domains what they serve, at startup.
+
+The manifests are not baked into this image. Each domain serves its own at
+``/.well-known/mcp-tools.json``, and its OpenAPI beside it, so the surface this edge presents is the
+surface the RUNNING builds actually have. A deployment cannot advertise a tool the service behind it
+does not serve, because the service is the one that said it did.
+
+WHICH DOMAINS EXIST is a deployment fact, read from the environment: a domain whose base URL is set
+is deployed. That is the whole of the eight-configuration story — identity plus any subset of
+meetings, flows and agent — and it needs no profile name, because a profile name is a second place
+to say something the URLs already say.
+
+FAIL DIRECTIONS, both deliberate and opposite:
+  * a domain that IS configured and does not answer FAILS THE BOOT. "The meetings tools are missing"
+    must never be something a person discovers by asking for one.
+  * a domain that is NOT configured contributes nothing and is not asked. Its tools are absent, and
+    absent is a state an agent recovers from.
+"""
+from __future__ import annotations
+
+import os
+from typing import Dict, Optional, Set, Tuple
+
+import httpx
+
+from .manifest import Assembly, ManifestError, assemble, load_mounted
+
+#: domain -> the env key naming its base URL. Identity is always required; the other three are the
+#: subset this deployment carries.
+DOMAIN_URL_ENV = {
+    "identity": "ADMIN_API_URL",
+    "meetings": "MEETING_API_URL",
+    "flows": "FLOWS_API_URL",
+    "agent": "AGENT_API_URL",
+}
+MANIFEST_PATH = "/.well-known/mcp-tools.json"
+OPENAPI_PATH = "/openapi.json"
+MOUNT_DIR_ENV = "VEXA_MCP_MANIFEST_DIR"
+
+
+def deployed_domains(env: Optional[dict] = None) -> Dict[str, str]:
+    """``{domain: base_url}`` for every domain this deployment names. Nothing else is asked."""
+    env = env if env is not None else os.environ
+    out = {}
+    for domain, key in DOMAIN_URL_ENV.items():
+        url = (env.get(key) or "").strip().rstrip("/")
+        if url:
+            out[domain] = url
+    return out
+
+
+def fetch(client: httpx.Client, url: str) -> Optional[dict]:
+    try:
+        r = client.get(url, timeout=5)
+        if r.status_code != 200:
+            return None
+        return r.json()
+    except Exception:  # noqa: BLE001 — an unreachable domain is decided by the caller, not here
+        return None
+
+
+def discover(client: httpx.Client, *, env: Optional[dict] = None
+             ) -> Tuple[Assembly, Dict[str, dict], Dict[str, str]]:
+    """``(assembly, openapi_by_domain, base_urls)``. Raises :class:`ManifestError` on a boot rule.
+
+    SYNCHRONOUS on purpose. This runs once, at boot, and every rule it applies is one that must stop
+    the process rather than degrade a request — so it belongs before the server is listening, not in
+    an async startup hook racing the first caller."""
+    env = env if env is not None else os.environ
+    bases = deployed_domains(env)
+    manifests, openapi = [], {}
+    for domain, base in bases.items():
+        doc = fetch(client, f"{base}{MANIFEST_PATH}")
+        if doc is None:
+            # A domain may legitimately carry no manifest yet — it simply contributes no tools.
+            # What it may NOT do is carry one and be unreachable, which is the case below.
+            continue
+        manifests.append(doc)
+        spec = fetch(client, f"{base}{OPENAPI_PATH}")
+        if spec is None:
+            raise ManifestError(
+                f"{domain} published a manifest but its OpenAPI at {base}{OPENAPI_PATH} did not "
+                "answer — refusing to bind a tool blind")
+        openapi[domain] = spec
+
+    for doc in load_mounted(env.get(MOUNT_DIR_ENV)):
+        domain = doc.get("domain")
+        base = (env.get(f"{str(domain).upper()}_API_URL") or "").strip().rstrip("/")
+        if not base:
+            raise ManifestError(
+                f"a mounted manifest for {domain!r} is present but {str(domain).upper()}_API_URL "
+                "is unset — a private domain that cannot be reached is a tool list that lies")
+        bases[domain] = base
+        manifests.append(doc)
+        spec = fetch(client, f"{base}{OPENAPI_PATH}")
+        if spec is None:
+            raise ManifestError(f"{domain} (mounted): no OpenAPI at {base}{OPENAPI_PATH}")
+        openapi[domain] = spec
+
+    deployed: Set[str] = set(bases)
+    return assemble(manifests, deployed=deployed), openapi, bases

--- a/core/meetings/services/mcp/src/vexa_mcp/identity.py
+++ b/core/meetings/services/mcp/src/vexa_mcp/identity.py
@@ -1,0 +1,122 @@
+"""The meeting-identity vocabulary — ONE name per concept, declared as data so a test can enforce it.
+
+## Why this file exists
+
+The MCP surface shipped three tools that ACCEPTED ``meeting_platform`` + ``meeting_id`` while every
+tool RETURNED ``platform`` + ``native_meeting_id``. No tool's output could be fed into the next
+tool's input, which is the one thing a model chaining calls will always try. That was found by a
+reader who had just read the service README, and fixed.
+
+**Hours later the same defect was reintroduced** — a new ``search_transcripts`` tool returned
+``meeting_id`` holding the INTEGER row id, colliding with the deprecated alias for the NATIVE
+STRING id. Feeding that tool's own output into ``get_meeting_transcript`` produced
+``404 Meeting not found for platform google_meet and ID 1``.
+
+Two occurrences in one day, by the same author, with the rule written down in between. The
+conclusion is not "be more careful": a convention that lives only in prose and review is enforced
+by nobody at 3am, and the failure is silent — every field is individually reasonable, and only the
+JOIN between two tools is wrong. So the vocabulary is declared here as DATA and asserted by
+``tests/test_identity_vocabulary.py`` against the surface the server actually emits.
+
+## The vocabulary
+
+Three concepts, three names, and they never overlap:
+
+===================  =======  ===============================================================
+name                 type     what it is
+===================  =======  ===============================================================
+``platform``         str      the meeting platform: google_meet | teams | zoom | jitsi
+``native_meeting_id``str      the PLATFORM's own id — "abc-defg-hij", "9361792952021"
+``meeting_db_id``    int      VEXA's internal row id. Never the platform's.
+===================  =======  ===============================================================
+
+``meeting_id`` is **not** in that table, deliberately: it is the name that meant all three at
+different times, so it is retired as a concept. It survives only as a deprecated INPUT alias.
+
+## The two rules a name must satisfy
+
+1. **A deprecated alias may appear only as an INPUT, only alongside its canonical name, and only
+   when its description says DEPRECATED.** A tool that accepts an alias without the canonical name
+   forces callers onto the old vocabulary; one that does not mark it teaches the old vocabulary.
+2. **A deprecated alias may NEVER appear in an OUTPUT.** This is the rule the search regression
+   broke. Outputs are what the next call is built from, so an ambiguous output name is the bug —
+   it is what turns "feed one tool's output into the next" from a promise into a 404.
+"""
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+#: concept -> the JSON type it always has. Nothing else may carry these names.
+CANONICAL_IDENTITY: Dict[str, str] = {
+    "platform": "string",
+    "native_meeting_id": "string",
+    "meeting_db_id": "integer",
+}
+
+#: retired name -> what to use instead. Accepted on input for backwards compatibility; never emitted.
+DEPRECATED_ALIASES: Dict[str, str] = {
+    "meeting_id": "native_meeting_id",
+    "meeting_platform": "platform",
+}
+
+
+def check_tool_inputs(tools: List[Dict[str, Any]]) -> List[str]:
+    """Rule 1 over an MCP ``tools/list`` payload. Returns human-readable violations."""
+    violations: List[str] = []
+    for tool in tools:
+        name = tool.get("name", "?")
+        props = (tool.get("inputSchema", {}) or {}).get("properties", {}) or {}
+        for alias, canonical in DEPRECATED_ALIASES.items():
+            if alias not in props:
+                continue
+            if canonical not in props:
+                violations.append(
+                    f"{name}: accepts deprecated `{alias}` but NOT canonical `{canonical}` — "
+                    f"a caller feeding another tool's output has nowhere to put it"
+                )
+            description = (props[alias].get("description") or "").upper()
+            if "DEPRECATED" not in description:
+                violations.append(
+                    f"{name}: `{alias}` is not marked DEPRECATED in its description, so the schema "
+                    f"teaches the retired name as if it were current (use `{canonical}`)"
+                )
+    return violations
+
+
+def check_output_names(tool_name: str, payload: Any) -> List[str]:
+    """Rule 2 against a tool's actual RETURNED payload. Recurses into dicts and lists.
+
+    Checks the alias names AND the types of the canonical ones — the search regression emitted a
+    correctly-spelled name carrying the wrong kind of value, which a name-only check would pass.
+    """
+    violations: List[str] = []
+
+    def walk(node: Any, path: str) -> None:
+        if isinstance(node, list):
+            for item in node[:5]:            # a page is homogeneous; five is plenty
+                walk(item, f"{path}[]")
+            return
+        if not isinstance(node, dict):
+            return
+        for key, value in node.items():
+            here = f"{path}.{key}" if path else key
+            if key in DEPRECATED_ALIASES:
+                violations.append(
+                    f"{tool_name}: returns `{here}` — a deprecated alias must never be EMITTED "
+                    f"(use `{DEPRECATED_ALIASES[key]}`); an ambiguous output name is what makes "
+                    f"the next call fail"
+                )
+            elif key in CANONICAL_IDENTITY and value is not None:
+                expected = CANONICAL_IDENTITY[key]
+                actual = "integer" if isinstance(value, int) and not isinstance(value, bool) else (
+                    "string" if isinstance(value, str) else type(value).__name__
+                )
+                if actual != expected:
+                    violations.append(
+                        f"{tool_name}: `{here}` is {actual} but `{key}` is always {expected} "
+                        f"({value!r}) — the same name must not carry two kinds of value"
+                    )
+            walk(value, here)
+
+    walk(payload, "")
+    return violations

--- a/core/meetings/services/mcp/src/vexa_mcp/manifest.py
+++ b/core/meetings/services/mcp/src/vexa_mcp/manifest.py
@@ -1,0 +1,215 @@
+"""ASSEMBLY — one MCP server, built from the manifests of the domains that are deployed.
+
+PRD decision 40, founder rulings of 2026-09-02. A tool belongs to the domain that owns the door
+behind it: meetings owns the bots and the transcripts, identity owns the person, flows owns the
+reaction engine, agent owns the desks. This service is an EDGE — like the gateway it carries the
+caller's identity and holds no domain logic — and its whole job is to ask each deployed domain what
+it serves, refuse the combinations that cannot be right, and present the union as one surface.
+
+TWO SOURCES, ONE NAME SPACE. `oss` manifests come from the packages in this repo; `mounted` ones
+come from a directory a private deployment supplies, so a paid domain composes onto this line
+without a line of it living here. They are assembled identically and compete for names equally — a
+mounted manifest gets no precedence, which is what makes a mount safe: it can COLLIDE, it can never
+SHADOW.
+
+EVERY RULE HERE FAILS THE BOOT. Not because failing loudly is a virtue in itself, but because each
+of these failures is otherwise silent, and a silent one is discovered by a person asking for a tool
+that is not there:
+
+    a deployed domain that does not answer   ->  a whole domain's tools missing, quietly
+    one name claimed twice                   ->  last-one-wins, and nobody knows which won
+    a route the domain does not serve        ->  the manifest lying about its own service
+    two entitlement hooks                    ->  "may this person act" answered twice
+
+The one thing that is NOT a failure is a domain that is simply not deployed. Its tools are ABSENT
+from `tools/list` — an agent that cannot see a tool recovers; an agent told a tool exists and then
+handed a 502 tells the person the product is broken.
+"""
+from __future__ import annotations
+
+import json
+import pathlib
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Set
+
+CONTRACT = "mcp.tools.v1"
+
+# PRD 40.8 — EXACTLY ONE AUTHENTICATION PATH into this edge: a bearer token in the header, the
+# session bound by `Mcp-Session-Id`, and a token minted mid-conversation bound to that session.
+# There is no `/do` GET bridge and no `token=` tool argument, because both put a credential in a
+# query string or an argument list: right for a fetch-only agent on a private host, wrong anywhere
+# requests are logged, and impossible to withdraw once a transcript holds it.
+#
+# It is enforced HERE, at the seam where a tool's surface is decided, rather than trusted to every
+# domain: a tool's schema is derived from its route's OpenAPI operation, and a route has no `token`
+# parameter — so the rule is mostly kept by construction. This list is what catches a domain that
+# reintroduces one on purpose.
+CREDENTIAL_ARGUMENTS = {"token", "api_key", "apikey", "key", "access_token", "bearer",
+                        "credential", "password", "secret"}
+DOMAINS = {"meetings", "identity", "flows", "agent", "gateway", "rehearse", "billing"}
+IDENTITIES = {"user", "admin", "operator", "none"}
+METHODS = {"GET", "POST", "PUT", "PATCH", "DELETE"}
+
+
+class ManifestError(Exception):
+    """A manifest, or a combination of them, that this deployment must not boot with."""
+
+
+@dataclass(frozen=True)
+class Tool:
+    name: str
+    domain: str
+    source: str
+    identity: str
+    requires: frozenset
+    route: Optional[dict]
+    base_url_env: Optional[str]
+    arguments: tuple = ()
+    note: str = ""
+
+
+@dataclass(frozen=True)
+class Entitlement:
+    domain: str
+    route: dict
+    answers: str
+
+
+@dataclass
+class Assembly:
+    tools: List[Tool] = field(default_factory=list)
+    entitlement: Optional[Entitlement] = None
+    absent_domains: Set[str] = field(default_factory=set)
+    by_domain: Dict[str, int] = field(default_factory=dict)
+
+
+def validate(doc: dict) -> dict:
+    """One manifest, on its own. Raises :class:`ManifestError` naming what is wrong."""
+    if not isinstance(doc, dict) or doc.get("contract") != CONTRACT:
+        raise ManifestError(f"not a {CONTRACT} manifest")
+    domain = doc.get("domain")
+    if domain not in DOMAINS:
+        raise ManifestError(f"unknown domain {domain!r}")
+    if doc.get("source") not in ("oss", "mounted"):
+        raise ManifestError(f"{domain}: source must be oss or mounted")
+
+    # A domain's doors are IDENTITY, RUNTIME and ITSELF. Runtime is a primitive — it spawns bots for
+    # meetings and workers for agent, has no tools and no person-facing surface — so it is allowed
+    # exactly as identity is, and is not a domain that can appear here at all.
+    depends = doc.get("depends_on")
+    if not isinstance(depends, list) or not set(depends) <= {"identity"}:
+        raise ManifestError(
+            f"{domain}: depends_on may name identity and nothing else (got {depends!r}) — "
+            "identity is the only domain everyone may depend on")
+    if domain == "identity" and depends:
+        raise ManifestError("identity: depends_on must be empty — it depends on nothing")
+
+    for t in doc.get("tools") or []:
+        name = t.get("name")
+        if not isinstance(name, str) or not name:
+            raise ManifestError(f"{domain}: a tool with no name")
+        if t.get("identity") not in IDENTITIES:
+            raise ManifestError(f"{domain}/{name}: identity must be one of {sorted(IDENTITIES)}")
+        requires = t.get("requires")
+        if not isinstance(requires, list) or not requires:
+            raise ManifestError(f"{domain}/{name}: requires must name at least one domain")
+        allowed = {domain, "identity"}
+        if domain == "rehearse":                 # the dev harness drives every door on purpose
+            allowed = DOMAINS
+        if not set(requires) <= allowed:
+            raise ManifestError(
+                f"{domain}/{name}: requires may name {sorted(allowed)} (got {sorted(requires)}) — "
+                "a tool that needs another domain is a composition, and a composition has an owner")
+        # PRD 40.8: one authentication path. A tool may not take a credential as an ARGUMENT.
+        for arg in t.get("arguments") or []:
+            if str(arg).strip().lower() in CREDENTIAL_ARGUMENTS:
+                raise ManifestError(
+                    f"{domain}/{name}: declares a credential argument {arg!r} — this edge has "
+                    "exactly one authentication path (a bearer header, session-bound). A "
+                    "credential in an argument list is in the transcript forever.")
+        route = t.get("route")
+        if route is None:
+            # Edge-owned: the assembler serves it itself. Only legal where there is no door.
+            if doc.get("base_url_env"):
+                raise ManifestError(
+                    f"{domain}/{name}: route is null but this domain HAS a door "
+                    f"({doc['base_url_env']}) — a tool with a door must name its route")
+        else:
+            if route.get("method") not in METHODS or not str(route.get("path", "")).startswith("/"):
+                raise ManifestError(f"{domain}/{name}: route needs a method and an absolute path")
+    ent = doc.get("entitlement")
+    if ent is not None:
+        if not isinstance(ent, dict) or not ent.get("route") or not ent.get("answers"):
+            raise ManifestError(f"{domain}: entitlement needs a route and what it answers")
+    return doc
+
+
+def load_mounted(directory: Optional[str]) -> List[dict]:
+    """Every manifest a private deployment supplied. EMPTY IS THE OSS PRODUCT, exactly.
+
+    A malformed file FAILS rather than being skipped: skipping it means a paid deployment silently
+    missing the tools it paid for, which is the worst outcome available here."""
+    if not directory:
+        return []
+    d = pathlib.Path(directory)
+    if not d.is_dir():
+        return []
+    out = []
+    for f in sorted(d.glob("*.mcp.tools.v1.json")):
+        try:
+            doc = json.loads(f.read_text(encoding="utf-8"))
+        except Exception as e:  # noqa: BLE001
+            raise ManifestError(f"mounted manifest {f.name} could not be read: {e}") from e
+        if not isinstance(doc, dict):
+            raise ManifestError(f"mounted manifest {f.name} is not an object")
+        # A file in the mount IS mounted, whatever it claims about itself — otherwise the one
+        # property that makes mounts safe (no precedence) could be opted out of by writing a word.
+        doc["source"] = "mounted"
+        out.append(doc)
+    return out
+
+
+def assemble(manifests: List[dict], *, deployed: Set[str],
+             required_domains: Optional[Set[str]] = None) -> Assembly:
+    """The union, with every combination rule applied. Raises :class:`ManifestError`."""
+    answered = {d.get("domain") for d in manifests}
+    for missing in sorted((required_domains or set()) - answered):
+        raise ManifestError(
+            f"{missing} is deployed but did not answer with a manifest — refusing to boot with a "
+            "domain's tools silently absent")
+
+    out = Assembly()
+    claimed: Dict[str, tuple] = {}
+    for doc in manifests:
+        validate(doc)
+        domain, source = doc["domain"], doc["source"]
+        ent = doc.get("entitlement")
+        if ent:
+            if out.entitlement is not None:
+                raise ManifestError(
+                    f"two manifests declare an entitlement hook ({out.entitlement.domain} and "
+                    f"{domain}) — 'may this person act' is not a question with two answers")
+            out.entitlement = Entitlement(domain=domain, route=ent["route"],
+                                          answers=ent["answers"])
+        for t in doc.get("tools") or []:
+            name = t["name"]
+            prior = claimed.get(name)
+            if prior:
+                raise ManifestError(
+                    f"the tool name {name!r} is claimed by two manifests ({prior[0]}/{prior[1]} "
+                    f"and {domain}/{source}) — a duplicate is a design question and a person has "
+                    "to answer it; a mounted manifest never wins by default")
+            claimed[name] = (domain, source)
+            if not set(t["requires"]) <= deployed:
+                continue
+            out.tools.append(Tool(
+                name=name, domain=domain, source=source, identity=t["identity"],
+                requires=frozenset(t["requires"]), route=t.get("route"),
+                base_url_env=doc.get("base_url_env"),
+                arguments=tuple(t.get("arguments") or ()), note=t.get("note", "")))
+    for doc in manifests:
+        if doc["domain"] not in deployed:
+            out.absent_domains.add(doc["domain"])
+    for t in out.tools:
+        out.by_domain[t.domain] = out.by_domain.get(t.domain, 0) + 1
+    return out

--- a/core/meetings/services/mcp/src/vexa_mcp/prompts.py
+++ b/core/meetings/services/mcp/src/vexa_mcp/prompts.py
@@ -24,12 +24,12 @@ PROMPTS: Dict[str, mcp_types.Prompt] = {
                 required=False,
             ),
             mcp_types.PromptArgument(
-                name="meeting_platform",
+                name="platform",
                 description="google_meet | teams | zoom (optional if meeting_url is provided).",
                 required=False,
             ),
             mcp_types.PromptArgument(
-                name="meeting_id",
+                name="native_meeting_id",
                 description="Native meeting ID (optional if meeting_url is provided).",
                 required=False,
             ),
@@ -45,8 +45,8 @@ PROMPTS: Dict[str, mcp_types.Prompt] = {
         title="Vexa: During Meeting",
         description="Check bot status and retrieve current transcript snapshot.",
         arguments=[
-            mcp_types.PromptArgument(name="meeting_platform", description="google_meet | teams | zoom", required=True),
-            mcp_types.PromptArgument(name="meeting_id", description="Native meeting ID", required=True),
+            mcp_types.PromptArgument(name="platform", description="google_meet | teams | zoom", required=True),
+            mcp_types.PromptArgument(name="native_meeting_id", description="The platform's own meeting id — exactly the `native_meeting_id` the tools return", required=True),
         ],
     ),
     "vexa.post_meeting": mcp_types.Prompt(
@@ -54,8 +54,8 @@ PROMPTS: Dict[str, mcp_types.Prompt] = {
         title="Vexa: Post Meeting",
         description="Fetch transcript + recordings and produce follow-ups.",
         arguments=[
-            mcp_types.PromptArgument(name="meeting_platform", description="google_meet | teams | zoom", required=True),
-            mcp_types.PromptArgument(name="meeting_id", description="Native meeting ID", required=True),
+            mcp_types.PromptArgument(name="platform", description="google_meet | teams | zoom", required=True),
+            mcp_types.PromptArgument(name="native_meeting_id", description="The platform's own meeting id — exactly the `native_meeting_id` the tools return", required=True),
         ],
     ),
     "vexa.teams_link_help": mcp_types.Prompt(
@@ -77,8 +77,8 @@ def get_prompt_result(name: str, arguments: Optional[Dict[str, str]] = None) -> 
 
     if name == "vexa.meeting_prep":
         meeting_url = (args.get("meeting_url") or "").strip()
-        meeting_platform = (args.get("meeting_platform") or "").strip()
-        meeting_id = (args.get("meeting_id") or "").strip()
+        platform = (args.get("platform") or "").strip()
+        native_meeting_id = (args.get("native_meeting_id") or "").strip()
         notes = (args.get("notes") or "").strip()
 
         return mcp_types.GetPromptResult(
@@ -98,8 +98,8 @@ def get_prompt_result(name: str, arguments: Optional[Dict[str, str]] = None) -> 
                         "- Keep any provided notes in the conversation for the post-meeting summary "
                         "(storing notes on the meeting record is not available via this MCP yet).\n\n"
                         f"Input:\n- meeting_url: {meeting_url or '(none)'}\n"
-                        f"- meeting_platform: {meeting_platform or '(none)'}\n"
-                        f"- meeting_id: {meeting_id or '(none)'}\n"
+                        f"- platform: {platform or '(none)'}\n"
+                        f"- native_meeting_id: {native_meeting_id or '(none)'}\n"
                         f"- notes: {notes or '(none)'}\n\n"
                         "Now do the tool calls and tell me what you did and what to do next."
                     ),
@@ -108,8 +108,8 @@ def get_prompt_result(name: str, arguments: Optional[Dict[str, str]] = None) -> 
         )
 
     if name == "vexa.during_meeting":
-        meeting_platform = (args.get("meeting_platform") or "").strip()
-        meeting_id = (args.get("meeting_id") or "").strip()
+        platform = (args.get("platform") or "").strip()
+        native_meeting_id = (args.get("native_meeting_id") or "").strip()
         return mcp_types.GetPromptResult(
             description="During-meeting helper prompt using Vexa MCP tools.",
             messages=[
@@ -117,7 +117,7 @@ def get_prompt_result(name: str, arguments: Optional[Dict[str, str]] = None) -> 
                     role="user",
                     content=t(
                         "You are my during-meeting assistant using Vexa.\n\n"
-                        f"Meeting: platform={meeting_platform}, id={meeting_id}\n\n"
+                        f"Meeting: platform={platform}, id={native_meeting_id}\n\n"
                         "Steps:\n"
                         "- Call `get_bot_status` to confirm the bot is active / requested.\n"
                         "- Call `get_meeting_transcript` to fetch the current transcript snapshot.\n"
@@ -130,8 +130,8 @@ def get_prompt_result(name: str, arguments: Optional[Dict[str, str]] = None) -> 
         )
 
     if name == "vexa.post_meeting":
-        meeting_platform = (args.get("meeting_platform") or "").strip()
-        meeting_id = (args.get("meeting_id") or "").strip()
+        platform = (args.get("platform") or "").strip()
+        native_meeting_id = (args.get("native_meeting_id") or "").strip()
         return mcp_types.GetPromptResult(
             description="Post-meeting helper prompt using Vexa MCP tools.",
             messages=[
@@ -139,7 +139,7 @@ def get_prompt_result(name: str, arguments: Optional[Dict[str, str]] = None) -> 
                     role="user",
                     content=t(
                         "You are my post-meeting assistant using Vexa.\n\n"
-                        f"Meeting: platform={meeting_platform}, id={meeting_id}\n\n"
+                        f"Meeting: platform={platform}, id={native_meeting_id}\n\n"
                         "Steps:\n"
                         "- Call `get_meeting_transcript` to fetch the meeting status, notes, and segments.\n"
                         "- Call `list_recordings` (optionally `get_recording`) if recordings are expected.\n"

--- a/core/meetings/services/mcp/src/vexa_mcp/register.py
+++ b/core/meetings/services/mcp/src/vexa_mcp/register.py
@@ -1,0 +1,111 @@
+"""REGISTRATION — an assembled tool becomes one route on this service, and therefore one MCP tool.
+
+`FastApiMCP` derives the MCP surface from this app's OpenAPI: a route with `operation_id=<name>` IS
+a tool called `<name>`. That is how the fourteen built-in tools work, so assembling through the same
+mechanism makes an assembled tool and a built-in one indistinguishable to a client — which is the
+whole point of assembling rather than proxying, and the reason there is no second code path to keep
+in step.
+
+WHAT TRAVELS: the caller's own credential, as `X-API-Key`, exactly as the fourteen send it. Nothing
+else. There is one authentication path into this edge (PRD 40.8) — a bearer in the header, the
+session bound by `Mcp-Session-Id` — so a tool cannot take a credential as an argument and this
+forward cannot invent one.
+
+WHAT DOES NOT TRAVEL: anything the manifest did not declare. An argument the owning route ignores is
+the worst reply available to an agent — it reports success for something that did not happen — so an
+undeclared parameter is dropped here rather than forwarded and silently discarded there.
+"""
+from __future__ import annotations
+
+from typing import Dict, List, Optional
+
+import httpx
+from fastapi import FastAPI, HTTPException, Request
+from fastapi.responses import JSONResponse
+
+from .bind import BoundTool
+
+
+def _caller_key(request: Request) -> str:
+    """The credential the edge already resolved. One carrier, no fallbacks: `x-api-key`, or the
+    bearer the MCP transport contract uses, adapted at this boundary exactly as `_mcp_key` does at
+    the gateway."""
+    key = (request.headers.get("x-api-key") or "").strip()
+    if key:
+        return key
+    auth = (request.headers.get("authorization") or "").strip()
+    if not auth:
+        return ""
+    scheme, _, token = auth.partition(" ")
+    return (token.strip() if scheme.lower() == "bearer" else auth) or ""
+
+
+def register(app: FastAPI, bound: List[BoundTool], base_urls: Dict[str, str], *,
+             transport: Optional[httpx.AsyncBaseTransport] = None) -> List[str]:
+    """Add one route per bound tool. Returns the names registered, in order."""
+    names: List[str] = []
+    for bt in bound:
+        names.append(_add(app, bt, base_urls[bt.tool.domain], transport))
+    return names
+
+
+def _add(app: FastAPI, bt: BoundTool, base: str,
+         transport: Optional[httpx.AsyncBaseTransport]) -> str:
+    method = bt.tool.route["method"]
+    template = bt.tool.route["path"]
+    declared = tuple(bt.parameters)
+    path_params = tuple(bt.path_params)
+
+    async def endpoint(request: Request):
+        key = _caller_key(request)
+        if key == "" and bt.tool.identity != "none":
+            raise HTTPException(status_code=401, detail="this tool needs your Vexa credential")
+        body = {}
+        if method in ("POST", "PUT", "PATCH"):
+            try:
+                body = await request.json()
+            except Exception:  # noqa: BLE001 — an empty body is a legitimate call
+                body = {}
+        body = body if isinstance(body, dict) else {}
+
+        path = template
+        for name in path_params:
+            value = body.pop(name, None)
+            if value is None:
+                value = request.query_params.get(name)
+            if value in (None, ""):
+                raise HTTPException(status_code=422,
+                                    detail=f"{bt.name} needs {name}")
+            path = path.replace("{" + name + "}", str(value))
+
+        params = {n: request.query_params[n] for n in declared if n in request.query_params}
+        for n in declared:
+            if n not in params and n in body:
+                params[n] = body.pop(n)
+
+        try:
+            async with httpx.AsyncClient(timeout=10, transport=transport) as client:
+                r = await client.request(
+                    method, f"{base}{path}",
+                    headers={"X-API-Key": key, "Content-Type": "application/json"},
+                    params=params or None,
+                    json=body if method in ("POST", "PUT", "PATCH") else None)
+        except httpx.TimeoutException:
+            raise HTTPException(status_code=504, detail=f"{bt.tool.domain} timed out")
+        except httpx.RequestError as e:
+            raise HTTPException(status_code=503, detail=f"{bt.tool.domain} is unreachable: {e}")
+        # THE DOMAIN'S OWN ANSWER, UNCHANGED. A 403 from flows is flows' answer and an agent needs
+        # to see it; rewriting it here would turn "you may not do that" into "we are broken".
+        try:
+            payload = r.json() if r.content else {}
+        except Exception:  # noqa: BLE001
+            payload = {"detail": r.text[:2000]}
+        return JSONResponse(status_code=r.status_code, content=payload)
+
+    endpoint.__name__ = bt.name
+    endpoint.__doc__ = bt.description or f"{bt.tool.domain}: {method} {template}"
+    app.add_api_route(f"/tools/{bt.name}", endpoint, methods=[method],
+                      operation_id=bt.name, name=bt.name,
+                      summary=bt.description or None,
+                      description=bt.description or None)
+    return bt.name

--- a/core/meetings/services/mcp/tests/test_app.py
+++ b/core/meetings/services/mcp/tests/test_app.py
@@ -5,6 +5,8 @@ with the caller's key as X-API-Key, and auth is fail-closed (401 with a Bearer h
 """
 import json
 
+import pytest
+
 from conftest import API_KEY, FakeGateway
 
 
@@ -104,7 +106,9 @@ def test_request_meeting_bot_409_reports_already_exists(client, gateway: FakeGat
 
 
 def test_update_bot_config_path_and_payload(client, gateway, auth):
-    r = client.put("/bot-config/teams/9361792952021", headers=auth, json={"language": "es"})
+    r = client.put(
+        "/bot-config?platform=teams&native_meeting_id=9361792952021", headers=auth, json={"language": "es"}
+    )
     assert r.status_code == 200
     req = gateway.requests[-1]
     assert (req.method, req.url.path) == ("PUT", "/bots/teams/9361792952021/config")
@@ -112,9 +116,48 @@ def test_update_bot_config_path_and_payload(client, gateway, auth):
 
 
 def test_stop_bot_path(client, gateway, auth):
-    client.delete("/bot/google_meet/abc-defg-hij", headers=auth)
+    client.delete("/bot?platform=google_meet&native_meeting_id=abc-defg-hij", headers=auth)
     req = gateway.requests[-1]
     assert (req.method, req.url.path) == ("DELETE", "/bots/google_meet/abc-defg-hij")
+
+
+# --- one identity vocabulary across the surface ------------------------------
+# Every tool RETURNS `platform` + `native_meeting_id`; three tools used to ACCEPT
+# `meeting_platform` + `meeting_id`, so no tool's output could be fed to the next tool's
+# input without a rename nothing documented. Canonical names must work, the deprecated
+# aliases must keep working, and platform must default rather than being mandatory.
+
+@pytest.mark.parametrize(
+    "query",
+    [
+        "platform=zoom&native_meeting_id=12345678901",   # canonical
+        "meeting_platform=zoom&meeting_id=12345678901",  # deprecated aliases
+        "platform=zoom&meeting_id=12345678901",          # mixed
+    ],
+)
+def test_transcript_accepts_canonical_and_legacy_identity(client, gateway, auth, query):
+    r = client.get(f"/meeting-transcript?{query}", headers=auth)
+    assert r.status_code == 200
+    req = gateway.requests[-1]
+    assert (req.method, req.url.path) == ("GET", "/transcripts/zoom/12345678901")
+
+
+def test_transcript_platform_defaults_to_google_meet(client, gateway, auth):
+    client.get("/meeting-transcript?native_meeting_id=abc-defg-hij", headers=auth)
+    assert gateway.requests[-1].url.path == "/transcripts/google_meet/abc-defg-hij"
+
+
+def test_stop_bot_accepts_legacy_identity(client, gateway, auth):
+    client.delete("/bot?meeting_platform=teams&meeting_id=9361792952021", headers=auth)
+    assert gateway.requests[-1].url.path == "/bots/teams/9361792952021"
+
+
+def test_missing_meeting_id_names_the_tool_and_the_field(client, gateway, auth):
+    r = client.get("/meeting-transcript?platform=zoom", headers=auth)
+    assert r.status_code == 422
+    detail = str(r.json()["detail"])
+    assert "get_meeting_transcript" in detail
+    assert "native_meeting_id" in detail
 
 
 def test_list_meetings_params(client, gateway, auth):
@@ -125,9 +168,50 @@ def test_list_meetings_params(client, gateway, auth):
 
 
 def test_get_meeting_transcript_path(client, gateway, auth):
-    client.get("/meeting-transcript/zoom/12345678901", headers=auth)
+    client.get("/meeting-transcript?platform=zoom&native_meeting_id=12345678901", headers=auth)
     req = gateway.requests[-1]
     assert (req.method, req.url.path) == ("GET", "/transcripts/zoom/12345678901")
+
+
+# --- following a live meeting without re-reading it --------------------------
+# The scarce resource is the CALLER's context window, not the hop to meeting-api: polling a live
+# meeting used to re-download every segment spoken so far on every call. `since_index` returns
+# only what is new; `total_segments`/`next_index` always describe the FULL transcript so a caller
+# can tell "nothing new" from "nothing at all" and can resume after losing its own state.
+
+def _transcript_route(gateway, n):
+    gateway.routes[("GET", "/transcripts/google_meet/abc-defg-hij")] = (
+        200,
+        {"status": "active", "segments": [{"speaker": "A", "text": f"line {i}"} for i in range(n)]},
+    )
+
+
+def test_transcript_since_index_returns_only_new_segments(client, gateway, auth):
+    _transcript_route(gateway, 6)
+    body = client.get(
+        "/meeting-transcript?native_meeting_id=abc-defg-hij&since_index=4", headers=auth
+    ).json()
+    assert [s["text"] for s in body["segments"]] == ["line 4", "line 5"]
+    assert (body["total_segments"], body["next_index"], body["since_index"]) == (6, 6, 4)
+
+
+def test_transcript_without_cursor_returns_everything(client, gateway, auth):
+    _transcript_route(gateway, 3)
+    body = client.get("/meeting-transcript?native_meeting_id=abc-defg-hij", headers=auth).json()
+    assert len(body["segments"]) == 3
+    assert body["next_index"] == 3
+    assert "since_index" not in body
+
+
+def test_transcript_cursor_past_the_end_is_empty_not_an_error(client, gateway, auth):
+    """The steady state of following a live meeting: caller is caught up, nothing new was said."""
+    _transcript_route(gateway, 2)
+    body = client.get(
+        "/meeting-transcript?native_meeting_id=abc-defg-hij&since_index=99", headers=auth
+    ).json()
+    assert body["segments"] == []
+    assert body["total_segments"] == 2
+    assert body["next_index"] == 2
 
 
 def test_list_recordings_params(client, gateway, auth):
@@ -167,7 +251,7 @@ TICKET = {
     "what_i_tried": "POST /bots for a google_meet room via the MCP request_meeting_bot tool",
     "what_happened": "The bot never appeared in the meeting and bot-status stayed empty for 3 min",
     "deployment": "self-hosted 0.12.3",
-    "meeting_id": "abc-defg-hij",
+    "native_meeting_id": "abc-defg-hij",
     "platform": "google_meet",
     "logs": "RuntimeError: admission timeout",
 }
@@ -186,9 +270,9 @@ def test_report_issue_without_sink_returns_503(client, gateway, auth, monkeypatc
 
 
 # Filing spends the OPERATOR's sink credential, so the caller's own credential is checked first.
-# The ticket carrying no meeting_id is the case that matters: it is the one with no other reason
+# The ticket carrying no native_meeting_id is the case that matters: it is the one with no other reason
 # to touch the gateway, so it is the one an unvalidated key would ride through.
-TICKET_NO_MEETING = {k: v for k, v in TICKET.items() if k not in ("meeting_id", "platform")}
+TICKET_NO_MEETING = {k: v for k, v in TICKET.items() if k not in ("native_meeting_id", "platform")}
 
 
 def test_report_issue_refuses_a_credential_the_gateway_rejects(client, gateway: FakeGateway, auth, monkeypatch):
@@ -219,7 +303,7 @@ def test_report_issue_files_a_ticket_that_names_no_meeting(client, gateway: Fake
 
     assert r.status_code == 200
     body = json.loads(_sink_requests(gateway)[-1].content)
-    assert body["meeting_id"] is None
+    assert body["native_meeting_id"] is None
     assert body["entity"] is None
 
 
@@ -236,7 +320,7 @@ def test_report_issue_forwards_ticket_to_sink(client, gateway: FakeGateway, auth
     assert body["what_happened"] == TICKET["what_happened"]
     assert body["deployment"] == "self-hosted 0.12.3"
     # the join key onto the cluster's own record of the same meeting
-    assert body["meeting_id"] == "abc-defg-hij"
+    assert body["native_meeting_id"] == "abc-defg-hij"
     assert body["platform"] == "google_meet"
     assert body["logs"] == "RuntimeError: admission timeout"
     assert body["logs_truncated"] is False
@@ -355,10 +439,10 @@ def test_report_issue_sink_failure_surfaces_as_502(client, gateway: FakeGateway,
     assert "sink rejected" in str(r.json()["detail"])
 
 
-def test_report_issue_without_meeting_id_still_authenticates_the_caller(client, gateway: FakeGateway, auth, monkeypatch):
+def test_report_issue_without_native_meeting_id_still_authenticates_the_caller(client, gateway: FakeGateway, auth, monkeypatch):
     """With no entity to resolve there is still a credential to check, and it is checked once."""
     monkeypatch.setenv("VEXA_TICKET_SINK_URL", SINK_URL)
-    payload = {k: v for k, v in TICKET.items() if k not in ("meeting_id", "platform")}
+    payload = {k: v for k, v in TICKET.items() if k not in ("native_meeting_id", "platform")}
     client.post("/report-issue", headers=auth, json=payload)
     hops = [r for r in gateway.requests if r.url.host == "gateway.test"]
     assert [(r.method, r.url.path) for r in hops] == [("GET", "/meetings")]
@@ -388,7 +472,7 @@ def test_report_issue_resolves_entity_only_for_a_meeting_the_caller_owns(
     assert json.loads(_sink_requests(gateway)[-1].content)["entity"]["id"] == "abc-defg-hij"
 
 
-def test_report_issue_unowned_meeting_id_files_without_an_entity(client, gateway: FakeGateway, auth, monkeypatch):
+def test_report_issue_unowned_native_meeting_id_files_without_an_entity(client, gateway: FakeGateway, auth, monkeypatch):
     """A quoted id the caller does not own is text, never a resolved join — and never fatal.
 
     The gateway answers with the caller's OWN meetings, so an id belonging to someone else is
@@ -396,12 +480,12 @@ def test_report_issue_unowned_meeting_id_files_without_an_entity(client, gateway
     """
     monkeypatch.setenv("VEXA_TICKET_SINK_URL", SINK_URL)
     gateway.routes[("GET", "/meetings")] = (200, [{"native_meeting_id": "mine", "platform": "google_meet"}])
-    r = client.post("/report-issue", headers=auth, json={**TICKET, "meeting_id": "someone-elses"})
+    r = client.post("/report-issue", headers=auth, json={**TICKET, "native_meeting_id": "someone-elses"})
     assert r.status_code == 200
     assert r.json()["entity"] is None
     body = json.loads(_sink_requests(gateway)[-1].content)
     assert body["entity"] is None
-    assert body["meeting_id"] == "someone-elses"     # quoted, not resolved
+    assert body["native_meeting_id"] == "someone-elses"     # quoted, not resolved
 
 
 def test_report_issue_meeting_absent_from_callers_meetings_does_not_resolve(
@@ -431,7 +515,7 @@ def test_report_issue_has_no_url_shaped_field_and_fetches_nothing(client, gatewa
 
     monkeypatch.setenv("VEXA_TICKET_SINK_URL", SINK_URL)
     poisoned = {
-        **{k: v for k, v in TICKET.items() if k not in ("meeting_id", "platform")},
+        **{k: v for k, v in TICKET.items() if k not in ("native_meeting_id", "platform")},
         "what_happened": "see http://169.254.169.254/latest/meta-data/ and file:///etc/passwd",
         "logs": "http://localhost:6379/ http://internal.svc/admin",
     }
@@ -498,7 +582,7 @@ def test_raw_is_the_default_and_is_byte_unchanged(client, gateway: FakeGateway, 
     assert set(body) == {
         "source", "tool", "reported_at", "fingerprint", "caller_fingerprint", "summary",
         "description", "what_i_tried", "what_happened", "deployment", "version", "severity",
-        "meeting_id", "platform", "entity", "logs", "logs_truncated",
+        "native_meeting_id", "platform", "entity", "logs", "logs_truncated",
     }
     assert req.headers["content-type"] == "application/json"
     assert req.headers["authorization"] == "Bearer sink-secret"
@@ -553,7 +637,7 @@ def test_github_body_calls_out_the_meeting_join_key(client, gateway: FakeGateway
 
 def test_github_body_states_when_no_meeting_was_supplied(client, gateway: FakeGateway, auth, monkeypatch):
     _gh(monkeypatch)
-    ticket = {k: v for k, v in TICKET.items() if k not in {"meeting_id", "platform"}}
+    ticket = {k: v for k, v in TICKET.items() if k not in {"native_meeting_id", "platform"}}
     client.post("/report-issue", headers=auth, json=ticket)
     md = json.loads(_sink_requests(gateway)[-1].content)["body"]
     assert "### Join key" in md
@@ -593,3 +677,188 @@ def test_github_format_still_never_forwards_the_api_key(client, gateway: FakeGat
     req = _sink_requests(gateway)[-1]
     assert API_KEY not in req.content.decode()
     assert API_KEY not in json.dumps(dict(req.headers))
+
+
+# --- annotations: the caller's own description of a meeting ------------------
+# The join key between a Vexa meeting and everything else the agent knows. Previously impossible:
+# PATCH /meetings answered 409 for the entire useful life of a meeting (once a bot was dispatched),
+# and there was no metadata field at all.
+
+def test_annotate_forwards_title_and_metadata(client, gateway, auth):
+    r = client.post(
+        "/meeting-annotate?platform=google_meet&native_meeting_id=abc-defg-hij",
+        headers=auth,
+        json={"title": "Acme renewal", "metadata": {"crm_deal": "acme-42"}},
+    )
+    assert r.status_code == 200
+    req = gateway.requests[-1]
+    assert (req.method, req.url.path) == ("POST", "/meetings/google_meet/abc-defg-hij/annotate")
+    assert gateway.last_json() == {"title": "Acme renewal", "metadata": {"crm_deal": "acme-42"}}
+
+
+def test_replace_is_refused_outright_not_silently_ignored(client, gateway, auth):
+    """There is no whole-object replace: a caller sharing an account's API key must not be able to
+    destroy annotations another agent — or the human — wrote and it never saw.
+
+    It is REFUSED rather than dropped. A caller that believes it replaced the object and was
+    silently merged holds a false model of the stored state, which is worse than an error."""
+    before = len(gateway.requests)
+    r = client.post(
+        "/meeting-annotate?native_meeting_id=abc-defg-hij&replace=true",
+        headers=auth, json={"metadata": {"only": "this"}},
+    )
+    assert r.status_code == 422
+    assert "replace" in r.text
+    assert len(gateway.requests) == before, "an unknown argument must not reach the gateway"
+
+
+def test_annotate_requires_something_to_write(client, gateway, auth):
+    r = client.post("/meeting-annotate?native_meeting_id=abc-defg-hij", headers=auth, json={})
+    assert r.status_code == 422
+
+
+def test_list_meetings_forwards_metadata_filter(client, gateway, auth):
+    client.get('/meetings?metadata_filter={"crm_deal":"acme-42"}', headers=auth)
+    assert dict(gateway.requests[-1].url.params)["metadata"] == '{"crm_deal":"acme-42"}'
+
+
+def test_list_meetings_rejects_a_malformed_metadata_filter(client, gateway, auth):
+    """A filter that silently failed to apply is WORSE than an error: the agent would read a full
+    unfiltered list as 'these all match'."""
+    before = len(gateway.requests)
+    r = client.get("/meetings?metadata_filter=not-json", headers=auth)
+    assert r.status_code == 422
+    assert "metadata_filter" in str(r.json()["detail"])
+    assert len(gateway.requests) == before, "must not reach the gateway with a bad filter"
+
+
+def test_list_meetings_rejects_a_non_object_metadata_filter(client, gateway, auth):
+    r = client.get("/meetings?metadata_filter=[1,2]", headers=auth)
+    assert r.status_code == 422
+
+
+# --- the interactive bot: ours talks, theirs records -------------------------
+
+def test_speak_forwards_to_the_bot_speak_route(client, gateway, auth):
+    r = client.post(
+        "/meeting-speak?platform=teams&native_meeting_id=9361792952021",
+        headers=auth,
+        json={"text": "Dmitry asked me to say the numbers are in the deck.",
+              "asked_by_a_human": True},
+    )
+    assert r.status_code == 200
+    req = gateway.requests[-1]
+    assert (req.method, req.url.path) == ("POST", "/bots/teams/9361792952021/speak")
+    assert gateway.last_json()["text"].startswith("Dmitry asked me")
+
+
+# --- speaking out loud needs a MECHANICAL guard, not only a warning ----------
+# This tool is one tools/call from being audible to real people in a real conversation, and it
+# will be loaded alongside a hundred others whose descriptions get skimmed. A required field
+# cannot be skimmed past the way a paragraph can.
+
+def test_speak_is_refused_without_the_explicit_acknowledgement(client, gateway, auth):
+    before = len(gateway.requests)
+    r = client.post(
+        "/meeting-speak?platform=teams&native_meeting_id=9361792952021",
+        headers=auth, json={"text": "hello"},
+    )
+    assert r.status_code == 422
+    assert len(gateway.requests) == before, "nothing may reach the meeting without the acknowledgement"
+
+
+def test_speak_is_refused_when_the_acknowledgement_is_false(client, gateway, auth):
+    before = len(gateway.requests)
+    r = client.post(
+        "/meeting-speak?platform=teams&native_meeting_id=9361792952021",
+        headers=auth, json={"text": "hello", "asked_by_a_human": False},
+    )
+    assert r.status_code == 422
+    assert len(gateway.requests) == before
+
+
+def test_the_acknowledgement_is_not_forwarded_as_speech(client, gateway, auth):
+    """It is a gate on the caller, not a field the bot should carry downstream."""
+    client.post(
+        "/meeting-speak?platform=teams&native_meeting_id=9361792952021",
+        headers=auth, json={"text": "hello", "asked_by_a_human": True},
+    )
+    assert "hello" in gateway.last_json()["text"]
+
+
+def test_get_meeting_chat_path(client, gateway, auth):
+    client.get("/meeting-chat?native_meeting_id=abc-defg-hij", headers=auth)
+    req = gateway.requests[-1]
+    assert (req.method, req.url.path) == ("GET", "/bots/google_meet/abc-defg-hij/chat")
+
+
+# --- an empty result must never be a guess -----------------------------------
+# A cold-start agent reported `platform="webex"` returning a confident `count: 0` — silence that
+# looks like an answer. "Nobody said that" and "you filtered everything away" must not be the
+# same reply.
+
+def test_unknown_platform_is_refused_not_answered_with_zero(client, gateway, auth):
+    before = len(gateway.requests)
+    r = client.get("/transcript-search", params={"q": "panel", "platform": "webex"}, headers=auth)
+    assert r.status_code == 422
+    detail = str(r.json()["detail"])
+    assert "webex" in detail and "google_meet" in detail, "the error must name the valid values"
+    assert len(gateway.requests) == before
+
+
+def test_unknown_platform_is_refused_on_list_meetings_too(client, auth):
+    assert client.get("/meetings", params={"platform": "webex"}, headers=auth).status_code == 422
+
+
+def test_a_valid_platform_still_works(client, gateway, auth):
+    assert client.get("/meetings", params={"platform": "zoom"}, headers=auth).status_code == 200
+
+
+def test_omitting_platform_searches_everything(client, gateway, auth):
+    r = client.get("/transcript-search", params={"q": "panel"}, headers=auth)
+    assert r.status_code == 200
+    assert "platform" not in dict(gateway.requests[-1].url.params)
+
+
+# --- a typo must not look like success ---------------------------------------
+# FastAPI ignores unknown query params, so `get_meeting_transcript(limit=2)` — no such parameter —
+# returned 200 with the argument dropped. For an agent that is the worst failure available: the
+# wrong answer is indistinguishable from the right one.
+
+def test_an_unknown_argument_is_refused(client, gateway, auth):
+    before = len(gateway.requests)
+    r = client.get("/meeting-transcript",
+                   params={"native_meeting_id": "abc-defg-hij", "limit": 2}, headers=auth)
+    assert r.status_code == 422
+    assert "limit" in r.text
+    assert len(gateway.requests) == before, "an unknown argument must not reach the gateway"
+
+
+def test_a_near_miss_argument_gets_a_suggestion(client, auth):
+    r = client.get("/transcript-search", params={"q": "x", "meeting_id_native": "abc"}, headers=auth)
+    assert r.status_code == 422
+    assert "did you mean" in str(r.json()["detail"]).lower()
+
+
+def test_the_accepted_arguments_are_listed_in_the_error(client, auth):
+    detail = client.get("/meetings", params={"totally_bogus": 1}, headers=auth).json()["detail"]
+    assert "accepted" in detail and "platform" in detail["accepted"]
+
+
+# --- a write echoes what it wrote, not the whole meeting ----------------------
+
+def test_annotate_returns_only_what_was_written(client, gateway, auth):
+    """The full row carries object-storage paths, a playback URL and a ~69 MB audio reference —
+    none of it requested, all of it landing in a calling model's context."""
+    gateway.routes[("POST", "/meetings/google_meet/abc-defg-hij/annotate")] = (200, {
+        "id": 1, "platform": "google_meet", "native_meeting_id": "abc-defg-hij", "status": "active",
+        "data": {"title": "Acme renewal", "metadata": {"crm_deal": "acme-42"},
+                 "recordings": [{"playback_url": "https://minio/…", "bytes": 69_000_000}],
+                 "webhook_url": "https://hooks.example/x"},
+    })
+    body = client.post("/meeting-annotate?native_meeting_id=abc-defg-hij",
+                       headers=auth, json={"metadata": {"crm_deal": "acme-42"}}).json()
+    assert body["metadata"] == {"crm_deal": "acme-42"}
+    assert body["title"] == "Acme renewal"
+    assert body["native_meeting_id"] == "abc-defg-hij" and body["meeting_db_id"] == 1
+    assert "recordings" not in body and "data" not in body and "webhook_url" not in body

--- a/core/meetings/services/mcp/tests/test_assembled_surface.py
+++ b/core/meetings/services/mcp/tests/test_assembled_surface.py
@@ -1,0 +1,95 @@
+"""END TO END — a domain's manifest becomes a tool an agent sees in `tools/list`.
+
+The point of assembling rather than proxying: an assembled tool and one of this service's own
+fourteen are indistinguishable to a client, because both are a route with `operation_id=<name>` that
+`FastApiMCP` reads out of the same OpenAPI.
+
+The flows manifest used here is THE FILE IN THE REPO — `core/flows/mcp.tools.v1.json`, the same one
+flows-api serves at `/.well-known/mcp-tools.json`. If that file stops being assemblable, this fails.
+"""
+from __future__ import annotations
+
+import json
+import pathlib
+
+import httpx
+
+from vexa_mcp import create_app
+from vexa_mcp.manifest import CONTRACT
+
+REPO = pathlib.Path(__file__).resolve().parents[5]
+FLOWS_MANIFEST = json.loads((REPO / "core" / "flows" / "mcp.tools.v1.json").read_text())
+
+FLOWS_OPENAPI = {"paths": {
+    "/flows": {"get": {"summary": "Every flow version the engine knows", "parameters": []}},
+    "/reactions": {"get": {"summary": "The operator projection", "parameters": [
+        {"name": "status", "in": "query", "schema": {"type": "string"}},
+        {"name": "subject", "in": "query", "schema": {"type": "string"}}]}},
+    "/reactions/{reaction_id}/{verb}": {"post": {"summary": "Steer one reaction", "parameters": []}},
+    "/timeline": {"get": {"summary": "One person's day, in order", "parameters": [
+        {"name": "subject", "in": "query", "schema": {"type": "string"}},
+        {"name": "since", "in": "query", "schema": {"type": "string"}},
+        {"name": "until", "in": "query", "schema": {"type": "string"}},
+        {"name": "limit", "in": "query", "schema": {"type": "integer"}}]}},
+}}
+
+BUILT_IN = 14
+
+
+def _boot(**env):
+    def handler(request: httpx.Request) -> httpx.Response:
+        url = str(request.url)
+        # ONLY the flows host answers. Identity is configured (it always is) and carries no manifest
+        # yet, which is the ordinary state of a domain that has not published one.
+        if not url.startswith("http://flows"):
+            return httpx.Response(404)
+        if url.endswith("/.well-known/mcp-tools.json"):
+            return httpx.Response(200, json=FLOWS_MANIFEST)
+        if url.endswith("/openapi.json"):
+            return httpx.Response(200, json=FLOWS_OPENAPI)
+        return httpx.Response(404)
+
+    return create_app(
+        "http://gateway.test",
+        transport=httpx.MockTransport(lambda r: httpx.Response(200, json={})),
+        assembly_env={"ADMIN_API_URL": "http://identity", **env},
+        assembly_transport=httpx.MockTransport(handler),
+    )
+
+
+def test_the_repo_s_flows_manifest_is_the_one_that_gets_assembled():
+    assert FLOWS_MANIFEST["contract"] == CONTRACT and FLOWS_MANIFEST["domain"] == "flows"
+
+
+def test_a_deployment_with_flows_serves_the_flows_tools_beside_the_built_in_ones():
+    app = _boot(FLOWS_API_URL="http://flows")
+    names = {t.name for t in app.state.mcp.tools}
+    declared = {t["name"] for t in FLOWS_MANIFEST["tools"]}
+    assert declared <= names, f"missing from tools/list: {sorted(declared - names)}"
+    assert len(names) == BUILT_IN + len(declared)
+
+
+def test_a_deployment_without_flows_serves_exactly_the_built_in_fourteen():
+    """Absent, not present-and-failing. An agent that cannot see a tool recovers; one told a tool
+    exists and handed a 502 tells the person the product is broken."""
+    app = _boot()
+    assert len(app.state.mcp.tools) == BUILT_IN
+    assert app.state.assembly is not None and not app.state.assembly.tools
+
+
+def test_an_assembled_tool_carries_the_owning_route_s_description():
+    """The manifest holds no description of its own — it is derived from the route's OpenAPI, so a
+    tool and the route behind it cannot disagree."""
+    app = _boot(FLOWS_API_URL="http://flows")
+    tool = next(t for t in app.state.mcp.tools if t.name == "flows_list")
+    assert "Every flow version the engine knows" in (tool.description or "")
+
+
+def test_no_assembled_tool_takes_a_credential_argument():
+    """PRD 40.8 — one authentication path into this edge: a bearer header, session-bound."""
+    app = _boot(FLOWS_API_URL="http://flows")
+    banned = {"token", "api_key", "apikey", "access_token", "password", "secret"}
+    for t in app.state.mcp.tools:
+        props = set(((t.inputSchema if hasattr(t, "inputSchema") else t.input_schema) or {})
+                    .get("properties", {}))
+        assert not (props & banned), f"{t.name} takes {sorted(props & banned)}"

--- a/core/meetings/services/mcp/tests/test_assembly.py
+++ b/core/meetings/services/mcp/tests/test_assembly.py
@@ -1,0 +1,173 @@
+"""THE ASSEMBLER — one MCP server, built from the manifests of the domains that are deployed.
+
+PRD decision 40, founder rulings of 2026-09-02. A tool belongs to the domain that owns the door
+behind it; this service is an EDGE that assembles what those domains declare, and holds no domain
+logic of its own. It also reads a MOUNTED manifest directory, so a private paid domain composes onto
+the line without a line of it living in this repo.
+
+Every rule below fails the BOOT rather than degrading, and each one is a failure that would
+otherwise be silent:
+
+  * a domain that is deployed but does not answer — "the meetings tools are missing" must never be
+    something a person discovers by asking for one;
+  * a tool name claimed twice — last-one-wins would let a mounted private manifest shadow an OSS
+    tool, which is the one thing a mount must never be able to do;
+  * a manifest naming a route its own service does not serve — a manifest lying about its service is
+    the only failure this design could otherwise hide;
+  * two entitlement hooks — "who decides whether this person may act" is not a question with two
+    answers.
+
+A tool whose `requires` is not satisfied is ABSENT from tools/list, never present-and-failing: an
+agent that cannot see a tool recovers, one told a tool exists and handed a 502 tells the person the
+product is broken.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from vexa_mcp import manifest as m
+
+
+def _manifest(domain="flows", tools=None, **kw):
+    doc = {
+        "contract": "mcp.tools.v1", "domain": domain, "source": kw.pop("source", "oss"),
+        "owner": f"core/{domain}", "base_url_env": f"{domain.upper()}_API_URL",
+        "served_at": "/.well-known/mcp-tools.json", "depends_on": ["identity"],
+        "tools": tools if tools is not None else [
+            {"name": "flows_list", "identity": "operator", "requires": ["identity", "flows"],
+             "route": {"method": "GET", "path": "/flows"}}],
+    }
+    doc.update(kw)
+    return doc
+
+
+# ── what a manifest must be ──────────────────────────────────────────────────────────────────
+def test_a_manifest_may_only_depend_on_identity():
+    """The independence ruling, checked where it is declared. Meetings, flows and agent each point
+    at identity and nothing else, which is what makes every configuration a product."""
+    with pytest.raises(m.ManifestError, match="depends_on"):
+        m.validate(_manifest(depends_on=["identity", "agent"]))
+    m.validate(_manifest(depends_on=["identity"]))
+    m.validate(_manifest(domain="identity", depends_on=[], base_url_env="ADMIN_API_URL", tools=[
+        {"name": "settings", "identity": "user", "requires": ["identity"],
+         "route": {"method": "GET", "path": "/user/settings"}}]))
+
+
+def test_a_tool_requires_its_own_domain_and_identity_only():
+    with pytest.raises(m.ManifestError, match="requires"):
+        m.validate(_manifest(tools=[
+            {"name": "x", "identity": "user", "requires": ["identity", "meetings"],
+             "route": {"method": "GET", "path": "/x"}}]))
+
+
+def test_an_edge_owned_tool_may_have_no_route_only_when_it_has_no_door():
+    m.validate(_manifest(domain="gateway", base_url_env=None, served_at=None, tools=[
+        {"name": "vexa_overview", "identity": "none", "requires": ["identity"], "route": None}]))
+    with pytest.raises(m.ManifestError, match="route"):
+        m.validate(_manifest(tools=[
+            {"name": "x", "identity": "user", "requires": ["identity", "flows"], "route": None}]))
+
+
+# ── assembly ─────────────────────────────────────────────────────────────────────────────────
+def test_only_tools_whose_domains_are_deployed_are_served():
+    """Eight configurations, not two. A tool the deployment cannot satisfy is ABSENT."""
+    flows = _manifest()
+    agent = _manifest(domain="agent", base_url_env="AGENT_API_URL", tools=[
+        {"name": "workspace_tree", "identity": "user", "requires": ["identity", "agent"],
+         "route": {"method": "GET", "path": "/api/workspace/tree"}}])
+    both = m.assemble([flows, agent], deployed={"identity", "flows", "agent"})
+    assert {t.name for t in both.tools} == {"flows_list", "workspace_tree"}
+    no_agents = m.assemble([flows, agent], deployed={"identity", "flows"})
+    assert {t.name for t in no_agents.tools} == {"flows_list"}
+    assert "agent" in no_agents.absent_domains
+
+
+def test_a_name_claimed_twice_fails_the_boot_and_names_both():
+    a = _manifest()
+    b = _manifest(domain="agent", base_url_env="AGENT_API_URL", tools=[
+        {"name": "flows_list", "identity": "user", "requires": ["identity", "agent"],
+         "route": {"method": "GET", "path": "/x"}}])
+    with pytest.raises(m.ManifestError) as e:
+        m.assemble([a, b], deployed={"identity", "flows", "agent"})
+    assert "flows_list" in str(e.value) and "flows" in str(e.value) and "agent" in str(e.value)
+
+
+def test_a_mounted_manifest_gets_no_precedence_over_an_oss_one():
+    """The rule that makes a private mount safe: it collides, it does not shadow."""
+    oss = _manifest()
+    mounted = _manifest(domain="billing", source="mounted", base_url_env="BILLING_API_URL",
+                        tools=[{"name": "flows_list", "identity": "user",
+                                "requires": ["identity", "billing"],
+                                "route": {"method": "GET", "path": "/seats"}}])
+    with pytest.raises(m.ManifestError, match="claimed"):
+        m.assemble([oss, mounted], deployed={"identity", "flows", "billing"})
+
+
+def test_at_most_one_manifest_may_declare_the_entitlement_hook():
+    ent = {"route": {"method": "GET", "path": "/entitlement"}, "answers": "entitled(subject)"}
+    one = m.assemble([_manifest(domain="billing", source="mounted",
+                                base_url_env="BILLING_API_URL", entitlement=ent, tools=[])],
+                     deployed={"identity", "billing"})
+    assert one.entitlement is not None and one.entitlement.domain == "billing"
+    with pytest.raises(m.ManifestError, match="entitlement"):
+        m.assemble([_manifest(domain="billing", source="mounted",
+                              base_url_env="BILLING_API_URL", entitlement=ent, tools=[]),
+                    _manifest(domain="flows", entitlement=ent)],
+                   deployed={"identity", "billing", "flows"})
+
+
+def test_no_entitlement_hook_means_everyone_is_entitled():
+    """No manifest declares it => there is no hook => the OSS product exactly. This repo never
+    carries a gate shipped dark."""
+    assembled = m.assemble([_manifest()], deployed={"identity", "flows"})
+    assert assembled.entitlement is None
+
+
+def test_a_deployed_domain_that_does_not_answer_fails_the_boot():
+    """"The meetings tools are missing" must never be something a person finds by asking."""
+    with pytest.raises(m.ManifestError, match="did not answer"):
+        m.assemble([_manifest()], deployed={"identity", "flows", "meetings"},
+                   required_domains={"meetings"})
+
+
+# ── the mounted directory ────────────────────────────────────────────────────────────────────
+def test_the_mounted_directory_is_empty_by_default_and_that_is_the_oss_product(tmp_path):
+    assert m.load_mounted(None) == []
+    assert m.load_mounted(str(tmp_path)) == []
+
+
+def test_a_mounted_file_is_read_and_marked_mounted(tmp_path):
+    doc = _manifest(domain="billing", source="oss", base_url_env="BILLING_API_URL", tools=[])
+    (tmp_path / "billing.mcp.tools.v1.json").write_text(json.dumps(doc))
+    loaded = m.load_mounted(str(tmp_path))
+    assert len(loaded) == 1
+    assert loaded[0]["source"] == "mounted", "a file in the mount is mounted whatever it claims"
+
+
+def test_a_malformed_mounted_file_fails_the_boot_rather_than_being_skipped(tmp_path):
+    """Skipping it would mean a paid deployment silently missing the tools it paid for."""
+    (tmp_path / "broken.mcp.tools.v1.json").write_text("{not json")
+    with pytest.raises(m.ManifestError, match="broken"):
+        m.load_mounted(str(tmp_path))
+
+
+# ── one authentication path (PRD 40.8) ───────────────────────────────────────────────────────
+def test_a_tool_may_not_take_a_credential_as_an_argument():
+    """The rig's 64 tools each carried `token=""` — a credential in an argument list, which is in
+    the transcript forever and cannot be withdrawn. The edge has ONE path: a bearer header, with the
+    session bound by Mcp-Session-Id. It is enforced here because this is where a tool's surface is
+    decided; a route's OpenAPI has no such parameter, so the rule is mostly kept by construction and
+    this catches a domain that reintroduces one on purpose."""
+    for arg in ("token", "api_key", "access_token", "password"):
+        with pytest.raises(m.ManifestError, match="one authentication path"):
+            m.validate(_manifest(tools=[
+                {"name": "x", "identity": "user", "requires": ["identity", "flows"],
+                 "route": {"method": "GET", "path": "/x"}, "arguments": [arg, "since"]}]))
+
+
+def test_ordinary_arguments_are_untouched():
+    m.validate(_manifest(tools=[
+        {"name": "x", "identity": "user", "requires": ["identity", "flows"],
+         "route": {"method": "GET", "path": "/x"}, "arguments": ["since", "limit", "status"]}]))

--- a/core/meetings/services/mcp/tests/test_bind.py
+++ b/core/meetings/services/mcp/tests/test_bind.py
@@ -1,0 +1,111 @@
+"""BINDING — a manifest's promise checked against the service that has to keep it.
+
+A manifest binds a NAME to a ROUTE. It carries no JSON schema and no description of its own: both
+are DERIVED from the bound route's OpenAPI operation, which is the mechanism this service already
+runs on for its own fourteen tools (`operation_id` on a FastAPI route, read by `FastApiMCP`). One
+place to write a tool's shape means the tool and the route it forwards to cannot disagree.
+
+So the manifest is a claim about another service, and this is where the claim is checked. A route
+the domain does not serve, or an argument the operation does not take, FAILS THE BOOT — a manifest
+lying about its own service is the one failure this design could otherwise hide, and it would
+surface as a tool that exists in the list and 404s when an agent calls it.
+"""
+from __future__ import annotations
+
+import pytest
+
+from vexa_mcp import bind
+from vexa_mcp import manifest as m
+
+FLOWS_OPENAPI = {
+    "paths": {
+        "/flows": {"get": {"operationId": "list_flows", "summary": "Every flow version",
+                           "parameters": []}},
+        "/reactions": {"get": {"summary": "The operator projection", "parameters": [
+            {"name": "status", "in": "query", "schema": {"type": "string"}},
+            {"name": "source_event_prefix", "in": "query", "schema": {"type": "string"}}]}},
+        "/reactions/{reaction_id}/{verb}": {"post": {"summary": "Steer one reaction",
+                                                     "parameters": []}},
+    }
+}
+
+
+def _assembly(tools):
+    doc = {"contract": "mcp.tools.v1", "domain": "flows", "source": "oss", "owner": "core/flows",
+           "base_url_env": "FLOWS_API_URL", "served_at": "/.well-known/mcp-tools.json",
+           "depends_on": ["identity"], "tools": tools}
+    return m.assemble([doc], deployed={"identity", "flows"})
+
+
+def test_a_bound_tool_takes_its_description_from_the_route():
+    a = _assembly([{"name": "flows_list", "identity": "operator",
+                    "requires": ["identity", "flows"],
+                    "route": {"method": "GET", "path": "/flows"}}])
+    bound = bind.verify(a, {"flows": FLOWS_OPENAPI})
+    assert bound[0].description == "Every flow version"
+    assert bound[0].name == "flows_list", "the MCP name is the manifest's, not the operationId's"
+
+
+def test_a_route_the_domain_does_not_serve_fails_the_boot():
+    """The manifest lying about its own service — the one failure this design could otherwise hide."""
+    a = _assembly([{"name": "x", "identity": "user", "requires": ["identity", "flows"],
+                    "route": {"method": "GET", "path": "/nope"}}])
+    with pytest.raises(m.ManifestError, match="does not serve"):
+        bind.verify(a, {"flows": FLOWS_OPENAPI})
+
+
+def test_the_wrong_method_on_a_real_path_fails_too():
+    a = _assembly([{"name": "x", "identity": "user", "requires": ["identity", "flows"],
+                    "route": {"method": "DELETE", "path": "/flows"}}])
+    with pytest.raises(m.ManifestError, match="does not serve"):
+        bind.verify(a, {"flows": FLOWS_OPENAPI})
+
+
+def test_an_argument_the_operation_does_not_take_fails_the_boot():
+    """An argument an agent can pass and the route ignores is the worst reply available: the agent
+    reports success on something that did not happen."""
+    a = _assembly([{"name": "reactions_list", "identity": "operator",
+                    "requires": ["identity", "flows"],
+                    "route": {"method": "GET", "path": "/reactions"},
+                    "arguments": ["status", "invented"]}])
+    with pytest.raises(m.ManifestError, match="invented"):
+        bind.verify(a, {"flows": FLOWS_OPENAPI})
+
+
+def test_declared_arguments_carry_their_schema_from_the_operation():
+    a = _assembly([{"name": "reactions_list", "identity": "operator",
+                    "requires": ["identity", "flows"],
+                    "route": {"method": "GET", "path": "/reactions"},
+                    "arguments": ["status", "source_event_prefix"]}])
+    bound = bind.verify(a, {"flows": FLOWS_OPENAPI})
+    assert bound[0].parameters == {"status": {"type": "string"},
+                                   "source_event_prefix": {"type": "string"}}
+
+
+def test_a_path_parameter_is_an_argument_without_being_declared():
+    """`/reactions/{reaction_id}/{verb}` cannot be called without them, so they are arguments
+    whether or not the manifest lists them — and a manifest that had to restate them would be a
+    second place to write the route."""
+    a = _assembly([{"name": "reaction_signal", "identity": "user",
+                    "requires": ["identity", "flows"],
+                    "route": {"method": "POST", "path": "/reactions/{reaction_id}/{verb}"}}])
+    bound = bind.verify(a, {"flows": FLOWS_OPENAPI})
+    assert set(bound[0].path_params) == {"reaction_id", "verb"}
+
+
+def test_an_edge_owned_tool_needs_no_openapi():
+    doc = {"contract": "mcp.tools.v1", "domain": "gateway", "source": "oss",
+           "owner": "core/gateway/services/mcp", "base_url_env": None, "served_at": None,
+           "depends_on": ["identity"],
+           "tools": [{"name": "vexa_overview", "identity": "none", "requires": ["identity"],
+                      "route": None}]}
+    a = m.assemble([doc], deployed={"identity"})
+    assert bind.verify(a, {}) == []
+
+
+def test_a_domain_with_no_openapi_at_all_fails_rather_than_binding_blind():
+    a = _assembly([{"name": "flows_list", "identity": "operator",
+                    "requires": ["identity", "flows"],
+                    "route": {"method": "GET", "path": "/flows"}}])
+    with pytest.raises(m.ManifestError, match="OpenAPI"):
+        bind.verify(a, {})

--- a/core/meetings/services/mcp/tests/test_discover.py
+++ b/core/meetings/services/mcp/tests/test_discover.py
@@ -1,0 +1,109 @@
+"""DISCOVERY — what a deployment carries, asked rather than assumed.
+
+Eight configurations, not two: identity plus any subset of meetings, flows and agent. Which ones
+exist is read off the base URLs the deployment sets, because a profile NAME would be a second place
+to say what the URLs already say — and the configuration nobody named is the one that breaks.
+
+No network: the domains are answered by an httpx MockTransport, which is this service's own idiom
+for driving the shipped forwarding path offline.
+"""
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+
+from vexa_mcp import discover as d
+from vexa_mcp import manifest as m
+
+FLOWS_MANIFEST = {
+    "contract": "mcp.tools.v1", "domain": "flows", "source": "oss", "owner": "core/flows",
+    "base_url_env": "FLOWS_API_URL", "served_at": "/.well-known/mcp-tools.json",
+    "depends_on": ["identity"],
+    "tools": [{"name": "flows_list", "identity": "operator", "requires": ["identity", "flows"],
+               "route": {"method": "GET", "path": "/flows"}}],
+}
+FLOWS_OPENAPI = {"paths": {"/flows": {"get": {"summary": "Every flow version", "parameters": []}}}}
+
+
+def _transport(answers):
+    def handler(request: httpx.Request) -> httpx.Response:
+        body = answers.get(str(request.url))
+        if body is None:
+            return httpx.Response(404, json={"detail": "not here"})
+        return httpx.Response(200, json=body)
+    return httpx.MockTransport(handler)
+
+
+def _answers(**extra):
+    a = {"http://flows/.well-known/mcp-tools.json": FLOWS_MANIFEST,
+         "http://flows/openapi.json": FLOWS_OPENAPI}
+    a.update(extra)
+    return a
+
+
+
+def test_only_the_domains_the_deployment_names_are_asked():
+    asked = []
+
+    def handler(request):
+        asked.append(str(request.url))
+        return httpx.Response(404)
+
+    with httpx.Client(transport=httpx.MockTransport(handler)) as c:
+        d.discover(c, env={"ADMIN_API_URL": "http://identity"})
+    assert all("identity" in u for u in asked), f"asked a domain nobody deployed: {asked}"
+
+
+
+def test_a_deployed_domain_s_tools_are_assembled():
+    with httpx.Client(transport=_transport(_answers())) as c:
+        assembly, openapi, bases = d.discover(
+            c, env={"ADMIN_API_URL": "http://identity", "FLOWS_API_URL": "http://flows"})
+    assert [t.name for t in assembly.tools] == ["flows_list"]
+    assert set(openapi) == {"flows"} and bases["flows"] == "http://flows"
+
+
+
+def test_a_domain_with_no_manifest_yet_contributes_nothing_and_does_not_fail():
+    """Not every domain has published one. That is a smaller surface, not a broken deployment."""
+    with httpx.Client(transport=_transport(_answers())) as c:
+        assembly, _o, _b = d.discover(
+            c, env={"ADMIN_API_URL": "http://identity", "FLOWS_API_URL": "http://flows",
+                    "MEETING_API_URL": "http://meetings"})
+    assert [t.name for t in assembly.tools] == ["flows_list"]
+
+
+
+def test_a_manifest_whose_openapi_does_not_answer_fails_the_boot():
+    """Publishing a manifest is a promise about routes. Binding it blind would turn that promise
+    into a tool that 404s the first time an agent calls it."""
+    answers = _answers()
+    answers.pop("http://flows/openapi.json")
+    with httpx.Client(transport=_transport(answers)) as c:
+        with pytest.raises(m.ManifestError, match="OpenAPI"):
+            d.discover(c, env={"ADMIN_API_URL": "http://identity",
+                                     "FLOWS_API_URL": "http://flows"})
+
+
+
+def test_a_mounted_domain_with_no_url_fails_rather_than_listing_a_tool_it_cannot_reach(tmp_path):
+    (tmp_path / "billing.mcp.tools.v1.json").write_text(json.dumps({
+        "contract": "mcp.tools.v1", "domain": "billing", "source": "oss", "owner": "private",
+        "base_url_env": "BILLING_API_URL", "served_at": "/.well-known/mcp-tools.json",
+        "depends_on": ["identity"], "tools": []}))
+    with httpx.Client(transport=_transport(_answers())) as c:
+        with pytest.raises(m.ManifestError, match="BILLING_API_URL"):
+            d.discover(c, env={"ADMIN_API_URL": "http://identity",
+                                     "VEXA_MCP_MANIFEST_DIR": str(tmp_path)})
+
+
+
+def test_an_empty_mount_is_the_oss_product_exactly(tmp_path):
+    with httpx.Client(transport=_transport(_answers())) as c:
+        assembly, _o, _b = d.discover(
+            c, env={"ADMIN_API_URL": "http://identity", "FLOWS_API_URL": "http://flows",
+                    "VEXA_MCP_MANIFEST_DIR": str(tmp_path)})
+    assert [t.name for t in assembly.tools] == ["flows_list"]
+    assert assembly.entitlement is None

--- a/core/meetings/services/mcp/tests/test_identity_vocabulary.py
+++ b/core/meetings/services/mcp/tests/test_identity_vocabulary.py
@@ -1,0 +1,163 @@
+"""THE GATE — one name per concept, asserted against the surface the server actually emits.
+
+This file exists because the same defect shipped TWICE IN ONE DAY, by the same author, with the
+rule written down in between:
+
+  * morning — three tools ACCEPTED ``meeting_platform`` + ``meeting_id`` while every tool RETURNED
+    ``platform`` + ``native_meeting_id``, so no tool's output composed into the next tool's input.
+    Found by a reader who had just read the README. Fixed, and the fix was documented.
+  * hours later — a NEW ``search_transcripts`` tool RETURNED ``meeting_id`` holding the integer row
+    id, colliding with the deprecated alias for the native string id. Feeding that tool's own
+    output into ``get_meeting_transcript`` gave ``404 … and ID 1``.
+
+The lesson is not "read the docs more carefully". A naming convention enforced only by prose and
+review is enforced by nobody, and this failure is SILENT: every field is individually plausible
+and only the join between two tools is wrong, so nothing fails until a caller chains them.
+
+So the vocabulary is data (``vexa_mcp.identity``) and this asserts it mechanically. It runs over
+the DERIVED surface — the schemas FastAPI/FastApiMCP actually produce and the payloads the tools
+actually return — not over source, because the bug is emergent from that derivation.
+
+``instructions`` promises callers: *"every tool returns `platform` + `native_meeting_id`, and every
+tool accepts those same two names. Feed one tool's output straight into the next."* These tests
+are what make that a checkable claim instead of a hope.
+"""
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from conftest import API_KEY
+from vexa_mcp import create_app
+from vexa_mcp.identity import (
+    CANONICAL_IDENTITY,
+    DEPRECATED_ALIASES,
+    check_output_names,
+    check_tool_inputs,
+)
+
+GATEWAY_URL = "http://gateway.test"
+
+
+def _tools(app):
+    """The MCP tool surface as a client receives it — derived, not declared."""
+    return [
+        {"name": name, "inputSchema": tool.inputSchema}
+        for name, tool in app.state.mcp.tools.items()
+    ] if isinstance(getattr(app.state.mcp, "tools", None), dict) else [
+        {"name": t.name, "inputSchema": t.inputSchema} for t in app.state.mcp.tools
+    ]
+
+
+@pytest.fixture
+def app():
+    return create_app(GATEWAY_URL, transport=httpx.MockTransport(
+        lambda r: httpx.Response(200, json={})))
+
+
+# ---- rule 1: a deprecated alias may appear only on INPUT, only beside its canonical name ----
+
+def test_no_tool_accepts_a_retired_name_without_its_replacement(app):
+    violations = check_tool_inputs(_tools(app))
+    assert not violations, (
+        "The identity vocabulary is broken on the tool INPUT surface:\n  - "
+        + "\n  - ".join(violations)
+        + "\n\nEvery tool that names a meeting must accept `platform` + `native_meeting_id` — the "
+          "exact field names the tools RETURN. A retired name may ride along as a deprecated alias, "
+          "but never alone and never unmarked."
+    )
+
+
+def test_the_canonical_names_are_actually_used_somewhere(app):
+    """Guards the guard: a vocabulary nothing uses would let every check above pass vacuously."""
+    names = {p for t in _tools(app) for p in (t["inputSchema"].get("properties") or {})}
+    assert {"platform", "native_meeting_id"} <= names
+
+
+# ---- rule 2: a deprecated alias may NEVER be emitted -----------------------------------
+
+def _payloads_from_gateway(monkeypatch_payload):
+    """Drive every read tool against a fake gateway returning a realistic identity-bearing body."""
+    return httpx.MockTransport(lambda r: httpx.Response(200, json=monkeypatch_payload))
+
+
+@pytest.mark.parametrize("payload,label", [
+    ({"meeting_id": 1, "platform": "google_meet"}, "integer meeting_id at the top level"),
+    ({"hits": [{"meeting_id": 7, "native_meeting_id": "abc-defg-hij"}]}, "meeting_id nested in a list"),
+    ({"meetings": [{"meeting_platform": "zoom"}]}, "meeting_platform nested in a list"),
+])
+def test_the_output_check_catches_a_retired_name(payload, label):
+    """The regression this file exists for, in miniature: these SHOULD be reported."""
+    violations = check_output_names("some_tool", payload)
+    assert violations, f"a retired name went unreported: {label}"
+
+
+@pytest.mark.parametrize("payload,label", [
+    ({"native_meeting_id": 7}, "native_meeting_id carrying an int"),
+    ({"meeting_db_id": "abc-defg-hij"}, "meeting_db_id carrying a string"),
+])
+def test_the_output_check_catches_a_canonical_name_with_the_wrong_kind_of_value(payload, label):
+    """The subtler half: a correctly-SPELLED name holding the wrong kind of value is exactly what
+    shipped — a name-only check would have passed it."""
+    assert check_output_names("some_tool", payload), f"type confusion went unreported: {label}"
+
+
+def test_a_clean_payload_reports_nothing():
+    clean = {"meetings": [{"platform": "google_meet", "native_meeting_id": "abc-defg-hij",
+                           "meeting_db_id": 1, "title": "Acme renewal"}]}
+    assert check_output_names("some_tool", clean) == []
+
+
+def test_live_tool_outputs_carry_no_retired_names(app):
+    """The real gate: drive the tools and inspect what they actually hand back.
+
+    The MCP service forwards gateway bodies verbatim, so this catches a retired name introduced
+    EITHER here or upstream in meeting-api — which is where the search regression actually lived.
+    """
+    from fastapi.testclient import TestClient
+
+    # A gateway body shaped like the real one, using only canonical names. If a tool renames or
+    # re-wraps a field on the way out, the check sees it.
+    body = {
+        "meetings": [{"platform": "google_meet", "native_meeting_id": "abc-defg-hij", "id": 1}],
+        "hits": [{"platform": "google_meet", "native_meeting_id": "abc-defg-hij",
+                  "meeting_db_id": 1, "speaker": "A", "snippet": "x"}],
+    }
+    client = TestClient(create_app(
+        GATEWAY_URL, transport=httpx.MockTransport(lambda r: httpx.Response(200, json=body))))
+    auth = {"Authorization": f"Bearer {API_KEY}"}
+
+    checked = 0
+    for path, params in [
+        ("/meetings", {}),
+        ("/transcript-search", {"q": "panel"}),
+        ("/meeting-transcript", {"native_meeting_id": "abc-defg-hij"}),
+        ("/bot-status", {}),
+        ("/recordings", {}),
+        ("/meeting-chat", {"native_meeting_id": "abc-defg-hij"}),
+    ]:
+        r = client.get(path, params=params, headers=auth)
+        if r.status_code != 200:
+            continue
+        checked += 1
+        violations = check_output_names(path, r.json())
+        assert not violations, (
+            "A tool EMITS a retired identity name — this is the defect that shipped twice:\n  - "
+            + "\n  - ".join(violations)
+            + "\n\nOutputs are what the next call is built from. An ambiguous output name is what "
+              "turns 'feed one tool's output into the next' into a 404."
+        )
+    assert checked >= 5, "too few tools exercised for this gate to mean anything"
+
+
+# ---- the vocabulary itself stays coherent ----------------------------------------------
+
+def test_no_alias_shadows_a_canonical_name():
+    assert not (set(DEPRECATED_ALIASES) & set(CANONICAL_IDENTITY)), (
+        "a retired name must not also be canonical — that is the ambiguity, not the fix"
+    )
+
+
+def test_every_alias_points_at_a_real_canonical_name():
+    for alias, canonical in DEPRECATED_ALIASES.items():
+        assert canonical in CANONICAL_IDENTITY, f"`{alias}` redirects to unknown `{canonical}`"

--- a/core/meetings/services/mcp/tests/test_manifest_files.py
+++ b/core/meetings/services/mcp/tests/test_manifest_files.py
@@ -1,0 +1,63 @@
+"""THE MANIFESTS IN THIS REPO ARE VALID, AND THEY ARE WHAT THE DOMAINS SERVE.
+
+Each domain commits its manifest in its own directory and serves that same file at
+`/.well-known/mcp-tools.json`. This test reads them off disk and puts them through the assembler,
+so a manifest that could not boot the edge fails here instead — in the suite of the service that
+would have refused to start.
+"""
+from __future__ import annotations
+
+import json
+import pathlib
+
+import pytest
+
+from vexa_mcp import bind
+from vexa_mcp import manifest as m
+
+REPO = pathlib.Path(__file__).resolve().parents[5]
+MANIFESTS = sorted(REPO.glob("core/*/mcp.tools.v1.json")) + \
+            sorted(REPO.glob("core/*/services/*/mcp.tools.v1.json"))
+
+
+def _load():
+    return [json.loads(p.read_text()) for p in MANIFESTS]
+
+
+def test_there_is_at_least_one_manifest_and_every_one_of_them_validates():
+    docs = _load()
+    assert docs, "no domain has published a manifest yet"
+    for doc, path in zip(docs, MANIFESTS):
+        try:
+            m.validate(doc)
+        except m.ManifestError as e:
+            pytest.fail(f"{path.relative_to(REPO)}: {e}")
+
+
+def test_one_domain_per_manifest_and_no_name_claimed_twice():
+    docs = _load()
+    domains = [d["domain"] for d in docs]
+    assert len(domains) == len(set(domains)), f"two manifests for one domain: {domains}"
+    deployed = {"identity"} | set(domains)
+    a = m.assemble(docs, deployed=deployed)          # raises on a duplicate name
+    assert a.tools, "the union is empty"
+
+
+def test_the_full_deployment_and_the_smallest_one_both_assemble():
+    """Eight configurations, not two. Identity alone must still produce a coherent surface, and a
+    tool whose domain is absent is ABSENT — never present-and-failing."""
+    docs = _load()
+    everything = m.assemble(docs, deployed={"identity", "meetings", "flows", "agent"})
+    identity_only = m.assemble(docs, deployed={"identity"})
+    assert len(identity_only.tools) <= len(everything.tools)
+    for t in identity_only.tools:
+        assert t.requires <= {"identity"}
+
+
+def test_no_manifest_declares_a_credential_argument():
+    """PRD 40.8 — one authentication path: a bearer header, session-bound. `validate` enforces it;
+    this states it as its own fact so the reason survives a refactor of the validator."""
+    for doc, path in zip(_load(), MANIFESTS):
+        for t in doc.get("tools") or []:
+            for arg in t.get("arguments") or []:
+                assert arg.lower() not in m.CREDENTIAL_ARGUMENTS, f"{path}: {t['name']} takes {arg}"

--- a/core/meetings/services/mcp/tests/test_mcp_surface.py
+++ b/core/meetings/services/mcp/tests/test_mcp_surface.py
@@ -1,4 +1,4 @@
-"""L1 — the MCP surface: the /mcp mount exists, exactly the 10 tools are exposed,
+"""L1 — the MCP surface: the /mcp mount exists, exactly the 14 tools are exposed,
 and the 4 prompts render."""
 import httpx
 import pytest
@@ -17,6 +17,10 @@ EXPECTED_TOOLS = {
     "list_recordings",
     "get_recording",
     "report_issue",
+    "annotate_meeting",
+    "speak_in_meeting",
+    "get_meeting_chat",
+    "search_transcripts",
 }
 
 
@@ -66,3 +70,36 @@ def test_prompts_only_reference_ported_tools():
 def test_unknown_prompt_raises():
     with pytest.raises(ValueError):
         get_prompt_result("vexa.nope")
+
+
+# --- orientation at connect time ---------------------------------------------
+# A client that connects should not have to infer what Vexa is from nine tool descriptions.
+# `instructions` is the MCP field for that, and it shipped empty.
+
+def test_server_ships_instructions():
+    app = create_app("http://gateway.test", transport=httpx.MockTransport(lambda r: httpx.Response(200, json={})))
+    instructions = app.state.mcp.server.instructions
+    assert instructions, "MCP server must ship `instructions` — a connecting client gets no map without it"
+    # The canonical flow and the identity vocabulary are the two things it exists to say.
+    for expected in ("parse_meeting_link", "request_meeting_bot", "get_meeting_transcript", "native_meeting_id"):
+        assert expected in instructions
+
+
+# --- a tool must refuse an argument it does not declare ----------------------
+# Without additionalProperties, fastapi-mcp DROPS an unknown argument before the HTTP call, so a
+# server-side guard never sees it and the tool answers 200 as if it had been honoured. Verified
+# live: `get_meeting_transcript(limit=2)` returned a transcript with `limit` silently ignored.
+
+def test_every_tool_schema_is_closed():
+    app = create_app("http://gateway.test",
+                     transport=httpx.MockTransport(lambda r: httpx.Response(200, json={})))
+    open_schemas = [
+        t.name for t in app.state.mcp.tools
+        if isinstance(getattr(t, "inputSchema", None), dict)
+        and t.inputSchema.get("type") == "object"
+        and t.inputSchema.get("additionalProperties") is not False
+    ]
+    assert not open_schemas, (
+        "these tools accept undeclared arguments and will silently drop them: "
+        f"{open_schemas}"
+    )

--- a/core/meetings/services/mcp/tests/test_register.py
+++ b/core/meetings/services/mcp/tests/test_register.py
@@ -1,0 +1,122 @@
+"""REGISTRATION — an assembled tool becomes a tool an agent can actually call.
+
+A bound tool is turned into one FastAPI route on this service, carrying `operation_id=<tool name>`,
+which is exactly how this service's own fourteen tools become MCP tools (`FastApiMCP` reads the
+OpenAPI it generates). One mechanism for both, so an assembled tool and a built-in one are
+indistinguishable to a client — which is the point of assembling rather than proxying.
+
+The forward carries THE CALLER'S IDENTITY and nothing else: the bearer the edge already resolved,
+travelling as `X-API-Key`, exactly as the fourteen do. There is no second credential and no way to
+pass one as an argument (PRD 40.8).
+"""
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from vexa_mcp import bind, register
+from vexa_mcp import manifest as m
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+FLOWS_OPENAPI = {"paths": {
+    "/flows": {"get": {"summary": "Every flow version", "parameters": []}},
+    "/reactions": {"get": {"summary": "The operator projection", "parameters": [
+        {"name": "status", "in": "query", "schema": {"type": "string"}}]}},
+    "/reactions/{reaction_id}/{verb}": {"post": {"summary": "Steer one reaction", "parameters": []}},
+}}
+MANIFEST = {
+    "contract": "mcp.tools.v1", "domain": "flows", "source": "oss", "owner": "core/flows",
+    "base_url_env": "FLOWS_API_URL", "served_at": "/.well-known/mcp-tools.json",
+    "depends_on": ["identity"],
+    "tools": [
+        {"name": "flows_list", "identity": "operator", "requires": ["identity", "flows"],
+         "route": {"method": "GET", "path": "/flows"}},
+        {"name": "reactions_list", "identity": "operator", "requires": ["identity", "flows"],
+         "route": {"method": "GET", "path": "/reactions"}, "arguments": ["status"]},
+        {"name": "reaction_signal", "identity": "user", "requires": ["identity", "flows"],
+         "route": {"method": "POST", "path": "/reactions/{reaction_id}/{verb}"}},
+    ],
+}
+
+
+@pytest.fixture()
+def wired():
+    seen = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request)
+        return httpx.Response(200, json={"ok": str(request.url)})
+
+    app = FastAPI()
+    assembly = m.assemble([MANIFEST], deployed={"identity", "flows"})
+    bound = bind.verify(assembly, {"flows": FLOWS_OPENAPI})
+    register.register(app, bound, {"flows": "http://flows"},
+                      transport=httpx.MockTransport(handler))
+    return app, seen
+
+
+def test_every_assembled_tool_gets_a_route_named_after_it(wired):
+    app, _seen = wired
+    ids = {getattr(r, "operation_id", None) for r in app.routes}
+    assert {"flows_list", "reactions_list", "reaction_signal"} <= ids
+
+
+def test_calling_the_tool_forwards_to_the_owning_domain(wired):
+    app, seen = wired
+    r = TestClient(app).get("/tools/flows_list", headers={"X-API-Key": "k"})
+    assert r.status_code == 200, r.text
+    assert str(seen[-1].url) == "http://flows/flows"
+
+
+def test_the_caller_s_identity_travels_and_no_other_credential_does(wired):
+    """PRD 40.8: one authentication path. The bearer the edge resolved goes on, and nothing else."""
+    app, seen = wired
+    TestClient(app).get("/tools/flows_list", headers={"X-API-Key": "the-caller-key"})
+    fwd = seen[-1]
+    assert fwd.headers.get("x-api-key") == "the-caller-key"
+    assert "token" not in str(fwd.url).lower()
+
+
+def test_a_declared_argument_travels_as_a_query_parameter(wired):
+    app, seen = wired
+    TestClient(app).get("/tools/reactions_list?status=blocked", headers={"X-API-Key": "k"})
+    assert "status=blocked" in str(seen[-1].url)
+
+
+def test_an_undeclared_argument_is_not_forwarded(wired):
+    """An argument the route ignores is a success the agent reports for something that did not
+    happen — so it never leaves this process."""
+    app, seen = wired
+    TestClient(app).get("/tools/reactions_list?status=blocked&invented=1",
+                        headers={"X-API-Key": "k"})
+    assert "invented" not in str(seen[-1].url)
+
+
+def test_path_parameters_are_substituted(wired):
+    app, seen = wired
+    r = TestClient(app).post("/tools/reaction_signal", json={"reaction_id": "r1", "verb": "retry"},
+                             headers={"X-API-Key": "k"})
+    assert r.status_code == 200, r.text
+    assert str(seen[-1].url) == "http://flows/reactions/r1/retry"
+
+
+def test_a_missing_credential_is_refused_before_the_forward(wired):
+    app, seen = wired
+    before = len(seen)
+    r = TestClient(app).get("/tools/flows_list")
+    assert r.status_code == 401
+    assert len(seen) == before, "nothing was forwarded"
+
+
+def test_the_domain_s_own_error_reaches_the_caller_unchanged():
+    """A 403 from flows is flows' answer, and an agent needs to see it. Rewriting it as a 500 would
+    turn "you may not do that" into "we are broken"."""
+    app = FastAPI()
+    assembly = m.assemble([MANIFEST], deployed={"identity", "flows"})
+    bound = bind.verify(assembly, {"flows": FLOWS_OPENAPI})
+    register.register(app, bound, {"flows": "http://flows"},
+                      transport=httpx.MockTransport(
+                          lambda r: httpx.Response(403, json={"detail": "operator only"})))
+    r = TestClient(app).get("/tools/flows_list", headers={"X-API-Key": "k"})
+    assert r.status_code == 403 and "operator only" in r.text

--- a/core/meetings/services/meeting-api/src/meeting_api/__main__.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/__main__.py
@@ -9,7 +9,7 @@ control-plane background loops alongside the HTTP app via the FastAPI lifespan:
   * **db-writer** — the RESTORED parent flush loop (0.10 ``process_redis_to_postgres``): each tick
     moves immutable live segments from the redis hash ``meeting:{id}:segments`` into the
     ``transcriptions`` table (upsert on segment identity; redis trimmed only after the confirmed
-    write) and drains the copilot's ``proc:meeting:{id}`` notes into ``meeting.data`` JSONB.
+    write).
   * **webhook retry-drain** — one ``drain_retry_queue`` sweep per interval over the redis retry
     queue (failed ``meeting.status_change`` deliveries are retried with backoff).
 
@@ -383,7 +383,7 @@ def _attach_background_loops(
     async def _db_writer_loop() -> None:
         # The RESTORED parent db-writer (0.10 process_redis_to_postgres): each tick, flush every
         # active meeting's IMMUTABLE redis-hash segments into the transcriptions table (upsert on
-        # (meeting_id, segment_id)) and drain its processed-notes stream into meeting.data JSONB.
+        # (meeting_id, segment_id)).
         # Redis is trimmed only AFTER the confirmed durable write. Without this loop nothing ever
         # moved segments to Postgres — the transcriptions table stayed EMPTY and a redis eviction
         # was unrecoverable transcript loss (the 0.12 release blocker).

--- a/core/meetings/services/meeting-api/src/meeting_api/app.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/app.py
@@ -253,13 +253,21 @@ def create_app(
     )
 
     # --- bot_spawn: POST /bots (invocation.v1 + runtime.v1) ---
-    app.include_router(
-        _bot_spawn.build_router(
-            meeting_repo,
-            runtime,
-            service_authority,
-        )
-    )
+    # A fresh meeting must start on an EMPTY transcript stream. Wire a redis-backed purge (None offline)
+    # so bot_spawn can clear tc:meeting:{new_row_id} on a FRESH insert — a reused row id (e.g. after a DB
+    # id-sequence reset without a redis flush) would otherwise carry a prior generation's stale
+    # session_end and the terminal would show "Meeting ended" before the first word. continue_meeting is
+    # untouched (it keeps the reused row's stream). See bot_spawn.service.request_bot.
+    _stream_purge = None
+    if redis is not None and hasattr(redis, "delete"):
+        async def _stream_purge(meeting_id, _r=redis):
+            await _r.delete(f"tc:meeting:{meeting_id}")
+    app.include_router(_bot_spawn.build_router(
+        meeting_repo,
+        runtime,
+        service_authority,
+        transcript_stream_purge=_stream_purge,
+    ))
 
     # --- user-stop: DELETE /bots/{platform}/{native_meeting_id} (lifecycle/stop.py over redis) ---
     from .lifecycle.stop_router import InMemoryCommandPublisher, build_stop_router
@@ -854,6 +862,32 @@ def _mount_lifecycle(
                     )
                 except Exception as e:  # noqa: BLE001 — the worker's idle timeout is the backstop
                     log_event("meeting_copilot_reap_failed", audience="system", level="warning",
+                              span="lifecycle.callback",
+                              fields={"meeting_row_id": meeting_row_id, "error": str(e)})
+        # NEW-SESSION MARKER (mirror of the reap above): when a meeting goes ACTIVE, write a
+        # `session_start` marker onto the same ROW-scoped stream. tc:meeting:{row_id} is SHARED across a
+        # meeting's sessions — a re-sent bot REUSES a terminal row — so a prior session's `session_end`
+        # lingers in the terminal SSE's replay tail and shows "Meeting ended" over the new live meeting.
+        # This marker lets the SSE reset that stale end (agent api.py's seed treats any non-session_end
+        # entry as "still live"), so even a SILENT new session clears the banner. Best-effort.
+        if (
+            redis is not None
+            and not change.no_op
+            and rec.status is not None
+            and rec.status.value == "active"
+            and isinstance(meeting_row, dict)
+            and hasattr(redis, "xadd")
+        ):
+            meeting_row_id = meeting_row.get("id")
+            native = meeting_row.get("native_meeting_id") or rec.connection_id
+            if meeting_row_id is not None:
+                try:
+                    await redis.xadd(
+                        f"tc:meeting:{meeting_row_id}",
+                        {"type": "session_start", "uid": str(native or meeting_row_id)},
+                    )
+                except Exception as e:  # noqa: BLE001 — best-effort; the seed also resets on new segments
+                    log_event("meeting_session_start_marker_failed", audience="system", level="warning",
                               span="lifecycle.callback",
                               fields={"meeting_row_id": meeting_row_id, "error": str(e)})
         log_event(

--- a/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/router.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/router.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 
 import ipaddress
 import os
-from typing import Optional
+from typing import Awaitable, Callable, Optional
 from urllib.parse import parse_qs, urlparse
 
 from fastapi import APIRouter, Header, HTTPException, Request
@@ -250,8 +250,13 @@ def build_router(
     repo: MeetingRepo,
     runtime: RuntimeClient,
     authority=None,
+    *,
+    transcript_stream_purge: "Optional[Callable[[int], Awaitable[None]]]" = None,
 ) -> APIRouter:
-    """The bot-spawn routes over injected storage, runtime, and authority ports."""
+    """The bot-spawn routes over the injected ``MeetingRepo`` + ``RuntimeClient`` + authority ports.
+
+    ``transcript_stream_purge`` (redis-backed in prod, None offline) clears a fresh meeting's transcript
+    stream so it never inherits a reused row id's stale data — see ``request_bot``."""
     router = APIRouter()
 
     @router.post("/bots", status_code=201)
@@ -462,6 +467,7 @@ def build_router(
                 webhook_url=x_user_webhook_url,
                 webhook_secret=x_user_webhook_secret,
                 webhook_events=webhook_events,
+                transcript_stream_purge=transcript_stream_purge,
             )
         except TranscriptionNotConfigured as e:
             raise HTTPException(status_code=503, detail=str(e))

--- a/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/service.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/service.py
@@ -26,7 +26,7 @@ from __future__ import annotations
 import os
 import re
 import uuid
-from typing import Any, Optional
+from typing import Any, Awaitable, Callable, Optional
 from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
 
 from ..config_preflight import CONFIG_FAULT_KINDS, cached_probe_verdict
@@ -398,6 +398,11 @@ async def request_bot(
     webhook_url: Optional[str] = None,
     webhook_secret: Optional[str] = None,
     webhook_events: Optional[dict] = None,
+    # Fresh-meeting stream hygiene: purge tc:meeting:{new_row_id} on a FRESH insert so a new meeting
+    # never inherits a prior generation's transcript (a reused row id after a DB reset would otherwise
+    # carry a stale session_end → "Meeting ended" before the first word). Injected (redis-backed in
+    # prod, None in tests/offline). NOT called on continue_meeting — that reuse KEEPS the stream.
+    transcript_stream_purge: "Optional[Callable[[int], Awaitable[None]]]" = None,
 ) -> dict:
     """Run the spawn flow and return a MeetingResponse-shaped dict.
 
@@ -684,6 +689,23 @@ async def request_bot(
             )
             raise
     meeting_id = row["id"]
+
+    # 3b. Fresh-meeting stream hygiene (see the param doc): a brand-new row must start on an EMPTY
+    # transcript stream. Row ids are monotonic, so tc:meeting:{id} normally doesn't exist yet — but if
+    # the DB id sequence is ever reset/restored without flushing redis, a NEW meeting can be minted on a
+    # row id whose OLD stream still holds a prior generation's session_end, and the terminal shows
+    # "Meeting ended" before the first word. Purge on the FRESH insert only (reused_row is None);
+    # continue_meeting KEEPS the reused row's stream for continuity. Best-effort — a purge failure must
+    # never block the spawn (the collector is the stream's writer and appends after this).
+    if reused_row is None and transcript_stream_purge is not None:
+        try:
+            await transcript_stream_purge(meeting_id)
+        except Exception as _e:  # noqa: BLE001 — best-effort; never fail the spawn on a purge error
+            log_event(
+                "bot_spawn_stream_purge_failed", audience="system", level="warning",
+                span="bots.create", user_id=user_id,
+                fields={"meeting_id": meeting_id, "error": str(_e)},
+            )
 
     # 4. MeetingToken + invocation. connection_id IS the session_uid (parent's connectionId).
     redis_url = redis_url or os.getenv("REDIS_URL", "redis://redis:6379/0")

--- a/core/meetings/services/meeting-api/src/meeting_api/collector/adapters.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/collector/adapters.py
@@ -59,6 +59,24 @@ def _now() -> datetime:
     return datetime.now(timezone.utc)
 
 
+def _build_share_grant(mode: str, allowed_emails, expires_in_sec: int) -> "tuple[dict, str]":
+    """The share-grant record and its one-time secret. ONE definition, because there are now two
+    ways to address the meeting it is minted on — the (platform, native) pair and the ROW id — and
+    two copies of the hash-at-rest shape would be two places to get the hashing wrong."""
+    from datetime import timedelta
+
+    secret = secrets.token_urlsafe(24)
+    grant = {
+        "id": secrets.token_hex(8),
+        "secret_hash": _sha(secret),
+        "mode": mode,
+        "allowed_emails": list(allowed_emails or []),
+        "expires_at": (_now() + timedelta(seconds=int(expires_in_sec))).isoformat(),
+        "revoked": False,
+    }
+    return grant, secret
+
+
 def _iso_utc(dt) -> Optional[str]:
     """UTC ISO-8601 (``…Z``) for a naive-or-aware datetime. The meeting time columns are naive but
     hold UTC (the DB session is UTC); a bare ``isoformat()`` is zone-less, so a browser's ``new Date()``
@@ -121,70 +139,6 @@ def _remove_doc(docs: list[dict], path: str) -> list[dict]:
     return [d for d in docs if d.get("path") != path]
 
 
-def _merge_notes_by_id(existing: list[dict], incoming: list[dict]) -> list[dict]:
-    """Merge drained copilot notes into a processed view's ``doc['notes']`` list, keyed by note
-    ``id`` (== segment_id): a refining re-emit UPDATES its note in place (order preserved);
-    a new id appends. Notes without an id append as-is (nothing to key an upsert on)."""
-    out = [dict(n) for n in existing]
-    index = {str(n.get("id")): i for i, n in enumerate(out) if n.get("id") is not None}
-    for note in incoming:
-        nid = note.get("id")
-        if nid is not None and str(nid) in index:
-            out[index[str(nid)]].update(note)
-        else:
-            if nid is not None:
-                index[str(nid)] = len(out)
-            out.append(dict(note))
-    return out
-
-
-def _find_processed_view(data: dict, view_id: str) -> Optional[dict]:
-    """The view with ``view_id`` inside ``data['processed']['views']`` (None when absent)."""
-    processed = data.get("processed") if isinstance(data.get("processed"), dict) else {}
-    views = processed.get("views") if isinstance(processed.get("views"), list) else []
-    return next((v for v in views if isinstance(v, dict) and v.get("id") == view_id), None)
-
-
-def _upsert_processed_view(
-    data: dict, *, view_id: str, kind: str, notes: list[dict],
-    source_cursor: Optional[str], params: Optional[dict],
-) -> dict:
-    """Pure merge of drained copilot notes into the ADDRESSABLE, VERSIONED processed shape
-    (release DoD — multi-consumer, meeting-scoped today, mountable by N consumers later):
-
-        data.processed = {"views": [{id, kind, params, doc, source_cursor, updated_at}]}
-
-    Upserts the view keyed by ``id`` — other views (future per-workspace/other processings) are
-    preserved untouched; merges ``notes`` into the view's ``doc['notes']`` by note id; stamps
-    ``params`` (the processing metadata APPLIED — provider/model/pipeline, stamped by the
-    producing worker — reproducibility) only when the drain carried them, so an idle drain never
-    erases provenance; ``source_cursor`` records the stream position the view reflects.
-    Returns the new ``data`` dict (the caller persists it)."""
-    from datetime import datetime, timezone
-
-    out = dict(data)
-    processed = dict(out.get("processed")) if isinstance(out.get("processed"), dict) else {}
-    views = [dict(v) for v in processed.get("views", []) if isinstance(v, dict)] \
-        if isinstance(processed.get("views"), list) else []
-    view = next((v for v in views if v.get("id") == view_id), None)
-    if view is None:
-        view = {"id": view_id, "kind": kind, "params": {}, "doc": {"notes": []}}
-        views.append(view)
-    doc = dict(view.get("doc")) if isinstance(view.get("doc"), dict) else {}
-    existing_notes = doc.get("notes") if isinstance(doc.get("notes"), list) else []
-    doc["notes"] = _merge_notes_by_id(list(existing_notes), notes)
-    view["doc"] = doc
-    view["kind"] = kind
-    if params:
-        view["params"] = params
-    if source_cursor:
-        view["source_cursor"] = source_cursor
-    view["updated_at"] = datetime.now(timezone.utc).isoformat()
-    processed["views"] = views
-    out["processed"] = processed
-    return out
-
-
 # A relative in-meeting offset never approaches this; anything at/above is an absolute epoch.
 _EPOCH_THRESHOLD_S = 1_000_000_000  # ~2001-09-09
 
@@ -230,6 +184,58 @@ def _segment_to_api(seg: dict) -> dict:
         if seg.get(k) is not None:
             out[k] = seg[k]
     return out
+
+
+# The ONE definition of a durable transcript write. Two callers reach it — the db-writer's flush
+# of a live meeting's redis hash (``upsert_segments``) and the import route's
+# ``complete_transcript_import`` — and a second copy of this statement would be a second place to
+# get the segment identity wrong. Keyed on ``(meeting_id, segment_id)`` (the partial unique index
+# ``ix_transcription_meeting_segment``): a re-write lands as an UPDATE, never a duplicate row.
+_SEGMENT_UPSERT_SQL = """
+    INSERT INTO transcriptions (meeting_id, start_time, end_time, text, speaker, language, session_uid, segment_id, created_at)
+    VALUES (:mid, :start, :end, :text, :speaker, :lang, :uid, :segid, :created)
+    ON CONFLICT (meeting_id, segment_id) WHERE segment_id IS NOT NULL
+    DO UPDATE SET text = EXCLUDED.text, speaker = EXCLUDED.speaker,
+                  start_time = EXCLUDED.start_time, end_time = EXCLUDED.end_time,
+                  language = EXCLUDED.language, created_at = EXCLUDED.created_at
+"""
+
+
+def _segment_upsert_rows(meeting_id, segments) -> "list[dict]":
+    """Normalize a batch of segments into the bind-parameter rows ``_SEGMENT_UPSERT_SQL`` takes.
+    A segment with no ``segment_id`` is skipped (0.12 ingest guarantees one; a legacy stray is
+    skipped, not guessed) and an unparseable start/end likewise."""
+    from datetime import datetime as _dt
+
+    rows = []
+    for seg in segments:
+        sid = seg.get("segment_id")
+        if not sid:
+            continue
+        try:
+            start = float(seg.get("start", seg.get("start_time", 0.0)) or 0.0)
+            end = float(seg.get("end", seg.get("end_time", start)) or start)
+        except (TypeError, ValueError):
+            continue
+        if end < start:
+            start, end = end, start
+        rows.append({
+            "mid": int(meeting_id), "start": start, "end": end,
+            "text": seg.get("text") or "", "speaker": seg.get("speaker"),
+            "lang": seg.get("language"), "uid": seg.get("session_uid"),
+            "segid": str(sid), "created": _dt.utcnow(),
+        })
+    return rows
+
+
+async def _write_segment_rows(db, rows) -> None:
+    """Execute the upsert for every row on an ALREADY-OPEN session, committing nothing. The caller
+    owns the transaction — which is how the import writes the segments and completes the row in one."""
+    from sqlalchemy import text as sql_text  # lazy: not needed for the in-memory fakes
+
+    stmt = sql_text(_SEGMENT_UPSERT_SQL)
+    for row in rows:
+        await db.execute(stmt, row)
 
 
 class SqlAlchemyTranscriptStore:
@@ -447,8 +453,9 @@ class SqlAlchemyTranscriptStore:
         return await self._merge_live_segments(pg, viewer_is_owner=is_owner)
 
     async def list_meetings(self, user_id, *, status=None, platform=None, limit=None, offset=None,
-                            member_workspaces=None, list_view=False, meeting_id=None, slim=False):
-        from sqlalchemy import cast, func, select, text, union_all
+                            member_workspaces=None, list_view=False, meeting_id=None, slim=False,
+                            metadata_filter=None):
+        from sqlalchemy import cast, func, literal, select, text, union_all
         from sqlalchemy.dialects.postgresql import JSONB
 
         from .models import Meeting
@@ -517,6 +524,19 @@ class SqlAlchemyTranscriptStore:
                     s = s.where(Meeting.id == meeting_id)
                 if platform:
                     s = s.where(Meeting.platform == platform)
+                if metadata_filter:
+                    # JSONB containment on the whole `data` blob, nesting the caller's filter under
+                    # `metadata` — `data @> '{"metadata": {...}}'`. Written against `data` (not
+                    # `data->'metadata'`) deliberately: THAT is the shape `ix_meeting_data_gin`
+                    # indexes, so this stays an index scan instead of degrading to a seq scan the
+                    # moment an account has history. Filtering in SQL rather than in Python is also
+                    # the difference between "the meetings tagged acme-42" and "the tagged ones on
+                    # the page you happened to fetch" — the latter is a wrong answer, not a slow one.
+                    s = s.where(
+                        cast(Meeting.data, JSONB).op("@>")(
+                            cast(literal(json.dumps({"metadata": metadata_filter})), JSONB)
+                        )
+                    )
                 if fetch_bound is not None:
                     # ORDER BY inside a compound member is only meaningful (and only kept by
                     # the compiler) together with LIMIT; an unbounded branch returns its full
@@ -702,38 +722,69 @@ class SqlAlchemyTranscriptStore:
             await db.commit()
             return workspace_id
 
-    async def mint_transcript_share(self, user_id, platform, native_meeting_id, *,
-                                    mode="open", allowed_emails=None, expires_in_sec=86400) -> "Optional[dict]":
-        """OWNER-scoped: mint an INDEPENDENT transcript share grant (no workspace needed). Stored in
-        ``data.share_grants[]`` as {id, secret_hash, mode, allowed_emails, expires_at, revoked} — only the
-        HASH, never the token. Returns {id, token, ...} ONCE (token = ``<meeting_id>.<secret>`` so redeem
-        resolves the meeting). None if the caller owns no such meeting."""
-        from datetime import timedelta
-
-        from sqlalchemy import select
+    async def _mint_share_on(self, stmt, *, mode, allowed_emails, expires_in_sec) -> "Optional[dict]":
+        """Mint a grant onto whichever ONE row ``stmt`` selects. The two public mints differ only in
+        how they address the meeting; everything after the row is identical."""
         from sqlalchemy.orm.attributes import flag_modified
 
-        from .models import Meeting
-
         async with self._session_factory() as db:
-            stmt = (select(Meeting).where(
-                Meeting.user_id == user_id, Meeting.platform == platform,
-                Meeting.platform_specific_id == native_meeting_id,
-            ).order_by(Meeting.created_at.desc()).limit(1).with_for_update())
             meeting = (await db.execute(stmt)).scalars().first()
             if not meeting:
                 return None
-            secret = secrets.token_urlsafe(24)
-            gid = secrets.token_hex(8)
-            expires_at = (_now() + timedelta(seconds=int(expires_in_sec))).isoformat()
-            grant = {"id": gid, "secret_hash": _sha(secret), "mode": mode,
-                     "allowed_emails": list(allowed_emails or []), "expires_at": expires_at, "revoked": False}
+            grant, secret = _build_share_grant(mode, allowed_emails, expires_in_sec)
             data = dict(meeting.data) if isinstance(meeting.data, dict) else {}
             data["share_grants"] = list(data.get("share_grants", [])) + [grant]
             meeting.data = data
             flag_modified(meeting, "data")
             await db.commit()
-            return {"id": gid, "token": f"{meeting.id}.{secret}", "mode": mode, "expires_at": expires_at}
+            return {"id": grant["id"], "token": f"{meeting.id}.{secret}",
+                    "mode": mode, "expires_at": grant["expires_at"]}
+
+    async def mint_transcript_share(self, user_id, platform, native_meeting_id, *,
+                                    mode="open", allowed_emails=None, expires_in_sec=86400) -> "Optional[dict]":
+        """OWNER-scoped: mint an INDEPENDENT transcript share grant (no workspace needed). Stored in
+        ``data.share_grants[]`` as {id, secret_hash, mode, allowed_emails, expires_at, revoked} — only the
+        HASH, never the token. Returns {id, token, ...} ONCE (token = ``<meeting_id>.<secret>`` so redeem
+        resolves the meeting). None if the caller owns no such meeting.
+
+        Addressed by the (platform, native) PAIR, which is not a reliable identity: a row planned from
+        an invite whose url no platform matched carries ``platform='unknown'`` and an EMPTY
+        ``platform_specific_id``, so no pair addresses it at all (meeting 97, 2026-09-02 — every
+        attendee mail for it shipped with no token). Prefer ``mint_transcript_share_by_id``; this one
+        stays because 0.10 clients and the ``/transcripts/{platform}/{native}/share`` alias call it."""
+        from sqlalchemy import select
+
+        from .models import Meeting
+
+        return await self._mint_share_on(
+            select(Meeting).where(
+                Meeting.user_id == user_id, Meeting.platform == platform,
+                Meeting.platform_specific_id == native_meeting_id,
+            ).order_by(Meeting.created_at.desc()).limit(1).with_for_update(),
+            mode=mode, allowed_emails=allowed_emails, expires_in_sec=expires_in_sec)
+
+    async def mint_transcript_share_by_id(self, user_id, meeting_id, *,
+                                          mode="open", allowed_emails=None, expires_in_sec=86400) -> "Optional[dict]":
+        """OWNER-scoped mint addressed by the ROW's primary key — the identity that always exists.
+
+        Same grant, same hash-at-rest, same one-time token shape as the pair-keyed mint above; the
+        only difference is the WHERE. Scoped to ``user_id`` so a row the caller does not own is
+        indistinguishable from one that does not exist (404 either way) — minting a capability is an
+        owner act, and a share route that leaked existence would be worse than one that leaked
+        nothing. No ``order_by``: a primary key selects exactly one row or none."""
+        from sqlalchemy import select
+
+        from .models import Meeting
+
+        try:
+            mid = int(meeting_id)
+        except (TypeError, ValueError):
+            return None
+        return await self._mint_share_on(
+            select(Meeting).where(
+                Meeting.id == mid, Meeting.user_id == user_id,
+            ).limit(1).with_for_update(),
+            mode=mode, allowed_emails=allowed_emails, expires_in_sec=expires_in_sec)
 
     async def redeem_transcript_share(self, user_id, user_email, token) -> "Optional[dict]":
         """Redeem a transcript share token (any authenticated user) → grants THIS user subscribe access to
@@ -824,85 +875,104 @@ class SqlAlchemyTranscriptStore:
         ``ix_transcription_meeting_segment`` in the admin-api authoritative schema), exactly the
         parent db-writer's ON CONFLICT statement: idempotent, a re-flushed rewrite lands as an
         UPDATE, never a duplicate row."""
-        from datetime import datetime as _dt
-
-        from sqlalchemy import text as sql_text  # lazy: not needed for the in-memory fakes
-
-        rows = []
-        for seg in segments:
-            sid = seg.get("segment_id")
-            if not sid:
-                continue  # 0.12 ingest guarantees segment_id; a legacy stray is skipped, not guessed
-            try:
-                start = float(seg.get("start", seg.get("start_time", 0.0)) or 0.0)
-                end = float(seg.get("end", seg.get("end_time", start)) or start)
-            except (TypeError, ValueError):
-                continue
-            if end < start:
-                start, end = end, start
-            rows.append({
-                "mid": int(meeting_id), "start": start, "end": end,
-                "text": seg.get("text") or "", "speaker": seg.get("speaker"),
-                "lang": seg.get("language"), "uid": seg.get("session_uid"),
-                "segid": str(sid), "created": _dt.utcnow(),
-            })
+        rows = _segment_upsert_rows(meeting_id, segments)
         if not rows:
             return
         async with self._session_factory() as db:
-            for row in rows:
-                await db.execute(
-                    sql_text("""
-                        INSERT INTO transcriptions (meeting_id, start_time, end_time, text, speaker, language, session_uid, segment_id, created_at)
-                        VALUES (:mid, :start, :end, :text, :speaker, :lang, :uid, :segid, :created)
-                        ON CONFLICT (meeting_id, segment_id) WHERE segment_id IS NOT NULL
-                        DO UPDATE SET text = EXCLUDED.text, speaker = EXCLUDED.speaker,
-                                      start_time = EXCLUDED.start_time, end_time = EXCLUDED.end_time,
-                                      language = EXCLUDED.language, created_at = EXCLUDED.created_at
-                    """),
-                    row,
-                )
+            await _write_segment_rows(db, rows)
             await db.commit()
 
-    async def processed_view_cursor(self, meeting_id, view_id) -> Optional[str]:
-        """The ``source_cursor`` of the ``view_id`` view inside ``meeting.data['processed']['views']``
-        — the last ``proc:meeting:{id}`` stream entry already durable; the db-writer resumes after it."""
-        from sqlalchemy import select
+    async def complete_transcript_import(self, user_id, meeting_id, *, segments, started_at,
+                                        ended_at, source, session_uid) -> "Optional[dict]":
+        """Land an imported transcript on the caller's row and COMPLETE it — see
+        ``ports.complete_transcript_import`` for the contract.
 
-        from .models import Meeting
+        ONE transaction, under the same per-user advisory lock ``create_planned_meeting`` and
+        ``annotate_meeting`` take, so an import serializes against a concurrent spawn/calendar-sync
+        on the same user rather than racing it. Inside it: the row lock, the idempotency check, the
+        segment upsert, the status/window write. Either the meeting is completed WITH its words or
+        neither happened — a half-import (segments under a `scheduled` row) is exactly the shape
+        that made the founder's walk read "MEETING · UPCOMING" over a finished call.
 
-        async with self._session_factory() as db:
-            m = (await db.execute(select(Meeting).where(Meeting.id == int(meeting_id)))).scalars().first()
-            if not m or not isinstance(m.data, dict):
-                return None
-            view = _find_processed_view(m.data, view_id)
-            return view.get("source_cursor") if view else None
-
-    async def merge_processed_view(
-        self, meeting_id, *, view_id, kind, notes, source_cursor, params=None,
-    ) -> None:
-        """Persist drained copilot notes into the meeting row's ``data['processed']['views']``
-        JSONB (the documented meeting.data home — the same pattern recordings/notes/docs use; NO
-        schema change), in the ADDRESSABLE, VERSIONED multi-consumer shape (release DoD):
-        the view keyed ``view_id`` is upserted (other views preserved), its ``doc['notes']`` merged
-        by note id, ``params`` = the processing metadata APPLIED, ``source_cursor`` = the stream
-        position the view reflects. ONE ``SELECT … FOR UPDATE`` row lock."""
-        from sqlalchemy import select
+        ``start_time``/``end_time`` are written NAIVE UTC, matching the columns (an aware datetime is
+        an asyncpg DataError here — see ``bot_spawn.adapters.update_meeting_status``).
+        """
+        from sqlalchemy import bindparam, func, select, text
         from sqlalchemy.orm.attributes import flag_modified
 
-        from .models import Meeting
+        from .models import Meeting, Transcription
+        from .transcript_import import IN_FLIGHT_STATUSES
+
+        try:
+            mid = int(meeting_id)
+        except (TypeError, ValueError):
+            return None
 
         async with self._session_factory() as db:
-            stmt = select(Meeting).where(Meeting.id == int(meeting_id)).with_for_update()
-            meeting = (await db.execute(stmt)).scalars().first()
-            if not meeting:
-                return
-            data = dict(meeting.data) if isinstance(meeting.data, dict) else {}
-            meeting.data = _upsert_processed_view(
-                data, view_id=view_id, kind=kind, notes=notes,
-                source_cursor=source_cursor, params=params,
+            await db.execute(
+                text("SELECT pg_advisory_xact_lock(:uid)").bindparams(bindparam("uid", user_id))
             )
+            meeting = (await db.execute(
+                select(Meeting).where(Meeting.id == mid, Meeting.user_id == user_id)
+                .with_for_update()
+            )).scalars().first()
+            # Owner-scoped: a row that is not the caller's answers exactly like one that does not
+            # exist, so this route is no existence oracle — the rule the by-id share mint follows.
+            if meeting is None:
+                return None
+            data = dict(meeting.data) if isinstance(meeting.data, dict) else {}
+            prior = data.get("transcript_import")
+            if isinstance(prior, dict) and prior.get("session_uid") == session_uid:
+                # The SAME import, again. Nothing is written — not the segments, not the window.
+                # A second call is a no-op that reports what the first one did.
+                return {
+                    "meeting_id": mid, "imported": False, "status": meeting.status,
+                    "segments_imported": int(prior.get("segments") or 0),
+                    "start_time": _iso_utc(meeting.start_time),
+                    "end_time": _iso_utc(meeting.end_time),
+                    "session_uid": session_uid, "source": prior.get("source") or source,
+                    "imported_at": prior.get("imported_at"),
+                }
+            if meeting.status in IN_FLIGHT_STATUSES:
+                return {"error": "conflict", "status": meeting.status}
+
+            rows = _segment_upsert_rows(mid, segments)
+            await _write_segment_rows(db, rows)
+
+            meeting.status = "completed"
+            meeting.start_time = started_at.astimezone(timezone.utc).replace(tzinfo=None)
+            meeting.end_time = ended_at.astimezone(timezone.utc).replace(tzinfo=None)
+            # The provenance, not a completion_reason. `completion_reason` is a BOT fact — why a run
+            # ended — and no bot ran here; writing one would be the double claiming to be a
+            # recording. `transcript_import` says what actually happened, and any reader can tell an
+            # imported meeting from a captured one by asking for it.
+            data["transcript_import"] = {
+                "source": source, "session_uid": session_uid, "segments": len(rows),
+                "started_at": _iso_utc(meeting.start_time),
+                "ended_at": _iso_utc(meeting.end_time),
+                "imported_at": _now().isoformat().replace("+00:00", "Z"),
+            }
+            # The same delivery marker a terminal transition writes (#807), counted the same way —
+            # SELECT COUNT over the durable rows, so it reports what is really in the table rather
+            # than what this call believes it wrote.
+            data["segments_captured"] = (await db.execute(
+                select(func.count()).select_from(Transcription).where(Transcription.meeting_id == mid)
+            )).scalar() or 0
+            meeting.data = data
             flag_modified(meeting, "data")
             await db.commit()
+            await db.refresh(meeting)
+            return {
+                "meeting_id": mid, "imported": True, "status": meeting.status,
+                "segments_imported": len(rows),
+                "segments_captured": data["segments_captured"],
+                "start_time": _iso_utc(meeting.start_time),
+                "end_time": _iso_utc(meeting.end_time),
+                "platform": meeting.platform,
+                "native_meeting_id": meeting.platform_specific_id,
+                "session_uid": session_uid, "source": source,
+                "imported_at": data["transcript_import"]["imported_at"],
+            }
 
     async def _mutate_docs(self, user_id, platform, native_meeting_id, mutator):
         """Owner-scoped atomic read→modify→write of ``meeting.data['docs']`` under ONE
@@ -1121,6 +1191,172 @@ class SqlAlchemyTranscriptStore:
                 data["calendar_name"] = primary.get("name") or "Calendar"
             meeting.data = data
             flag_modified(meeting, "data")
+            await db.commit()
+            await db.refresh(meeting)
+            return self._planned_row(meeting)
+
+    # The text-search config, used for BOTH the index expression and every query. These MUST be
+    # the same string: an index on to_tsvector('english', text) is invisible to a query that says
+    # to_tsvector('simple', text), and the failure is silent — correct answers, seq scan, no error.
+    FTS_CONFIG = "english"
+
+    async def search_transcripts(self, user_id, query, *, limit=20, offset=0,
+                                 platform=None, native_meeting_id=None) -> list[dict]:
+        """Owner-scoped FTS over transcript segments (see ports.search_transcripts).
+
+        Measured on 210k segments across two tenants (dogfood, 2026-08-29): a rare term took
+        914ms unindexed for a 400-meeting tenant and 0.108ms with the GIN index — and 45.7ms →
+        0.126ms even for a 24-meeting one, because the dominant cost is computing to_tsvector()
+        per row at query time, not finding the rows. The index is part of the feature, not a
+        later optimisation.
+        """
+        from sqlalchemy import text as sql_text
+
+        q = (query or "").strip()
+        if not q:
+            return []
+
+        cfg = self.FTS_CONFIG
+        sql = sql_text(f"""
+            SELECT t.id                AS segment_row_id,
+                   -- `meeting_db_id`, never `meeting_id`: the INT row id must not travel
+                   -- under the name that means the platform's STRING id on every other
+                   -- tool. Emitting it as `meeting_id` is the regression this branch's
+                   -- identity gate exists to stop.
+                   t.meeting_id        AS meeting_db_id,
+                   m.platform          AS platform,
+                   m.platform_specific_id AS native_meeting_id,
+                   t.start_time        AS start,
+                   t.end_time          AS "end",
+                   t.speaker           AS speaker,
+                   t.language          AS language,
+                   ts_rank_cd(to_tsvector('{cfg}', t.text), qq) AS rank,
+                   ts_headline('{cfg}', t.text, qq,
+                       'StartSel=<mark>,StopSel=</mark>,MaxWords=24,MinWords=8,MaxFragments=2') AS snippet,
+                   t.text              AS text
+            FROM transcriptions t
+            JOIN meetings m ON m.id = t.meeting_id,
+                 websearch_to_tsquery('{cfg}', :q) AS qq
+            WHERE m.user_id = :uid
+              AND to_tsvector('{cfg}', t.text) @@ qq
+              -- Explicit casts: asyncpg cannot infer a bind parameter's type when it appears
+              -- only in `IS NULL` ("could not determine data type of parameter $3"), so an
+              -- optional filter must state its own type.
+              AND (CAST(:platform AS text) IS NULL OR m.platform = CAST(:platform AS text))
+              AND (CAST(:native AS text) IS NULL
+                   OR m.platform_specific_id = CAST(:native AS text))
+            ORDER BY rank DESC, t.meeting_id DESC, t.start_time ASC
+            LIMIT :lim OFFSET :off
+        """)
+        async with self._session_factory() as db:
+            rows = (await db.execute(sql, {
+                "q": q, "uid": user_id, "platform": platform, "native": native_meeting_id,
+                "lim": max(1, min(int(limit or 20), 100)), "off": max(0, int(offset or 0)),
+            })).mappings().all()
+        return [dict(r) for r in rows]
+
+    async def ensure_fts_index(self) -> dict:
+        """Build the transcript FTS index CONCURRENTLY, idempotently, out of band.
+
+        Deliberately NOT part of ``_sync_indexes``: that wraps each index in a SAVEPOINT, and
+        ``CREATE INDEX CONCURRENTLY`` cannot run inside a transaction block. It also must not run
+        in-band at boot — a plain CREATE INDEX takes ACCESS EXCLUSIVE on ``transcriptions``, the
+        highest-row-count table, which would stall startup for as long as the build takes.
+
+        Safe to call on every boot BECAUSE SEARCH WORKS WITHOUT IT: a missing or half-built index
+        means a slower query, never a wrong answer and never a failed request. That is what keeps
+        this off the deploy's critical path — unlike ``meeting_event_time`` (MIGRATION-0005),
+        whose absence makes every list request fail.
+
+        Handles the one real trap: a failed CONCURRENTLY build leaves an INVALID index behind that
+        Postgres silently never uses. We detect it via ``pg_index.indisvalid``, drop it, and let
+        the next call rebuild.
+        """
+        from sqlalchemy import text as sql_text
+
+        name = "ix_transcription_text_fts"
+        # AUTOCOMMIT: CREATE/DROP INDEX CONCURRENTLY cannot run in a transaction block.
+        engine = self._session_factory.kw["bind"] if hasattr(self._session_factory, "kw") else None
+        engine = engine or getattr(self, "_engine", None)
+        if engine is None:
+            return {"status": "skipped", "reason": "no engine handle"}
+
+        async with engine.connect() as conn:
+            conn = await conn.execution_options(isolation_level="AUTOCOMMIT")
+            state = (await conn.execute(sql_text(
+                "SELECT i.indisvalid FROM pg_class c JOIN pg_index i ON i.indexrelid = c.oid "
+                "WHERE c.relname = :n"), {"n": name})).scalar()
+            if state is True:
+                return {"status": "present", "index": name}
+            if state is False:
+                # A previous CONCURRENTLY build failed. The leftover is INVALID and unusable —
+                # Postgres will not error on it, it will simply never use it. Drop and rebuild.
+                await conn.execute(sql_text(f"DROP INDEX CONCURRENTLY IF EXISTS {name}"))
+            await conn.execute(sql_text(
+                f"CREATE INDEX CONCURRENTLY IF NOT EXISTS {name} ON transcriptions "
+                f"USING gin (to_tsvector('{self.FTS_CONFIG}', text))"))
+            return {"status": "created", "index": name}
+
+    async def annotate_meeting(self, user_id, meeting_id, *, title=None,
+                               metadata=None) -> "Optional[dict]":
+        """Caller-owned annotations on a row in ANY status (see ports.annotate_meeting).
+
+        Modelled on ``attach_calendar_source``, not on ``update_planned_meeting``: nothing written
+        here is read by the dispatch pipeline, so there is no FSM to fight and no status check."""
+        from sqlalchemy import bindparam, select, text
+        from sqlalchemy.orm.attributes import flag_modified
+
+        from .models import Meeting
+
+        async with self._session_factory() as db:
+            await db.execute(
+                text("SELECT pg_advisory_xact_lock(:uid)").bindparams(bindparam("uid", user_id))
+            )
+            meeting = (await db.execute(
+                select(Meeting).where(Meeting.id == meeting_id, Meeting.user_id == user_id)
+                .with_for_update()
+            )).scalars().first()
+            if meeting is None:
+                return None
+
+            # `title` lives in the data blob, NOT as a column — same place update_planned_meeting
+            # puts it. Both writes therefore go through `data`, and both need flag_modified.
+            data = dict(meeting.data) if isinstance(meeting.data, dict) else {}
+            touched = False
+
+            if title is not None:
+                cleaned = (title or "").strip()[:512]
+                if cleaned:
+                    data["title"] = cleaned
+                else:
+                    data.pop("title", None)   # empty string clears it
+                touched = True
+
+            if metadata is not None:
+                touched = True
+                # ALWAYS a merge. A caller can only ever affect keys it names — an explicit null
+                # deletes exactly one. There is no whole-object replace, so nothing a writer never
+                # saw can be destroyed by it.
+                current = data.get("metadata")
+                merged = dict(current) if isinstance(current, dict) else {}
+                for k, v in metadata.items():
+                    if v is None:
+                        merged.pop(k, None)
+                    else:
+                        merged[k] = v
+                # Bound the MERGED result, never the patch alone: a cap on each write is not a cap
+                # at all when writes merge. Refuse rather than truncate — silently storing part of
+                # what a caller sent is a worse failure than telling them it did not fit.
+                from .projection import check_metadata_bounds
+                reason = check_metadata_bounds(merged)
+                if reason:
+                    return {"error": "metadata_too_large", "detail": reason}
+                data["metadata"] = merged
+
+            if touched:
+                meeting.data = data
+                flag_modified(meeting, "data")
+
             await db.commit()
             await db.refresh(meeting)
             return self._planned_row(meeting)

--- a/core/meetings/services/meeting-api/src/meeting_api/collector/app.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/collector/app.py
@@ -33,6 +33,8 @@ from __future__ import annotations
 
 from typing import Any, Callable, Optional
 
+import json
+
 from fastapi import APIRouter, FastAPI, Header, HTTPException, Query, Request, Response
 from fastapi.responses import JSONResponse
 
@@ -143,6 +145,41 @@ def build_router(
         )
         return JSONResponse(content=doc)
 
+    # --- GET /transcripts/search?q= → ranked, snippeted hits across the caller's OWN transcripts.
+    # Registered BEFORE /transcripts/{platform}/{native_meeting_id} so `search` is not swallowed
+    # as a platform — the same ordering `by-id` above depends on.
+    #
+    # This answers what metadata cannot: not "meetings I tagged X" but "meetings where someone
+    # SAID X". Owner-scoped only, deliberately narrower than GET /meetings (which also surfaces
+    # share-recipient and workspace rows) — a search that over-returns is a disclosure, so it
+    # fails closed until widening it has had its own review.
+    @router.get("/transcripts/search")
+    async def search_transcripts(
+        request: Request,
+        q: str = Query(..., min_length=1, description=(
+            "Search text. Supports \"quoted phrases\", `or`, and `-excluded` terms "
+            "(websearch syntax). Malformed input never errors."
+        )),
+        limit: int = Query(20, ge=1, le=100),
+        offset: int = Query(0, ge=0),
+        platform: Optional[str] = Query(None, description="Restrict to one platform."),
+        native_meeting_id: Optional[str] = Query(None, description="Restrict to one meeting."),
+        x_user_id: Optional[str] = Header(default=None),
+    ):
+        user_id = _resolve_user_id(x_user_id)
+        if not (q or "").strip():
+            raise HTTPException(status_code=422, detail="'q' must not be blank")
+        hits = await store.search_transcripts(
+            user_id, q, limit=limit, offset=offset,
+            platform=platform, native_meeting_id=native_meeting_id,
+        )
+        log_event(
+            "transcripts_searched", audience="user", span="transcripts.search",
+            user_id=user_id,
+            fields={"query_chars": len(q), "hits": len(hits), "platform": platform},
+        )
+        return JSONResponse(content={"query": q, "hits": hits, "count": len(hits)})
+
     # --- GET /transcripts/{platform}/{native_meeting_id} → api.v1 TranscriptionResponse ---
     @router.get("/transcripts/{platform}/{native_meeting_id}")
     async def get_transcript(
@@ -196,13 +233,29 @@ def build_router(
         status: Optional[str] = Query(default=None),
         platform: Optional[str] = Query(default=None),
         exclude_planned: bool = Query(default=False),
+        metadata: Optional[str] = Query(
+            default=None,
+            description=(
+                'JSON object. Returns only meetings whose caller-set metadata CONTAINS it — e.g. '
+                '{"crm_deal":"acme-42"}. Containment, so extra keys on the row still match. '
+                "Filtered in SQL against the data GIN index, not on the fetched page."
+            ),
+        ),
     ):
         user_id = _resolve_user_id(x_user_id)
         member_workspaces = {w.strip() for w in (x_user_workspaces or "").split(",") if w.strip()}
         status_filter = status if status is not None else (_NON_PLANNED_STATUSES if exclude_planned else None)
+        metadata_filter = None
+        if metadata:
+            try:
+                metadata_filter = json.loads(metadata)
+            except Exception:
+                raise HTTPException(status_code=422, detail="'metadata' must be a JSON object")
+            if not isinstance(metadata_filter, dict):
+                raise HTTPException(status_code=422, detail="'metadata' must be a JSON object")
         meetings, _has_more = await store.list_meetings(
             user_id, status=status_filter, platform=platform, limit=limit, offset=offset,
-            member_workspaces=member_workspaces, list_view=True,
+            member_workspaces=member_workspaces, list_view=True, metadata_filter=metadata_filter,
         )
         log_event(
             "meetings_listed",
@@ -589,6 +642,72 @@ def build_router(
     # refuses an FSM-owned row with 409). Unknown/unowned native → 404. Additive: the int routes are
     # unchanged. DELETE returns 200 + a small body (the sealed native-delete response), NOT the 204
     # the row-id route returns. ---
+    # --- POST /meetings/{platform}/{native_meeting_id}/annotate → the caller's OWN description of
+    # a meeting: `title` and arbitrary `metadata`. Works in ANY status, unlike the PATCH below.
+    #
+    # The split is by WHAT is written, not when. PATCH edits the INSTRUCTIONS for a meeting (url,
+    # schedule, auto-join) and is refused once the FSM owns the row, because changing dispatch
+    # parameters under a running bot fights it. Annotations are the caller's DESCRIPTION: nothing
+    # in the pipeline reads them, so writing them can never re-arm, re-dispatch or re-route
+    # anything — and the moments a description is most worth writing are exactly the ones the FSM
+    # owns. Mid-meeting ("this is the Acme renewal call") and after it ends (the agent's own
+    # summary) were both previously impossible: PATCH answered 409 for the entire useful life of
+    # a meeting.
+    #
+    # `metadata` ALWAYS merges key-wise; an explicit null deletes exactly one key. There is
+    # deliberately NO whole-object replace: every writer on an account shares one API key, so a
+    # replace would let any caller destroy annotations written by another agent — or by the human
+    # — that it never saw and could not have known about. Merge plus explicit nulls expresses
+    # every legitimate edit while making "corrupt what you did not write" unrepresentable.
+    @router.post("/meetings/{platform}/{native_meeting_id}/annotate")
+    async def annotate_native_meeting(
+        platform: str,
+        native_meeting_id: str,
+        request: Request,
+        x_user_id: Optional[str] = Header(default=None),
+    ):
+        user_id = _resolve_user_id(x_user_id)
+        try:
+            payload = await request.json()
+        except Exception:
+            raise HTTPException(status_code=422, detail="invalid JSON body")
+        if not isinstance(payload, dict):
+            raise HTTPException(status_code=422, detail="body must be an object")
+
+        title = payload.get("title")
+        if title is not None and not isinstance(title, str):
+            raise HTTPException(status_code=422, detail="'title' must be a string")
+        metadata = payload.get("metadata")
+        if metadata is not None and not isinstance(metadata, dict):
+            raise HTTPException(status_code=422, detail="'metadata' must be an object")
+        if title is None and metadata is None:
+            raise HTTPException(
+                status_code=422,
+                detail="nothing to annotate: send 'title' and/or 'metadata'",
+            )
+
+        meeting_id = await _resolve_owned_native(user_id, platform, native_meeting_id)
+        if meeting_id is None:
+            raise HTTPException(
+                status_code=404,
+                detail=f"Meeting not found for platform {platform} and ID {native_meeting_id}",
+            )
+        row = await store.annotate_meeting(user_id, meeting_id, title=title, metadata=metadata)
+        if row is None:
+            raise HTTPException(status_code=404, detail="Meeting not found")
+        if isinstance(row, dict) and row.get("error") == "metadata_too_large":
+            # 413, not 422: the request is well-formed, it is the SIZE that is refused. Nothing is
+            # written — a partial store would be worse than the refusal.
+            raise HTTPException(status_code=413, detail=row.get("detail", "metadata too large"))
+        log_event(
+            "meeting_annotated", audience="user", span="meetings.annotate",
+            user_id=user_id, meeting_id=str(meeting_id),
+            fields={"title": title is not None,
+                    "metadata_keys": sorted(metadata.keys()) if metadata else [],
+                    "status": row.get("status")},
+        )
+        return JSONResponse(content=row)
+
     @router.patch("/meetings/{platform}/{native_meeting_id}")
     async def patch_native_meeting(
         platform: str,
@@ -767,9 +886,173 @@ def build_router(
         )
         return JSONResponse(content={"workspace_id": bound})
 
+    def _share_payload(payload) -> "tuple[str, list, int]":
+        """mode | allowed_emails | ttl out of a share-mint body, defaulted the same way for both
+        address shapes. `restricted` + allowed_emails is what makes a forwarded mail grant nothing."""
+        if not isinstance(payload, dict):
+            payload = {}
+        return (
+            str(payload.get("mode", "open")).strip() or "open",
+            payload.get("allowed_emails") or [],
+            int(payload.get("expires_in_sec", 86400) or 86400),
+        )
+
+    # --- POST /meetings/{meeting_id}/transcript-import → complete a meeting FROM A TRANSCRIPT.
+    #
+    # The product feature is "import a transcript": a meeting that already happened somewhere we did
+    # not record — a Zoom export, a TSC recording, minutes from a call nobody sent a bot to — becomes
+    # a first-class Vexa meeting. Everything downstream then treats it as one: the canvas, the by-id
+    # transcript read, search, the post-meeting flows.
+    #
+    # It is ALSO the honest capture double. The rehearsal rig used to build this row by hand —
+    # `docker exec … psql` INSERTing `transcriptions` and UPDATEing `meetings` with the DB password
+    # it read out of another container — because meeting-api owned the two things the double needed
+    # and exposed neither: a way to put words on a row, and a way to say WHEN the meeting was (a bot
+    # run stamps start/end from `now()`, so a call that happened last Tuesday was inexpressible).
+    # That shell-out is the audit's V4/N5 — a second writer on a table this service owns, building
+    # SQL by string-interpolating speaker names, and it produced rows the product never makes
+    # (`scheduled`, NULL start/end) which read as "UPCOMING" over a finished meeting. One route
+    # closes the feature gap and the ownership hole at once, which is why `source` is declared
+    # rather than inferred: a reader can always tell a double from a real import.
+    #
+    # ROW ID, not the (platform, native) pair — the same lesson the by-id share mint above records:
+    # the pair is not an identity, and the rows most likely to be imported into are exactly the ones
+    # no pair addresses. Three segments against the pair routes' four, so neither can shadow the
+    # other; registered before them anyway, matching the `by-id` precedent.
+    #
+    # Owner-scoped, and refused (409) while a bot is in flight on the row — the FSM is never fought.
+    @router.post("/meetings/{meeting_id}/transcript-import")
+    async def import_transcript(
+        meeting_id: int,
+        request: Request,
+        x_user_id: Optional[str] = Header(default=None),
+    ):
+        from .transcript_import import (SOURCES, normalize_segments, occurrence_window,
+                                        session_uid_for)
+
+        user_id = _resolve_user_id(x_user_id)
+        try:
+            payload = await request.json()
+        except Exception:
+            raise HTTPException(status_code=422, detail="invalid JSON body")
+        if not isinstance(payload, dict):
+            raise HTTPException(status_code=422, detail="body must be an object")
+
+        source = str(payload.get("source") or "import").strip()
+        if source not in SOURCES:
+            raise HTTPException(
+                status_code=422,
+                detail=f"'source' must be one of {sorted(SOURCES)} — say where the transcript came from",
+            )
+        session_uid = session_uid_for(source, meeting_id)
+        segments, reason = normalize_segments(payload.get("segments"), session_uid)
+        if reason:
+            raise HTTPException(status_code=422, detail=reason)
+        started_at, ended_at, reason = occurrence_window(
+            segments, payload.get("started_at"), payload.get("ended_at"),
+        )
+        if reason:
+            raise HTTPException(status_code=422, detail=reason)
+
+        result = await store.complete_transcript_import(
+            user_id, meeting_id, segments=segments, started_at=started_at, ended_at=ended_at,
+            source=source, session_uid=session_uid,
+        )
+        if result is None:
+            log_event(
+                "transcript_import_failed", audience="system", level="warning",
+                span="meetings.transcript.import", user_id=user_id, meeting_id=str(meeting_id),
+                fields={"source": source, "reason": "no such meeting for this owner"},
+            )
+            raise HTTPException(status_code=404, detail=f"Meeting {meeting_id} not found")
+        if result.get("error") == "conflict":
+            raise HTTPException(
+                status_code=409,
+                detail=(f"Meeting {meeting_id} is {result.get('status')} — a bot is in flight on it. "
+                        "A live meeting is completed by its bot, not by an import."),
+            )
+
+        if result.get("imported"):
+            # What a real completion emits, emitted here for the same reason: the terminal learns a
+            # meeting's status from the `u:{user}:meetings` frame the gateway `/ws` forwards
+            # (surfaces/gatewayWS.ts), and its live view of a meeting ends on the `session_end`
+            # marker the collector appends to `tc:meeting:{id}` (ingest._transcript_stream). Both are
+            # best-effort, like every other publish on this path — the durable row is the truth.
+            #
+            # What is deliberately NOT emitted: the segments themselves, into the live stream. They
+            # went through it during a real call because the call was happening. Replaying an
+            # already-finished transcript as live frames would be a fake liveness, and the canvas
+            # reads a completed meeting from `GET /transcripts/by-id/{id}` anyway.
+            await _publish_user_meeting_status(
+                redis, user_id=user_id, meeting_id=result.get("meeting_id"),
+                native_id=result.get("native_meeting_id"), status="completed",
+                when=result.get("end_time"), log_event=log_event,
+            )
+            if redis is not None:
+                try:
+                    await redis.xadd(f"tc:meeting:{result['meeting_id']}",
+                                     {"type": "session_end", "uid": session_uid})
+                except Exception as e:  # noqa: BLE001 — best-effort marker; never fail the import
+                    log_event("transcript_import_marker_failed", audience="system", level="warning",
+                              span="meetings.transcript.import", user_id=user_id,
+                              meeting_id=str(meeting_id), fields={"error": str(e)})
+
+        log_event(
+            "transcript_imported", audience="user", span="meetings.transcript.import",
+            user_id=user_id, meeting_id=str(meeting_id),
+            fields={"source": source, "segments": result.get("segments_imported"),
+                    "imported": bool(result.get("imported")),
+                    "start_time": result.get("start_time"), "end_time": result.get("end_time")},
+        )
+        return JSONResponse(content=result)
+
+    # --- POST /meetings/{meeting_id}/share → the SAME mint, addressed by the ROW's primary key.
+    #
+    # Why it exists: the (platform, native) pair is not an identity. A meeting planned from an invite
+    # whose url matched no platform lands as platform='unknown' with an EMPTY platform_specific_id —
+    # no pair addresses it, so the pair-keyed mint below answers 404 and every attendee mail for that
+    # meeting went out with no capability at all (row 97, 2026-09-02). The row id always exists.
+    #
+    # Route ordering / shadowing: this path is THREE segments (`meetings/{id}/share`) and the pair
+    # route is FOUR — Starlette compiles a full-path regex per route, so on segment count alone
+    # neither can swallow the other, the same property the gateway's by-row-id notes rely on. The
+    # `meeting_id: int` annotation is belt-and-braces: a non-numeric id is refused by validation here
+    # rather than being resolved as some other kind of name. Registered BEFORE the pair route anyway,
+    # matching the `by-id` precedent at the top of this file.
+    #
+    # Owner-scoped: a row that is not the caller's 404s exactly like an unknown one. Minting a
+    # capability is an owner act, and a share route that distinguished the two would leak existence.
+    @router.post("/meetings/{meeting_id}/share")
+    async def mint_transcript_share_by_id(
+        meeting_id: int,
+        request: Request,
+        x_user_id: Optional[str] = Header(default=None),
+    ):
+        user_id = _resolve_user_id(x_user_id)
+        try:
+            payload = await request.json()
+        except Exception:
+            payload = {}
+        mode, emails, ttl = _share_payload(payload)
+        minted = await store.mint_transcript_share_by_id(
+            user_id, meeting_id, mode=mode, allowed_emails=emails, expires_in_sec=ttl,
+        )
+        if minted is None:
+            log_event(
+                "transcript_share_mint_failed", audience="system", level="warning",
+                span="meetings.transcript.share", user_id=user_id, meeting_id=str(meeting_id),
+                fields={"mode": mode, "reason": "no such meeting for this owner"},
+            )
+            raise HTTPException(status_code=404, detail=f"Meeting {meeting_id} not found")
+        log_event("transcript_share_minted", audience="user", span="meetings.transcript.share",
+                  user_id=user_id, meeting_id=str(meeting_id), fields={"mode": mode, "by": "row_id"})
+        return JSONResponse(content=minted)
+
     # --- POST /meetings/{platform}/{native_meeting_id}/share → mint an INDEPENDENT transcript share link
     # (capability token). Owner-scoped. open|restricted(+allowed_emails), TTL. The token is returned ONCE
-    # (only its hash is stored). Redeemed at POST /transcripts/share/accept — NO workspace involved. ---
+    # (only its hash is stored). Redeemed at POST /transcripts/share/accept — NO workspace involved.
+    # Kept for 0.10 clients and the /transcripts/{platform}/{native}/share alias; new callers use the
+    # by-row-id route above, which can address rows this one cannot. ---
     @router.post("/meetings/{platform}/{native_meeting_id}/share")
     async def mint_transcript_share(
         platform: str,
@@ -782,18 +1065,21 @@ def build_router(
             payload = await request.json()
         except Exception:
             payload = {}
-        if not isinstance(payload, dict):
-            payload = {}
-        mode = str(payload.get("mode", "open")).strip() or "open"
-        emails = payload.get("allowed_emails") or []
-        ttl = int(payload.get("expires_in_sec", 86400) or 86400)
+        mode, emails, ttl = _share_payload(payload)
         minted = await store.mint_transcript_share(
             user_id, platform, native_meeting_id, mode=mode, allowed_emails=emails, expires_in_sec=ttl,
         )
         if minted is None:
+            log_event(
+                "transcript_share_mint_failed", audience="system", level="warning",
+                span="meetings.transcript.share", user_id=user_id,
+                meeting_id=f"{platform}/{native_meeting_id}",
+                fields={"mode": mode, "reason": "no meeting addressed by this (platform, native) pair"},
+            )
             raise HTTPException(status_code=404, detail=f"Meeting not found for {platform}/{native_meeting_id}")
         log_event("transcript_share_minted", audience="user", span="meetings.transcript.share",
-                  user_id=user_id, meeting_id=f"{platform}/{native_meeting_id}", fields={"mode": mode})
+                  user_id=user_id, meeting_id=f"{platform}/{native_meeting_id}",
+                  fields={"mode": mode, "by": "pair"})
         return JSONResponse(content=minted)
 
     # --- POST /transcripts/share/accept → redeem a transcript share token (any authenticated user) →

--- a/core/meetings/services/meeting-api/src/meeting_api/collector/db_writer.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/collector/db_writer.py
@@ -1,4 +1,4 @@
-"""The background **db-writer** — flush live Redis segments (and processed notes) to the durable store.
+"""The background **db-writer** — flush live Redis segments to the durable store.
 
 RESTORES the parent loop the 0.12 carve dropped (0.10 ``meeting_api/collector/db_writer.py``
 ``process_redis_to_postgres``): the consumer (``ingest.py``) lands live segments in the Redis hash
@@ -31,25 +31,16 @@ Additions over the parent:
   * ``finalize_meeting(...)`` — the completion hook: flush EVERYTHING left (threshold 0, mutable
     tail included) the moment the lifecycle FSM lands on a terminal status, so a completed meeting's
     transcript is durable immediately instead of eventually.
-  * ``flush_meeting_processed(...)`` — drain the copilot's cleaned-notes stream
-    (``proc:meeting:{meeting_id}``, agent-worker the single writer, P23) into the meeting row's
-    ``data['processed']`` JSONB (the documented meeting.data home; NO schema change), resuming
-    from the persisted ``source_cursor``. Redis was the ONLY home of the processed doc before
-    this — stopping the bot made the processed output unreachable over REST.
-
-The persisted processed shape is ADDRESSABLE and VERSIONED (multi-consumer, per the release DoD):
-``data.processed = {"views": [{id, kind, params, doc, source_cursor, updated_at}]}`` — ``params``
-records the processing metadata APPLIED (provider/model/pipeline, stamped by the producing worker
-on the stream entries — reproducibility), ``doc`` is the view body (``{"notes": [...]}`` for the
-copilot's cleaned-transcript view), ``source_cursor`` the stream position the view reflects. A
-LIST of views so multiple processings of one meeting (per-workspace views are coming) coexist;
-today the collector maintains the ONE meeting-scoped copilot view, upserted by ``id``. The views
-ride the sealed api.v1 responses' existing free-form ``data`` field (GET /transcripts +
-GET /meetings) — no new REST surface, no contract change.
+There used to be a second drain beside it — ``flush_meeting_processed(...)``, which pulled the
+copilot's cleaned-notes stream ``proc:meeting:{meeting_id}`` into the meeting row's
+``data['processed']`` JSONB, plus the ``processed_pending`` parking that waited for that
+producer's ``view_end`` marker after a meeting finished. PRD decision 34 removed the producer:
+the product runs no model calls of its own beside the agent, so nothing writes that stream and
+there is no second body of a transcript to keep durable. Segments are the whole job.
 
 Everything here talks to redis through plain client calls (hgetall/hdel/smembers/scan/xrange) that
 both ``redis.asyncio`` and ``fakeredis.aioredis`` satisfy, and to the durable store through two
-getattr-guarded sink methods (``upsert_segments``, ``merge_processed_notes``) implemented by BOTH
+a getattr-guarded sink method (``upsert_segments``) implemented by BOTH
 ``SqlAlchemyTranscriptStore`` (prod) and ``InMemoryTranscriptStore`` (tests) — so the whole writer
 is unit-tested offline, no docker.
 """
@@ -176,34 +167,10 @@ async def _trim_segments_stream(redis_c, retention_s: float, now_ms: int) -> Non
     except Exception:
         pass
 
-# ── the end-of-processing protocol (ADR 0027 / processed-notes.v1) ────────────────────────────────
-# The copilot worker runs one final LLM beat AFTER session_end (~10s), then XADDs a `view_end`
-# marker: the proc stream is COMPLETE at that entry. finalize_meeting's inline drain used to be the
-# LAST drain ever (the meeting then left this writer's sweep), so the final beat's notes stayed in
-# redis forever (run-46: durable cursor 1783512746260-0 < stream tail 1783512757882-0). Now a
-# finalized meeting whose stream is not yet marker-complete PARKS in `processed_pending` (zset,
-# score = deadline) and every tick re-drains it until the marker is seen — or the deadline passes
-# (the P22 pairing: graceful marker, hard bounded guarantee for a worker that died markerless).
-PROC_PENDING_KEY = "processed_pending"
-PROC_PENDING_GRACE_SEC = float(os.environ.get("PROC_PENDING_GRACE_SEC", "120"))
-
-# The one processed view the collector maintains today: the copilot's 1:1 cleaned transcript.
-# Addressable by id inside data.processed.views[] so future processings (per-workspace views,
-# summaries, translations) ADD views instead of overwriting this one.
-PROC_VIEW_ID = "copilot-notes"
-PROC_VIEW_KIND = "cleaned_transcript"
-
 
 def segments_hash_key(meeting_id) -> str:
     """The live Redis hash of in-flight segments (``ingest`` writes it; the read path merges it)."""
     return f"meeting:{meeting_id}:segments"
-
-
-def proc_stream_key(meeting_id) -> str:
-    """The copilot's cleaned-notes stream for ONE meeting row — keyed by the NUMERIC meeting id
-    (unique per row) so a re-sent bot on the same native link can never mix/clobber a previous
-    meeting's processed doc (the native-id keying defect)."""
-    return f"proc:meeting:{meeting_id}"
 
 
 def _s(v) -> str:
@@ -288,77 +255,6 @@ async def flush_meeting_segments(
     return len(batch)
 
 
-async def flush_meeting_processed(redis_c, sink, meeting_id: int) -> int:
-    """Drain NEW entries of the meeting's processed-notes stream (``proc:meeting:{meeting_id}``,
-    written by the agent worker) into the copilot view of the meeting row's
-    ``data['processed']['views']`` JSONB via the sink, resuming from the view's persisted
-    ``source_cursor`` (exclusive). Notes are merged by their ``id`` (== segment_id), so a refining
-    re-emit updates in place. ``params`` (provider/model/pipeline, stamped by the worker on each
-    entry) ride along into the view for reproducibility. Returns the count of notes merged."""
-    merge = getattr(sink, "merge_processed_view", None)
-    cursor_of = getattr(sink, "processed_view_cursor", None)
-    if merge is None or cursor_of is None:
-        return 0
-    cursor = await cursor_of(meeting_id, PROC_VIEW_ID)
-    start = "-" if not cursor else f"({cursor}"
-    try:
-        rows = await redis_c.xrange(proc_stream_key(meeting_id), min=start, max="+")
-    except Exception:  # noqa: BLE001 — a missing/typed-over key must not break the segments flush
-        return 0
-    if not rows:
-        return 0
-    notes: list[dict] = []
-    params: Optional[dict] = None
-    last_id = cursor
-    for entry_id, fields in rows:
-        last_id = _s(entry_id)
-        decoded = {_s(k): _s(v) for k, v in fields.items()}
-        raw_params = decoded.get("params")
-        if raw_params:
-            try:
-                parsed = json.loads(raw_params)
-                if isinstance(parsed, dict):
-                    params = parsed  # last writer wins — the params APPLIED to the newest notes
-            except (json.JSONDecodeError, ValueError):
-                pass
-        raw_note = decoded.get("note")
-        if not raw_note:
-            continue
-        try:
-            note = json.loads(raw_note)
-        except (json.JSONDecodeError, ValueError):
-            continue
-        if isinstance(note, dict):
-            notes.append(note)
-    if notes or last_id != cursor:
-        await merge(
-            meeting_id,
-            view_id=PROC_VIEW_ID, kind=PROC_VIEW_KIND,
-            notes=notes, source_cursor=last_id, params=params,
-        )
-    return len(notes)
-
-
-async def _processed_complete(redis_c, sink, meeting_id: int) -> bool:
-    """Whether the meeting's processed stream is DRAINED THROUGH its ``view_end`` marker: the
-    stream's last entry is the marker AND the persisted view cursor sits exactly on it. A sink
-    that can't persist views has nothing to wait for (vacuously complete)."""
-    cursor_of = getattr(sink, "processed_view_cursor", None)
-    if cursor_of is None:
-        return True
-    try:
-        rows = await redis_c.xrevrange(proc_stream_key(meeting_id), max="+", min="-", count=1)
-    except Exception:  # noqa: BLE001 — unreadable stream ⇒ not provably complete
-        return False
-    if not rows:
-        return False  # nothing written (yet) — a just-armed copilot may still deliver
-    entry_id, fields = rows[0]
-    decoded = {_s(k): _s(v) for k, v in fields.items()}
-    if decoded.get("type") != "view_end":
-        return False
-    return await cursor_of(meeting_id, PROC_VIEW_ID) == _s(entry_id)
-
-
 async def db_writer_tick(
     redis_c,
     sink,
@@ -368,8 +264,7 @@ async def db_writer_tick(
     reconcile: bool = False,
 ) -> int:
     """ONE db-writer sweep (the loop body ``__main__`` polls): flush every discovered meeting's
-    immutable segments to the durable sink, then drain its processed-notes stream. Returns the total
-    segments stored. Per-meeting failures are contained — one bad meeting never starves the rest.
+    immutable segments to the durable sink. Returns the total segments stored. Per-meeting failures are contained — one bad meeting never starves the rest.
 
     Discovery is the ``active_meetings`` set (authoritative in steady state — ``append_segment`` SADDs
     the meeting in the SAME transaction that writes its hash). ``reconcile=True`` ADDITIONALLY runs the
@@ -402,41 +297,8 @@ async def db_writer_tick(
                 redis_c, sink, meeting_id,
                 immutability_threshold=immutability_threshold, now=now,
             )
-            await flush_meeting_processed(redis_c, sink, meeting_id)
         except Exception:  # noqa: BLE001 — isolate per meeting; the next tick retries
             log.exception("db-writer flush failed for meeting %s", raw_id)
-
-    # Finalized-but-incomplete processed streams (ADR 0027): re-drain each parked meeting until its
-    # view_end marker is drained-through, or its deadline passes. These meetings have LEFT the sweep
-    # above (hash drained, out of active_meetings) — without this pass the final beat's notes would
-    # never reach the durable row.
-    try:
-        pending = await redis_c.zrange(PROC_PENDING_KEY, 0, -1, withscores=True)
-    except Exception:  # noqa: BLE001 — the pending pass is additive; never break the main sweep
-        pending = []
-    now_ts = (now or datetime.now(timezone.utc)).timestamp()
-    for member, deadline in pending or []:
-        raw_id = _s(member)
-        try:
-            meeting_id = int(raw_id)
-        except (TypeError, ValueError):
-            await redis_c.zrem(PROC_PENDING_KEY, member)
-            continue
-        try:
-            await flush_meeting_processed(redis_c, sink, meeting_id)
-            if await _processed_complete(redis_c, sink, meeting_id):
-                await redis_c.zrem(PROC_PENDING_KEY, raw_id)
-            elif now_ts >= float(deadline):
-                # P18: the give-up is a reportable state, not silence — everything that DID arrive
-                # was flushed above; what never arrived is attributed to the worker, loudly.
-                log.warning(
-                    "processed view for meeting %s never saw view_end within %ss — "
-                    "flushed what arrived, giving up the pending re-drain",
-                    raw_id, PROC_PENDING_GRACE_SEC,
-                )
-                await redis_c.zrem(PROC_PENDING_KEY, raw_id)
-        except Exception:  # noqa: BLE001 — isolate per meeting; the next tick retries
-            log.exception("pending processed re-drain failed for meeting %s", raw_id)
 
     # #527 C2: bound the ingest stream in steady state (trims only acked entries past the retention
     # window; never an unread one). Isolated — a trim failure never blocks the durable flush above.
@@ -451,19 +313,11 @@ async def db_writer_tick(
 async def finalize_meeting(redis_c, sink, meeting_id: int) -> int:
     """The COMPLETION flush — called by the lifecycle callback the moment a meeting reaches a
     terminal status (completed/failed): flush EVERYTHING still in the hash (threshold 0 — the
-    mutable tail and trailing drafts included; no more updates are coming) and drain the processed
-    notes, so the finished meeting's transcript + processed doc are durable IMMEDIATELY.
+    mutable tail and trailing drafts included; no more updates are coming), so the finished
+    meeting's transcript is durable IMMEDIATELY.
 
-    The processed stream is NOT necessarily complete here — the copilot's final beat runs ~10s
-    AFTER session_end (ADR 0027). Unless the ``view_end`` marker is already drained-through, the
-    meeting PARKS in ``processed_pending``; ``db_writer_tick`` keeps re-draining it until the
-    marker (or the bounded deadline). Never processed ⇒ the deadline simply expires the parking."""
-    stored = await flush_meeting_segments(redis_c, sink, meeting_id, immutability_threshold=0)
-    await flush_meeting_processed(redis_c, sink, meeting_id)
-    if not await _processed_complete(redis_c, sink, meeting_id):
-        try:
-            deadline = datetime.now(timezone.utc).timestamp() + PROC_PENDING_GRACE_SEC
-            await redis_c.zadd(PROC_PENDING_KEY, {str(meeting_id): deadline})
-        except Exception:  # noqa: BLE001 — parking is the safety net, never fail the finalize
-            log.exception("could not park meeting %s for the pending processed re-drain", meeting_id)
-    return stored
+    It used to do a second thing: drain the copilot's processed notes and, when their ``view_end``
+    marker had not arrived, PARK the meeting in ``processed_pending`` for a bounded re-drain — the
+    final beat ran ~10s after session_end. PRD decision 34 removed that producer, so there is
+    nothing left to wait for and the flush is complete when the segments are."""
+    return await flush_meeting_segments(redis_c, sink, meeting_id, immutability_threshold=0)

--- a/core/meetings/services/meeting-api/src/meeting_api/collector/fakes.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/collector/fakes.py
@@ -187,9 +187,22 @@ class InMemoryTranscriptStore:
         return await self._transcript_doc(mid, viewer_is_owner=is_owner) if authorized else None
 
     async def list_meetings(self, user_id, *, status=None, platform=None, limit=None, offset=None,
-                            member_workspaces=None, list_view=False, meeting_id=None, slim=False):
+                            member_workspaces=None, list_view=False, meeting_id=None, slim=False,
+                            metadata_filter=None):
         from .projection import DEFAULT_LIST_LIMIT, list_order_key, project_list_data
         mws = member_workspaces or set()
+
+        def metadata_matches(m):
+            """Mirror of the adapter's JSONB `@>` on `data.metadata`: every key in the filter must
+            be present with an equal value. Containment, not equality — extra keys on the row do
+            not disqualify it."""
+            if not metadata_filter:
+                return True
+            data = m.get("data") if isinstance(m.get("data"), dict) else {}
+            stored = data.get("metadata")
+            if not isinstance(stored, dict):
+                return False
+            return all(stored.get(k) == v for k, v in metadata_filter.items())
 
         def accessible(m):
             data = m.get("data") if isinstance(m.get("data"), dict) else {}
@@ -204,6 +217,7 @@ class InMemoryTranscriptStore:
                                     else m["status"] == status))
             and (meeting_id is None or mid == meeting_id)
             and (platform is None or m["platform"] == platform)
+            and metadata_matches(m)
         ]
         if list_view:
             # #1222: the USER-FACING list orders by (non-terminal pin, event time) — the meeting
@@ -304,22 +318,34 @@ class InMemoryTranscriptStore:
         self._meetings[mid]["data"]["workspace_id"] = workspace_id
         return workspace_id
 
+    def _mint_share_on(self, mid, mode, allowed_emails, expires_in_sec):
+        """The grant, once, for both address shapes — mirrors the SqlAlchemy store's ``_mint_share_on``."""
+        from .adapters import _build_share_grant
+
+        if mid is None or mid not in self._meetings:
+            return None
+        grant, secret = _build_share_grant(mode, allowed_emails, expires_in_sec)
+        self._meetings[mid]["data"].setdefault("share_grants", []).append(grant)
+        return {"id": grant["id"], "token": f"{mid}.{secret}",
+                "mode": mode, "expires_at": grant["expires_at"]}
+
     async def mint_transcript_share(self, user_id, platform, native_meeting_id, *,
                                     mode="open", allowed_emails=None, expires_in_sec=86400):
-        from datetime import timedelta
+        return self._mint_share_on(self._find(user_id, platform, native_meeting_id),
+                                   mode, allowed_emails, expires_in_sec)
 
-        from .adapters import _now, _sha
-        mid = self._find(user_id, platform, native_meeting_id)
-        if mid is None:
+    async def mint_transcript_share_by_id(self, user_id, meeting_id, *,
+                                          mode="open", allowed_emails=None, expires_in_sec=86400):
+        """Owner-scoped by primary key. A row that is not this caller's reads exactly like one that
+        does not exist — the store never tells a non-owner that an id is taken."""
+        try:
+            mid = int(meeting_id)
+        except (TypeError, ValueError):
             return None
-        import secrets
-        secret = secrets.token_urlsafe(24)
-        gid = secrets.token_hex(8)
-        expires_at = (_now() + timedelta(seconds=int(expires_in_sec))).isoformat()
-        grant = {"id": gid, "secret_hash": _sha(secret), "mode": mode,
-                 "allowed_emails": list(allowed_emails or []), "expires_at": expires_at, "revoked": False}
-        self._meetings[mid]["data"].setdefault("share_grants", []).append(grant)
-        return {"id": gid, "token": f"{mid}.{secret}", "mode": mode, "expires_at": expires_at}
+        row = self._meetings.get(mid)
+        if row is None or row.get("user_id") != user_id:
+            return None
+        return self._mint_share_on(mid, mode, allowed_emails, expires_in_sec)
 
     async def redeem_transcript_share(self, user_id, user_email, token):
         from .adapters import _sha, validate_transcript_grant
@@ -477,6 +503,116 @@ class InMemoryTranscriptStore:
             primary = calendar_sources[0]
             data["calendar_connection_id"] = primary.get("id")
             data["calendar_name"] = primary.get("name") or "Calendar"
+        return self._planned_row(meeting_id)
+
+    async def search_transcripts(self, user_id, query, *, limit=20, offset=0,
+                                 platform=None, native_meeting_id=None):
+        """A DELIBERATELY CRUDE stand-in for Postgres FTS — enough to test the ROUTE's contract
+        (owner scoping, filters, paging, hit shape), never the search semantics.
+
+        Case-insensitive whole-word AND matching, quoted phrases, `-term` negation. It does NOT
+        stem, does NOT rank by cover density, and does NOT implement `or`. Anything asserting real
+        tsquery behaviour must run against Postgres — meeting-api has no `requires_docker` lane
+        the way admin-api does, so that assertion lives in this branch's live validation.
+        Pretending otherwise here would produce tests that pass while production is wrong.
+        """
+        import re as _re
+
+        q = (query or "").strip()
+        if not q:
+            return []
+
+        phrases = _re.findall(r'"([^"]+)"', q)
+        rest = _re.sub(r'"[^"]*"', " ", q)
+        negations = [w[1:].lower() for w in rest.split() if w.startswith("-") and len(w) > 1]
+        terms = [w.lower() for w in rest.split() if not w.startswith("-")]
+
+        def matches(text: str) -> bool:
+            low = text.lower()
+            words = set(_re.findall(r"\w+", low))
+            if any(n in words for n in negations):
+                return False
+            if not all(p.lower() in low for p in phrases):
+                return False
+            return all(t in words for t in terms)
+
+        hits = []
+        for mid, m in self._meetings.items():
+            if m["user_id"] != user_id:
+                continue          # owner-scoped, fail-closed — mirrors the adapter
+            if platform and m["platform"] != platform:
+                continue
+            if native_meeting_id and m["native_meeting_id"] != native_meeting_id:
+                continue
+            for seg in m["segments"].values():
+                text = seg.get("text") or ""
+                if not matches(text):
+                    continue
+                low = text.lower()
+                needle = (phrases + terms or [""])[0].lower()
+                i = low.find(needle)
+                snippet = text if i < 0 else (
+                    ("…" if i > 30 else "") + text[max(0, i - 30): i + len(needle) + 60] + "…"
+                )
+                hits.append({
+                    "segment_row_id": seg.get("segment_id"),
+                    # `meeting_db_id`, never `meeting_id`: the int row id must not travel under
+                    # the name that means the platform's STRING id everywhere else.
+                    "meeting_db_id": mid,
+                    "platform": m["platform"],
+                    "native_meeting_id": m["native_meeting_id"],
+                    "start": float(seg.get("start", 0.0)),
+                    "end": float(seg.get("end", 0.0)),
+                    "speaker": seg.get("speaker"),
+                    "language": seg.get("language"),
+                    # A flat count, NOT ts_rank_cd — enough to make ordering deterministic in a
+                    # test, not a claim about relevance.
+                    "rank": float(sum(low.count(t) for t in terms) + len(phrases)),
+                    "snippet": snippet,
+                    "text": text,
+                })
+        hits.sort(key=lambda h: (-h["rank"], -h["meeting_db_id"], h["start"]))
+        lim = max(1, min(int(limit or 20), 100))
+        off = max(0, int(offset or 0))
+        return hits[off:off + lim]
+
+    async def ensure_fts_index(self):
+        """No index to build without Postgres. The fake always answers 'search works anyway',
+        which is exactly the property that makes skipping the real build safe."""
+        return {"status": "skipped", "reason": "in-memory store"}
+
+    async def annotate_meeting(self, user_id, meeting_id, *, title=None, metadata=None):
+        """Caller-owned annotations on a row in ANY status — mirrors the adapter. No status check:
+        nothing written here is read by the dispatch pipeline, so there is no FSM to fight."""
+        m = self._meetings.get(meeting_id)
+        if m is None or m["user_id"] != user_id:
+            return None
+        data = m["data"]
+        # `title` lives in the data blob, NOT as a top-level field — mirrors the adapter and
+        # update_planned_meeting. Writing it anywhere else persists nothing.
+        if title is not None:
+            cleaned = (title or "").strip()[:512]
+            if cleaned:
+                data["title"] = cleaned
+            else:
+                data.pop("title", None)
+        if metadata is not None:
+            # ALWAYS a merge — mirrors the adapter. No whole-object replace exists, so a caller
+            # can never destroy a key it did not name.
+            current = data.get("metadata")
+            merged = dict(current) if isinstance(current, dict) else {}
+            for k, v in metadata.items():
+                if v is None:
+                    merged.pop(k, None)   # explicit null deletes exactly one key
+                else:
+                    merged[k] = v
+            # Bound the MERGED result, never the patch alone — mirrors the adapter. Checked
+            # BEFORE anything is stored, so a refusal writes nothing at all.
+            from .projection import check_metadata_bounds
+            reason = check_metadata_bounds(merged)
+            if reason:
+                return {"error": "metadata_too_large", "detail": reason}
+            data["metadata"] = merged
         return self._planned_row(meeting_id)
 
     async def update_planned_meeting(self, user_id, meeting_id, updates):
@@ -667,27 +803,64 @@ class InMemoryTranscriptStore:
             if sid:
                 m["segments"][sid] = dict(seg)
 
-    async def processed_view_cursor(self, meeting_id, view_id) -> Optional[str]:
-        from .adapters import _find_processed_view
+    async def complete_transcript_import(self, user_id, meeting_id, *, segments, started_at,
+                                        ended_at, source, session_uid):
+        """Mirror of the SqlAlchemy store's import — same owner scope, same idempotency on
+        ``session_uid``, same FSM refusal, same row shape afterwards. Most of the suite drives this
+        fake, so the two must agree on every branch a caller can observe."""
+        from datetime import datetime as _now_dt
+        from datetime import timezone
 
-        m = self._meetings.get(meeting_id)
-        if not m:
+        from .transcript_import import IN_FLIGHT_STATUSES
+
+        def _iso(dt):
+            return dt.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+        try:
+            mid = int(meeting_id)
+        except (TypeError, ValueError):
             return None
-        view = _find_processed_view(m["data"], view_id)
-        return view.get("source_cursor") if view else None
+        m = self._meetings.get(mid)
+        if m is None or m.get("user_id") != user_id:
+            return None  # owner-scoped: not-yours is indistinguishable from not-there
+        data = m["data"] if isinstance(m.get("data"), dict) else {}
+        prior = data.get("transcript_import")
+        if isinstance(prior, dict) and prior.get("session_uid") == session_uid:
+            return {
+                "meeting_id": mid, "imported": False, "status": m["status"],
+                "segments_imported": int(prior.get("segments") or 0),
+                "start_time": m["start_time"], "end_time": m["end_time"],
+                "session_uid": session_uid, "source": prior.get("source") or source,
+                "imported_at": prior.get("imported_at"),
+            }
+        if m["status"] in IN_FLIGHT_STATUSES:
+            return {"error": "conflict", "status": m["status"]}
 
-    async def merge_processed_view(
-        self, meeting_id, *, view_id, kind, notes, source_cursor, params=None,
-    ) -> None:
-        """Persist drained copilot notes into ``data['processed']['views']`` — the SAME pure
-        upsert the SqlAlchemy store commits (the versioned multi-view shape, merged by note id)."""
-        from .adapters import _upsert_processed_view
-
-        m = self._row_or_placeholder(meeting_id)
-        m["data"] = _upsert_processed_view(
-            m["data"], view_id=view_id, kind=kind, notes=notes,
-            source_cursor=source_cursor, params=params,
-        )
+        written = 0
+        for seg in segments:
+            sid = seg.get("segment_id")
+            if not sid:
+                continue
+            m["segments"][sid] = dict(seg)
+            written += 1
+        m["status"] = "completed"
+        m["start_time"] = _iso(started_at)
+        m["end_time"] = _iso(ended_at)
+        data["transcript_import"] = {
+            "source": source, "session_uid": session_uid, "segments": written,
+            "started_at": m["start_time"], "ended_at": m["end_time"],
+            "imported_at": _iso(_now_dt.now(timezone.utc)),
+        }
+        data["segments_captured"] = len(m["segments"])
+        m["data"] = data
+        return {
+            "meeting_id": mid, "imported": True, "status": "completed",
+            "segments_imported": written, "segments_captured": data["segments_captured"],
+            "start_time": m["start_time"], "end_time": m["end_time"],
+            "platform": m["platform"], "native_meeting_id": m["native_meeting_id"],
+            "session_uid": session_uid, "source": source,
+            "imported_at": data["transcript_import"]["imported_at"],
+        }
 
 
 class FakeRedisBus:

--- a/core/meetings/services/meeting-api/src/meeting_api/collector/ports.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/collector/ports.py
@@ -60,9 +60,15 @@ class TranscriptStore(Protocol):
         limit: Optional[int] = None,
         offset: Optional[int] = None,
         member_workspaces: "Optional[set[str]]" = None,
+        metadata_filter: "Optional[dict]" = None,
     ) -> list[dict]:
         """The user's meetings, newest first — a list of api.v1 ``MeetingResponse``-shaped dicts
-        (the body of ``MeetingListResponse``)."""
+        (the body of ``MeetingListResponse``).
+
+        ``metadata_filter`` selects rows whose ``data.metadata`` CONTAINS the given object (JSONB
+        ``@>``, served by ``ix_meeting_data_gin``). It is what turns the list from a log into a
+        queryable store: an agent that stamped ``{"crm_deal": "acme-42"}`` onto its meetings can
+        ask for exactly those back instead of paging the account and filtering client-side."""
         ...
 
     async def authorize_subscribe(
@@ -88,6 +94,37 @@ class TranscriptStore(Protocol):
     ) -> "Optional[dict]":
         """OWNER-scoped: mint an INDEPENDENT transcript share grant (``data.share_grants[]``, hash-at-rest).
         Returns {id, token, ...} once, or ``None`` when the user owns no such meeting."""
+        ...
+
+    async def mint_transcript_share_by_id(
+        self, user_id: int, meeting_id: int, *,
+        mode: str = "open", allowed_emails: "Optional[list]" = None, expires_in_sec: int = 86400,
+    ) -> "Optional[dict]":
+        """OWNER-scoped mint addressed by the ROW id — the identity a meeting always has. Same grant and
+        same one-time token as the pair-keyed mint; ``None`` when the row is unknown OR not the caller's."""
+        ...
+
+    async def complete_transcript_import(
+        self, user_id: int, meeting_id: int, *, segments: list, started_at, ended_at,
+        source: str, session_uid: str,
+    ) -> "Optional[dict]":
+        """OWNER-scoped: land an ALREADY-HAPPENED meeting's transcript on the row and complete it.
+
+        The import route's whole persistence. One transaction: the segments are upserted into
+        ``transcriptions`` through the SAME sink the db-writer flushes with (the ``(meeting_id,
+        segment_id)`` identity), the row's ``status`` becomes ``completed``, ``start_time`` /
+        ``end_time`` become the window the caller states (the ONE thing a bot run cannot express —
+        it derives both from ``now()``), and ``data.transcript_import`` records the provenance.
+
+        IDEMPOTENT on ``session_uid``, which the caller derives from ``(source, meeting_id)``: a
+        second import of the same source onto the same row writes NOTHING and reports
+        ``imported: False``. The segment ids are derived from the same ``session_uid``, so even a
+        write that did land twice would upsert in place rather than duplicate.
+
+        Returns the completed row summary, ``{"error": "conflict", ...}`` when the row is inside the
+        bot FSM (this never fights the FSM — a live meeting is completed by its bot, not by an
+        import), or ``None`` when the caller owns no such row (→ 404, no existence oracle).
+        """
         ...
 
     async def redeem_transcript_share(
@@ -235,6 +272,74 @@ class TranscriptStore(Protocol):
         ``auto_join_user_set``, ``calendar_managed``, ``scheduled_at`` or ``status``.
 
         Returns the row (``list_meetings`` shape), or ``None`` when the user owns no such row."""
+        ...
+
+    async def search_transcripts(
+        self,
+        user_id: int,
+        query: str,
+        *,
+        limit: int = 20,
+        offset: int = 0,
+        platform: Optional[str] = None,
+        native_meeting_id: Optional[str] = None,
+    ) -> list[dict]:
+        """Full-text search over the CALLER'S OWN transcript segments, ranked, with snippets.
+
+        Answers the question metadata cannot: not "meetings I tagged X" but "meetings where
+        someone SAID X". Without it the only way to answer that is to pull every transcript and
+        read it — precisely the thing an agent must not do.
+
+        Lexical, not semantic: Postgres FTS over ``to_tsvector('english', text)``. The query is
+        parsed with ``websearch_to_tsquery`` so a caller gets quoted phrases, ``or`` and ``-term``
+        negation for free, and — unlike ``to_tsquery`` — malformed input never raises. Ranked by
+        ``ts_rank_cd`` (cover density: term frequency weighted by proximity; NOT BM25 — no IDF, no
+        length normalisation). Each hit carries a ``ts_headline`` snippet rather than the whole
+        segment, which is what keeps a result cheap in a calling model's context.
+
+        ``'english'`` is the text-search config for BOTH indexing and querying, and it must stay
+        the same on both sides or the index goes unused. It is not an English-only decision:
+        English stemming leaves unknown tokens (e.g. Cyrillic) untouched, so non-English terms
+        still match EXACTLY — what is lost is stemming for those languages, while ``'simple'``
+        would have thrown away English stemming for everyone.
+
+        OWNER-SCOPED ONLY — fail-closed, and deliberately narrower than ``list_meetings``, which
+        also surfaces share-recipient and workspace-member rows. Widening search to those is a
+        separate decision with its own review; a search that over-returns is a disclosure.
+
+        Each hit: ``meeting_id`` · ``platform`` · ``native_meeting_id`` · ``start``/``end`` ·
+        ``speaker`` · ``language`` · ``rank`` · ``snippet`` · ``text``. Newest-meeting-first
+        within equal rank so a tie is deterministic."""
+        ...
+
+    async def annotate_meeting(
+        self, user_id: int, meeting_id: int, *,
+        title: Optional[str] = None,
+        metadata: "Optional[dict]" = None,
+    ) -> Optional[dict]:
+        """Attach the CALLER's own annotations to a row in ANY status — including one the bot FSM
+        owns, and including one already completed.
+
+        The sibling of ``attach_calendar_source`` (identity stamped onto a live row) rather than of
+        ``update_planned_meeting`` (which refuses an FSM row, because dispatch parameters must not
+        change under a running bot). The distinction is what is being written, not when:
+        ``update_planned_meeting`` edits the INSTRUCTIONS for a meeting — url, schedule, auto-join
+        — and changing those mid-flight fights the FSM. ``title`` and ``metadata`` are the caller's
+        DESCRIPTION of a meeting. Nothing in the pipeline reads them, so writing them can never
+        re-arm, re-dispatch or re-route anything — and the moments a description is most worth
+        writing are exactly the ones the FSM owns: mid-meeting, and after it ends.
+
+        ``metadata`` is arbitrary caller-owned JSON stored at ``data.metadata``. It ALWAYS merges
+        key-wise; a key set to ``None`` deletes that one key. There is deliberately NO whole-object
+        replace: every writer shares one API key, so a replace would let a caller destroy keys
+        written by another agent — or by the human — that it never saw. Merge plus explicit nulls
+        expresses every legitimate edit while making it impossible to affect a key you did not
+        name. It is the join key between a Vexa meeting and everything else the caller knows —
+        a CRM record, a ticket, its own summary — and it is queryable through
+        ``list_meetings(metadata_filter=...)``.
+
+        Returns the updated row (``list_meetings`` shape), or ``None`` when the user owns no such
+        row (→ 404). Never returns a conflict: there is no state in which annotating is refused."""
         ...
 
     async def delete_planned_meeting(self, user_id: int, meeting_id: int) -> Optional[bool]:

--- a/core/meetings/services/meeting-api/src/meeting_api/collector/projection.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/collector/projection.py
@@ -41,6 +41,8 @@ two tiers of response omissions, and the default page size that bounds an otherw
 """
 from __future__ import annotations
 
+import json
+
 from typing import Any, Dict, Optional
 
 # Heavy per-meeting ``data`` keys the list NEVER renders — dropped from list rows. Everything else
@@ -290,3 +292,42 @@ def project_list_data(
     if isinstance(sources, list):
         projected["calendar_sources"] = sources
     return projected
+
+
+# --- caller-supplied metadata: bounds -------------------------------------------------------
+# Arbitrary caller JSON, persisted to a JSONB column, GIN-indexed on write, and echoed in EVERY
+# list response. Unbounded, one caller's junk becomes everyone's cost forever. Measured on the
+# dogfood stack before these caps existed: a 10 MB value was accepted in 3s, after which
+# `GET /meetings` returned 10.3 MB on every call — and an MCP client feeds that straight into a
+# model's context window, so the read side is the real blast radius, not the disk.
+#
+# The bounds are checked against the MERGED result, never the patch alone: a cap on each write is
+# not a cap at all when writes merge (100 calls of 15 KB is 1.5 MB).
+#
+# 16 KB is generous for what this field is FOR — join keys, tags, an agent's own short summary.
+# Anything larger is a document, and a document belongs behind a link the metadata points at.
+_MAX_METADATA_BYTES = 16 * 1024
+_MAX_METADATA_KEYS = 64
+_MAX_METADATA_KEY_CHARS = 128
+
+
+def check_metadata_bounds(merged: dict) -> Optional[str]:
+    """Return a human-readable reason the merged metadata is out of bounds, or None if it fits."""
+    if len(merged) > _MAX_METADATA_KEYS:
+        return f"too many metadata keys: {len(merged)} (max {_MAX_METADATA_KEYS})"
+    for key in merged:
+        if len(str(key)) > _MAX_METADATA_KEY_CHARS:
+            return (
+                f"metadata key too long: {len(str(key))} chars "
+                f"(max {_MAX_METADATA_KEY_CHARS}) — {str(key)[:40]}…"
+            )
+    try:
+        size = len(json.dumps(merged).encode("utf-8"))
+    except (TypeError, ValueError):
+        return "metadata must be JSON-serializable"
+    if size > _MAX_METADATA_BYTES:
+        return (
+            f"metadata too large: {size} bytes after merge (max {_MAX_METADATA_BYTES}). "
+            "Store large content elsewhere and put a reference here."
+        )
+    return None

--- a/core/meetings/services/meeting-api/src/meeting_api/collector/transcript_import.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/collector/transcript_import.py
@@ -1,0 +1,167 @@
+"""Transcript IMPORT — the pure half of "this meeting already happened, here are its words".
+
+The product feature is *bring a transcript Vexa did not record* (a Zoom export, an LFX/TSC
+recording, minutes from a call nobody sent a bot to) into a meeting row, so everything
+downstream — the canvas, ``GET /transcripts/by-id/{id}``, search, the post-meeting flows — sees
+it exactly as it sees a recorded one. The capture double the rehearsal rig runs is the SAME
+feature with ``source='seed'``; that is why there is one route and not two.
+
+Everything here is pure: parse, validate, derive. The persistence lives in the store
+(``TranscriptStore.complete_transcript_import``) — this module is imported by the route, by both
+store implementations, and by the tests, so the identity of an import has ONE definition.
+
+**The identity of an import is ``(source, meeting_id)``.** That derives the ``session_uid``, which
+derives every segment id. A bot run's session uid is a uuid4 minted per spawn — right for a run
+that could happen twice, wrong here: importing the same source into the same meeting a second time
+is the SAME import, not a second one. Deriving rather than minting is what makes the route
+idempotent at the row AND at the segment (a re-write upserts on ``(meeting_id, segment_id)``
+instead of doubling the transcript, which is what a hand-rolled ``INSERT … ON CONFLICT DO
+NOTHING`` with a fresh uuid could never guarantee).
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+
+# The declared origins of an import. ``import`` is a person bringing a transcript from elsewhere;
+# ``seed`` is the rehearsal rig's capture double. They differ ONLY in the provenance recorded on
+# the row — a reader can always tell a double from a real import, which is the whole point of
+# naming the source rather than letting the double pretend to be a recording.
+SOURCES = frozenset({"import", "seed"})
+
+# A cap, refused rather than truncated: silently storing part of what a caller sent is a worse
+# failure than telling them it did not fit (the same rule `annotate_meeting` applies to metadata).
+MAX_SEGMENTS = 20000
+MAX_TEXT = 8000
+
+
+def session_uid_for(source: str, meeting_id: int) -> str:
+    """The import's session identity — DERIVED, never minted. See the module docstring."""
+    return f"import-{source}-{int(meeting_id)}"
+
+
+def segment_id_for(session_uid: str, index: int) -> str:
+    """The segment identity the ``(meeting_id, segment_id)`` upsert keys on. Positional inside the
+    import, so re-importing a corrected transcript UPDATES each segment in place."""
+    return f"{session_uid}-{index:06d}"
+
+
+def parse_instant(raw) -> Optional[datetime]:
+    """ISO-8601 (``Z`` accepted) or epoch seconds → an aware UTC datetime. ``None`` when neither.
+
+    Both shapes because the two callers already speak both: a calendar/export stamp is ISO, a
+    recording tool's is epoch. Refusing one of them would just move the conversion into every
+    caller, where it would be written slightly differently each time.
+    """
+    if raw is None:
+        return None
+    if isinstance(raw, (int, float)) and not isinstance(raw, bool):
+        try:
+            return datetime.fromtimestamp(float(raw), timezone.utc)
+        except (OverflowError, OSError, ValueError):
+            return None
+    if not isinstance(raw, str):
+        return None
+    s = raw.strip()
+    if not s:
+        return None
+    try:
+        if s.replace(".", "", 1).lstrip("-").isdigit():
+            return datetime.fromtimestamp(float(s), timezone.utc)
+        dt = datetime.fromisoformat(s.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    return (dt.replace(tzinfo=timezone.utc) if dt.tzinfo is None else dt).astimezone(timezone.utc)
+
+
+def normalize_segments(raw, session_uid: str) -> "tuple[Optional[list], Optional[str]]":
+    """``[{start, end, speaker, text, language?}, …]`` → the store's segment shape, or an error.
+
+    Returns ``(segments, None)`` or ``(None, reason)``. The reason is returned rather than raised
+    so the route decides the status code and the tests can assert the sentence a caller reads.
+
+    Deliberately STRICTER than the live-stream coercion in ``ingest._coerce_segment``: that one
+    drops a malformed segment and keeps the stream flowing, because a live meeting must not stop
+    for one bad frame. An import is a single, whole artifact a person handed us — dropping part of
+    it silently would hand them back a transcript with holes they cannot see. So one bad segment
+    refuses the whole import and names its index.
+    """
+    if not isinstance(raw, list) or not raw:
+        return None, "'segments' must be a non-empty array"
+    if len(raw) > MAX_SEGMENTS:
+        return None, f"'segments' exceeds the {MAX_SEGMENTS}-segment cap ({len(raw)} sent)"
+    out = []
+    for i, seg in enumerate(raw):
+        if not isinstance(seg, dict):
+            return None, f"segment {i}: must be an object"
+        try:
+            start = float(seg.get("start"))
+            end = float(seg.get("end", seg.get("start")))
+        except (TypeError, ValueError):
+            return None, f"segment {i}: 'start' and 'end' must be numbers (seconds from the start)"
+        if start < 0 or end < 0:
+            return None, f"segment {i}: 'start' and 'end' are seconds from the start, never negative"
+        if end < start:
+            start, end = end, start
+        text = seg.get("text")
+        if text is not None and not isinstance(text, str):
+            return None, f"segment {i}: 'text' must be a string"
+        text = (text or "").strip()
+        if len(text) > MAX_TEXT:
+            return None, f"segment {i}: 'text' exceeds {MAX_TEXT} characters"
+        speaker = seg.get("speaker")
+        if speaker is not None and not isinstance(speaker, str):
+            return None, f"segment {i}: 'speaker' must be a string"
+        language = seg.get("language")
+        if language is not None and not isinstance(language, str):
+            return None, f"segment {i}: 'language' must be a string"
+        out.append({
+            "segment_id": segment_id_for(session_uid, i),
+            "session_uid": session_uid,
+            "start": start,
+            "end": end,
+            "text": text,
+            "speaker": (speaker or None),
+            "language": (language or None),
+            "completed": True,
+        })
+    return out, None
+
+
+def occurrence_window(
+    segments: list, started_at, ended_at,
+) -> "tuple[Optional[datetime], Optional[datetime], Optional[str]]":
+    """The meeting's real occurrence window: ``(start, end, None)`` or ``(None, None, reason)``.
+
+    ``started_at`` is REQUIRED and is the single fact an import carries that a bot run cannot: a
+    run's ``start_time``/``end_time`` are stamped from ``now()`` at the FSM's transitions, so a
+    meeting that happened last Tuesday is not expressible through the bot path at all. That is
+    exactly why the rehearsal rig used to reach past the service and ``UPDATE meetings`` by hand.
+
+    ``ended_at`` is optional: absent, the end is the start plus the transcript's own length (the
+    last segment's ``end`` is seconds from the start of the capture, so it IS the duration). An
+    ``ended_at`` BEFORE the start is refused rather than swapped — an inverted window is a caller
+    bug, and silently reordering it would seed the meeting at a time nobody asked for.
+    """
+    start = parse_instant(started_at)
+    if start is None:
+        return None, None, "'started_at' is required — ISO-8601 or epoch seconds"
+    duration = max((float(s["end"]) for s in segments), default=0.0)
+    end = parse_instant(ended_at)
+    if ended_at not in (None, "") and end is None:
+        return None, None, "'ended_at' is neither ISO-8601 nor epoch seconds"
+    if end is None:
+        end = start + timedelta(seconds=duration)
+    if end < start:
+        return None, None, "'ended_at' is before 'started_at'"
+    return start, end, None
+
+
+# The statuses that mean a BOT IS IN FLIGHT on this row. An import is refused on all of them: the
+# FSM is never fought (`update_planned_meeting` refuses for the same reason), and a transcript
+# landing under a running bot would interleave two capture sources on one meeting. Terminal
+# (`completed`/`failed`) is NOT here — a finished row may be re-imported (idempotently), and the
+# intent statuses (`idle`/`scheduled`) are the normal case: a planned row that has now happened.
+IN_FLIGHT_STATUSES = frozenset({
+    "requested", "joining", "awaiting_admission", "needs_help", "active", "stopping",
+})

--- a/core/meetings/services/meeting-api/tests/test_bot_spawn.py
+++ b/core/meetings/services/meeting-api/tests/test_bot_spawn.py
@@ -165,6 +165,35 @@ async def test_request_bot_eager_creates_session_and_spawns(monkeypatch):
     assert repo.sessions[0]["session_uid"] == spawned["connectionId"]
 
 
+async def test_fresh_spawn_purges_transcript_stream_but_continue_does_not(monkeypatch):
+    """A FRESH meeting must start on an EMPTY transcript stream, so a reused row id (e.g. after a DB
+    id-sequence reset without a redis flush) can't carry a prior generation's session_end → the
+    terminal showing "Meeting ended" before the first word. The injected purge fires with the new row
+    id on a fresh insert, and NOT on continue_meeting (which intentionally keeps the reused stream)."""
+    monkeypatch.setenv("TRANSCRIPTION_SERVICE_URL", "https://stt.vexa.ai")
+    monkeypatch.setenv("TRANSCRIPTION_SERVICE_TOKEN", "tok-test")
+    repo, runtime = InMemoryMeetingRepo(), FakeRuntimeClient()
+    purged: list[int] = []
+
+    async def _purge(mid):
+        purged.append(mid)
+
+    kw = dict(redis_url="r", token_secret=SECRET, meeting_api_url="http://meeting-api:8080",
+              transcript_stream_purge=_purge)
+
+    first = await request_bot(repo, runtime, user_id=USER, platform="google_meet",
+                              native_meeting_id="abc-defg-hij", **kw)
+    assert purged == [first["id"]]            # fresh insert → the NEW row's stream is purged
+
+    # the meeting completes; a CONTINUED bot reuses the SAME row and must NOT purge (keeps continuity)
+    repo.set_status(first["id"], "completed")
+    purged.clear()
+    second = await request_bot(repo, runtime, user_id=USER, platform="google_meet",
+                               native_meeting_id="abc-defg-hij", continue_meeting=True, **kw)
+    assert second["id"] == first["id"]
+    assert purged == []                       # continue_meeting KEEPS the reused row's stream
+
+
 def test_iso_utc_marks_naive_utc_with_z():
     # Meeting time columns are naive but hold UTC. Serializing must emit a Z marker so a browser
     # parses it as UTC and renders local — a bare isoformat is read as LOCAL (the 6h-skew bug).

--- a/core/meetings/services/meeting-api/tests/test_db_writer.py
+++ b/core/meetings/services/meeting-api/tests/test_db_writer.py
@@ -11,9 +11,12 @@ the redis-wired in-memory store mirroring the prod topology — no docker):
   * the FLIPPED INCIDENT — redis wiped after a flush ⇒ GET /transcripts still serves from durable;
   * parent semantics — the mutable tail (young ``updated_at``) stays in redis; empty text is
     dropped not stored; a failed durable write leaves the hash INTACT (trim-after-confirm);
-  * completion finalization — the lifecycle callback's terminal advance flushes EVERYTHING left;
-  * processed-doc durability — ``proc:meeting:{row_id}`` notes persist into ``data['processed']``,
-    and a SECOND meeting on the same native link never clobbers the first row's persisted doc.
+  * completion finalization — the lifecycle callback's terminal advance flushes EVERYTHING left.
+
+A whole section used to sit beside these: the processed-doc drain — ``proc:meeting:{row_id}``
+notes into ``data['processed']``, its ``view_end`` end-of-processing protocol and the bounded
+``processed_pending`` re-drain. PRD decision 34 removed the producer of that stream, so there is
+one body of a transcript and one drain to prove.
 """
 from __future__ import annotations
 
@@ -27,13 +30,9 @@ from fastapi.testclient import TestClient
 from meeting_api.collector import consume_segments
 from meeting_api.collector.db_writer import (
     ACTIVE_MEETINGS_KEY,
-    PROC_PENDING_KEY,
-    PROC_VIEW_ID,
     db_writer_tick,
     finalize_meeting,
-    flush_meeting_processed,
     flush_meeting_segments,
-    proc_stream_key,
     segments_hash_key,
 )
 from meeting_api.collector.fakes import FakeRedisBus, InMemoryTranscriptStore
@@ -358,145 +357,6 @@ async def test_nonterminal_advance_does_not_finalize(redis_c, goldens):
     assert await redis_c.hlen(segments_hash_key(1)) == 1
 
 
-# ── (d) processed-doc durability + the re-send clobber fix ──────────────────────────────────────
-
-def _note(nid: str, text: str) -> dict:
-    return {"id": nid, "speaker": "Alice", "text": text}
-
-
-def _view(store, meeting_id: int, view_id: str = PROC_VIEW_ID) -> dict:
-    """The persisted processed VIEW — data.processed.views[] upserted by id (the addressable,
-    versioned multi-consumer shape the release DoD rules)."""
-    views = store._meetings[meeting_id]["data"]["processed"]["views"]
-    return next(v for v in views if v["id"] == view_id)
-
-
-async def test_processed_doc_persists_into_meeting_data_as_versioned_view(store, redis_c):
-    params = {"provider": "anthropic", "model": "claude-x", "pipeline": "meeting-copilot/proc-notes", "version": 1}
-    await redis_c.xadd(proc_stream_key(1), {"note": json.dumps(_note("s1", "Cleaned one.")),
-                                            "params": json.dumps(params)})
-    await redis_c.xadd(proc_stream_key(1), {"note": json.dumps(_note("s2", "Cleaned two.")),
-                                            "params": json.dumps(params)})
-
-    assert await flush_meeting_processed(redis_c, store, 1) == 2
-    view = _view(store, 1)
-    assert view["kind"] == "cleaned_transcript"
-    assert [n["text"] for n in view["doc"]["notes"]] == ["Cleaned one.", "Cleaned two."]
-    assert view["params"] == params        # the processing metadata APPLIED — reproducibility
-    assert view["source_cursor"]           # the stream position this view reflects
-    assert view["updated_at"]
-
-    # Cursor resume: nothing new ⇒ nothing re-merged; a refining re-emit UPDATES in place.
-    assert await flush_meeting_processed(redis_c, store, 1) == 0
-    await redis_c.xadd(proc_stream_key(1), {"note": json.dumps(_note("s2", "Cleaned two, better."))})
-    assert await flush_meeting_processed(redis_c, store, 1) == 1
-    view = _view(store, 1)
-    assert [n["text"] for n in view["doc"]["notes"]] == ["Cleaned one.", "Cleaned two, better."]
-    assert view["params"] == params        # a params-less drain never erases provenance
-
-
-async def test_processed_views_are_multi_consumer_other_views_preserved(store, redis_c):
-    """The views LIST is the multi-consumer seam: a future per-workspace/other processing's view
-    must survive the copilot view's upsert untouched."""
-    other = {"id": "ws-team:summary", "kind": "summary", "params": {"model": "m"},
-             "doc": {"text": "…"}, "source_cursor": "9-0", "updated_at": "2026-06-20T09:00:00Z"}
-    store._meetings[1]["data"]["processed"] = {"views": [dict(other)]}
-    await redis_c.xadd(proc_stream_key(1), {"note": json.dumps(_note("s1", "Copilot note."))})
-
-    await flush_meeting_processed(redis_c, store, 1)
-    views = store._meetings[1]["data"]["processed"]["views"]
-    assert [v["id"] for v in views] == ["ws-team:summary", PROC_VIEW_ID]
-    assert views[0] == other  # untouched
-
-
-async def test_second_meeting_on_same_native_does_not_clobber_first_processed_doc(redis_c):
-    """The clobber defect: proc docs were keyed by the NATIVE id, which a re-sent bot REUSES —
-    meeting 2's copilot output landed on meeting 1's doc. Keyed by the ROW id and persisted per
-    row, each meeting keeps its own processed doc across completion and a re-send."""
-    store = InMemoryTranscriptStore(redis_client=redis_c)
-    store.seed_meeting(user_id=USER, platform="google_meet", native_meeting_id=NATIVE, meeting_id=1,
-                       created_at="2026-06-20T08:59:00Z")
-    await redis_c.xadd(proc_stream_key(1), {"note": json.dumps(_note("a1", "First meeting note."))})
-    await finalize_meeting(redis_c, store, 1)  # meeting 1 completes; its doc is durable
-
-    # The bot is RE-SENT to the same native link → a NEW meeting row (id 2), its own proc stream.
-    store.seed_meeting(user_id=USER, platform="google_meet", native_meeting_id=NATIVE, meeting_id=2,
-                       created_at="2026-06-20T10:00:00Z")
-    await redis_c.xadd(proc_stream_key(2), {"note": json.dumps(_note("b1", "Second meeting note."))})
-    await finalize_meeting(redis_c, store, 2)
-
-    first = _view(store, 1)["doc"]["notes"]
-    second = _view(store, 2)["doc"]["notes"]
-    assert [n["text"] for n in first] == ["First meeting note."]    # SURVIVED the re-send
-    assert [n["text"] for n in second] == ["Second meeting note."]
-
-
-async def test_db_writer_tick_also_drains_processed_notes(store, bus, redis_c):
-    """The periodic tick persists the processed doc for ACTIVE meetings too (not only at
-    completion) — a crash mid-meeting keeps everything cleaned so far."""
-    await bus.xadd("transcription_segments", json.loads(_message(1, [_seg("s1", 1.0, "raw")])["payload"]))
-    await consume_segments(store, bus)  # puts meeting 1 in active_meetings
-    await redis_c.xadd(proc_stream_key(1), {"note": json.dumps(_note("s1", "Cleaned mid-meeting."))})
-
-    await db_writer_tick(redis_c, store, now=LATER)
-    assert [n["text"] for n in _view(store, 1)["doc"]["notes"]] == ["Cleaned mid-meeting."]
-
-
-# ── the end-of-processing protocol (ADR 0027 / processed-notes.v1 view_end) ─────────────────────
-# The copilot's final beat lands ~10s AFTER session_end, i.e. AFTER finalize_meeting's inline drain
-# — and the meeting then leaves the tick's sweep, so those notes were stranded in redis forever
-# (run-46: durable cursor froze below the stream tail). The protocol: finalize PARKS an
-# incomplete meeting in `processed_pending`; the tick re-drains it until the worker's `view_end`
-# marker is drained-through (or a bounded deadline passes — the dead-worker guarantee).
-
-async def _pending_ids(redis_c):
-    return [m.decode() if isinstance(m, bytes) else m
-            for m in await redis_c.zrange(PROC_PENDING_KEY, 0, -1)]
-
-
-async def test_late_final_beat_notes_land_after_finalize_via_view_end(store, redis_c):
-    """The run-46 regression: notes written AFTER the completion flush reach the durable row on the
-    next tick, and the parking clears exactly when the view_end marker is drained-through."""
-    await redis_c.xadd(proc_stream_key(1), {"note": json.dumps(_note("s1", "Mid-meeting note."))})
-    await finalize_meeting(redis_c, store, 1)
-    assert [n["text"] for n in _view(store, 1)["doc"]["notes"]] == ["Mid-meeting note."]
-    assert await _pending_ids(redis_c) == ["1"]        # no marker yet → parked, not forgotten
-
-    # The final post-session_end beat lands AFTER the finalize drain — then the marker.
-    await redis_c.xadd(proc_stream_key(1), {"note": json.dumps(_note("s1", "Final polished note."))})
-    marker_id = await redis_c.xadd(proc_stream_key(1), {"type": "view_end", "cursor": "9-0"})
-
-    await db_writer_tick(redis_c, store, now=LATER)
-    view = _view(store, 1)
-    assert [n["text"] for n in view["doc"]["notes"]] == ["Final polished note."]  # upgraded in place
-    assert view["source_cursor"] == (marker_id.decode() if isinstance(marker_id, bytes) else marker_id)
-    assert await _pending_ids(redis_c) == []           # drained-through the marker → unparked
-
-
-async def test_finalize_already_marker_complete_does_not_park(store, redis_c):
-    """A worker that finished BEFORE the terminal callback (marker already on the stream): the
-    finalize drain goes through the marker in one pass — nothing parks."""
-    await redis_c.xadd(proc_stream_key(1), {"note": json.dumps(_note("s1", "Done early."))})
-    await redis_c.xadd(proc_stream_key(1), {"type": "view_end"})
-
-    await finalize_meeting(redis_c, store, 1)
-    assert [n["text"] for n in _view(store, 1)["doc"]["notes"]] == ["Done early."]
-    assert await _pending_ids(redis_c) == []
-
-
-async def test_pending_redrain_gives_up_at_deadline_keeping_what_arrived(store, redis_c):
-    """A worker that died markerless: the parking expires at its deadline (bounded, P22's hard
-    guarantee) — everything that DID arrive is durable, the zset never grows unbounded."""
-    await redis_c.xadd(proc_stream_key(1), {"note": json.dumps(_note("s1", "Only note."))})
-    await finalize_meeting(redis_c, store, 1)
-    assert await _pending_ids(redis_c) == ["1"]
-
-    past_deadline = datetime.now(timezone.utc) + timedelta(seconds=600)  # > PROC_PENDING_GRACE_SEC
-    await db_writer_tick(redis_c, store, now=past_deadline)
-    assert await _pending_ids(redis_c) == []                             # gave up, loudly (logged)
-    assert [n["text"] for n in _view(store, 1)["doc"]["notes"]] == ["Only note."]  # kept
-
-
 # ── the REST surface, during AND after (DoD 8): api.v1 responses, both phases ───────────────────
 
 def _rest(store):
@@ -527,18 +387,19 @@ async def test_rest_mid_meeting_serves_merged_postgres_plus_redis_tail(store, bu
     assert_api_conforms("TranscriptionResponse", body)
 
 
-async def test_rest_after_completion_with_redis_wiped_serves_transcript_and_processed_view(redis_c, goldens):
-    """AFTER the meeting — the observed defects, both: stop the bot, redis evicted ⇒ (pre-fix) the
-    transcript read EMPTY and the processed output was UNREACHABLE. Post-fix: completion finalizes
-    both into postgres (meeting.data JSONB), and GET /transcripts serves the full transcript AND the
-    processed view from the durable row alone — conformant to the sealed api.v1 shape."""
+async def test_rest_after_completion_with_redis_wiped_serves_the_transcript(redis_c, goldens):
+    """AFTER the meeting — the observed defect: stop the bot, redis evicted ⇒ (pre-fix) the
+    transcript read EMPTY. Post-fix: completion finalizes it into postgres and GET /transcripts
+    serves the full transcript from the durable row alone — conformant to the sealed api.v1 shape.
+
+    It also used to assert a second body on the same response: ``data.processed.views[]``, the
+    copilot's cleaned view. PRD decision 34 removed the producer; a legacy row may still carry the
+    key (the free-form ``data`` field is unchanged), but nothing writes or reads one."""
     from collector_contracts import assert_api_conforms
 
     client, store = await _terminal_app_and_stores(redis_c)
     await store.append_segment(1, {**_seg("s1", 1.0, "closing words"),
                                    "updated_at": datetime.now(timezone.utc).isoformat()})
-    await redis_c.xadd(proc_stream_key(1), {"note": json.dumps(_note("s1", "Closing words, cleaned.")),
-                                            "params": json.dumps({"model": "claude-x"})})
 
     for case in ("joining", "active", "completed-stopped"):
         assert client.post("/bots/internal/callback/lifecycle", json=goldens[case]).status_code == 200
@@ -549,8 +410,5 @@ async def test_rest_after_completion_with_redis_wiped_serves_transcript_and_proc
     assert r.status_code == 200
     body = r.json()
     assert [s["text"] for s in body["segments"]] == ["closing words"]
-    views = body["data"]["processed"]["views"]  # rides the existing free-form data field — no new surface
-    assert views[0]["id"] == PROC_VIEW_ID and views[0]["kind"] == "cleaned_transcript"
-    assert [n["text"] for n in views[0]["doc"]["notes"]] == ["Closing words, cleaned."]
-    assert views[0]["params"] == {"model": "claude-x"}
+    assert not (body.get("data") or {}).get("processed")
     assert_api_conforms("TranscriptionResponse", body)

--- a/core/meetings/services/meeting-api/tests/test_identity_vocabulary.py
+++ b/core/meetings/services/meeting-api/tests/test_identity_vocabulary.py
@@ -1,0 +1,138 @@
+"""THE GATE, response side — no route may EMIT a retired identity name.
+
+meeting-api owns the response shapes the MCP tools forward verbatim, so this is where the
+regression actually lived: ``search_transcripts`` selected ``t.meeting_id AS meeting_id``, putting
+the INTEGER row id under the name three other tools use for the NATIVE STRING id. Feeding that
+tool's own output into ``get_meeting_transcript`` produced ``404 … and ID 1``.
+
+It was the second occurrence of that defect class in one day, by the same author, with the rule
+written down in between — so it is asserted here rather than remembered.
+
+The vocabulary MIRRORS ``vexa_mcp.identity`` (the input-side gate lives there, against the MCP
+tool schemas). The two services have separate dependency trees and cannot import each other, so
+this is a deliberate mirror in the same style as the ``sessions/models.py`` ↔ admin-api schema
+mirror. If you change one, change both — and the constants below are tiny precisely so that stays
+cheap.
+"""
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from meeting_api.collector import create_app
+from meeting_api.collector.fakes import InMemoryTranscriptStore
+
+#: MIRROR of vexa_mcp.identity.CANONICAL_IDENTITY — concept -> the kind of value it always holds.
+CANONICAL_IDENTITY = {"platform": str, "native_meeting_id": str, "meeting_db_id": int}
+#: MIRROR of vexa_mcp.identity.DEPRECATED_ALIASES — retired name -> replacement. Never emitted.
+DEPRECATED_ALIASES = {"meeting_id": "native_meeting_id", "meeting_platform": "platform"}
+
+USER = 7
+H = {"x-user-id": str(USER)}
+PLAT, NID = "google_meet", "abc-defg-hij"
+
+
+class _NullRedis:
+    async def publish(self, channel, data):
+        return None
+
+
+def emitted_violations(where: str, payload, *, path: str = "") -> list[str]:
+    """Every retired name, and every canonical name carrying the wrong kind of value."""
+    out: list[str] = []
+    if isinstance(payload, list):
+        for item in payload[:5]:
+            out += emitted_violations(where, item, path=f"{path}[]")
+        return out
+    if not isinstance(payload, dict):
+        return out
+    for key, value in payload.items():
+        here = f"{path}.{key}" if path else key
+        if key in DEPRECATED_ALIASES:
+            out.append(f"{where}: emits `{here}` (retired; use `{DEPRECATED_ALIASES[key]}`)")
+        elif key in CANONICAL_IDENTITY and value is not None:
+            want = CANONICAL_IDENTITY[key]
+            if want is int and (not isinstance(value, int) or isinstance(value, bool)):
+                out.append(f"{where}: `{here}` should be an int, got {value!r}")
+            if want is str and not isinstance(value, str):
+                out.append(f"{where}: `{here}` should be a string, got {value!r}")
+        out += emitted_violations(where, value, path=here)
+    return out
+
+
+def _client():
+    store = InMemoryTranscriptStore()
+    store.seed_meeting(
+        user_id=USER, platform=PLAT, native_meeting_id=NID, meeting_id=1, status="completed",
+        segments=[{"segment_id": "s1", "start": 0.0, "end": 2.0,
+                   "text": "take the back of the panel", "speaker": "Dmitriy", "language": "en"}],
+    )
+    return TestClient(create_app(store, redis=_NullRedis()))
+
+
+# ---- the gate ---------------------------------------------------------------------------
+
+def test_no_route_emits_a_retired_identity_name():
+    """Drives every identity-bearing read route and inspects what it actually returns."""
+    client = _client()
+    checked = 0
+    for label, path, params in [
+        ("GET /meetings", "/meetings", {}),
+        ("GET /transcripts/search", "/transcripts/search", {"q": "panel"}),
+        ("GET /transcripts/{platform}/{native}", f"/transcripts/{PLAT}/{NID}", {}),
+        ("GET /transcripts/by-id", "/transcripts/by-id/1", {}),
+    ]:
+        r = client.get(path, params=params, headers=H)
+        if r.status_code != 200:
+            continue
+        checked += 1
+        violations = emitted_violations(label, r.json())
+        assert not violations, (
+            "A route EMITS a retired identity name — the defect that shipped twice:\n  - "
+            + "\n  - ".join(violations)
+            + "\n\nOutputs are what a caller builds the NEXT call from, so an ambiguous output "
+              "name is the bug: it turns 'feed one tool's output into the next' into a 404."
+        )
+    assert checked >= 3, "too few routes exercised for this gate to mean anything"
+
+
+def test_search_hits_carry_the_names_the_next_call_needs():
+    """The composability promise, made concrete: a search hit must be feedable straight into the
+    transcript route without renaming anything."""
+    client = _client()
+    hits = client.get("/transcripts/search", params={"q": "panel"}, headers=H).json()["hits"]
+    assert hits, "fixture produced no hits; the rest of this test would be vacuous"
+    hit = hits[0]
+    assert "platform" in hit and "native_meeting_id" in hit
+    # The actual round trip — this is what 404'd before.
+    r = client.get(f"/transcripts/{hit['platform']}/{hit['native_meeting_id']}", headers=H)
+    assert r.status_code == 200, (
+        f"a search hit could not be fed into the transcript route: {r.status_code} {r.text[:200]}"
+    )
+
+
+def test_the_integer_row_id_is_never_called_meeting_id():
+    """Specifically pins the regression: the int row id travels as `meeting_db_id`, never under
+    the name that means the platform's string id elsewhere."""
+    client = _client()
+    hit = client.get("/transcripts/search", params={"q": "panel"}, headers=H).json()["hits"][0]
+    assert "meeting_id" not in hit
+    assert isinstance(hit.get("meeting_db_id"), int)
+    assert isinstance(hit.get("native_meeting_id"), str)
+
+
+# ---- guards on the checker itself --------------------------------------------------------
+
+def test_the_checker_catches_the_exact_regression():
+    """A gate that only ever passes proves nothing. This is the shape that shipped."""
+    assert emitted_violations("x", {"hits": [{"meeting_id": 1}]})
+    assert emitted_violations("x", {"meeting_platform": "zoom"})
+    assert emitted_violations("x", {"native_meeting_id": 7})      # right name, wrong kind
+    assert emitted_violations("x", {"meeting_db_id": "abc-defg"})  # right name, wrong kind
+    assert emitted_violations("x", [{"nested": {"meeting_id": 2}}])
+
+
+def test_the_checker_passes_a_clean_payload():
+    assert emitted_violations("x", {
+        "platform": "google_meet", "native_meeting_id": "abc-defg-hij",
+        "meeting_db_id": 1, "speaker": "Dmitriy",
+    }) == []

--- a/core/meetings/services/meeting-api/tests/test_lifecycle_seam.py
+++ b/core/meetings/services/meeting-api/tests/test_lifecycle_seam.py
@@ -1219,7 +1219,12 @@ def test_non_terminal_advance_does_not_emit_session_end():
     _post(client, connection_id="sess-uid", status="active")
 
     stream = f"tc:meeting:{m['id']}"
-    assert stream not in redis.streams, "session_end emitted while the meeting is still live"
+    # A non-terminal advance must NOT emit session_end (that would end the live view). It DOES write a
+    # session_start marker on `active` — the signal the terminal SSE uses to clear a prior session's
+    # stale session_end when a re-sent bot reuses this meeting row.
+    entries = redis.streams.get(stream, [])
+    assert not any(p.get("type") == "session_end" for p in entries), "session_end emitted while the meeting is still live"
+    assert any(p.get("type") == "session_start" for p in entries), "session_start marker not emitted on active"
     assert "tc:meeting:m1" not in redis.streams
 
 

--- a/core/meetings/services/meeting-api/tests/test_meeting_annotate.py
+++ b/core/meetings/services/meeting-api/tests/test_meeting_annotate.py
@@ -1,0 +1,266 @@
+"""POST /meetings/{platform}/{native_meeting_id}/annotate — the caller's OWN description.
+
+`title` and arbitrary `metadata`, writable in ANY status. This is the surface that makes a Vexa
+meeting joinable to everything else the caller knows: a CRM id, a ticket, tags, an agent's own
+summary. It is REST-first — the MCP tool is a thin wrapper over exactly these routes, so anything
+proven here holds for curl, the SDKs and any MCP client alike.
+
+The split against PATCH /meetings/{platform}/{native} is by WHAT is written, not when. PATCH edits
+the INSTRUCTIONS for a meeting (url, schedule, auto-join) and is refused once the FSM owns the row.
+Annotations are read by nothing in the dispatch pipeline, so writing them can never re-arm or
+re-route anything — and the moments a description is most worth writing (mid-meeting, and after it
+ends) are exactly the ones PATCH answered 409 for.
+
+Drives the collector ``create_app`` over the in-memory fake, OFFLINE (TestClient, no docker/DB).
+"""
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from meeting_api.collector import create_app
+from meeting_api.collector.fakes import InMemoryTranscriptStore
+
+USER = 7
+H = {"x-user-id": str(USER)}
+PLAT, NID = "google_meet", "abc-defg-hij"
+
+
+class _NullRedis:
+    async def publish(self, channel, data):
+        return None
+
+
+def _client(status="active"):
+    """Default status is `active` deliberately: the FSM-owned state is the one that matters."""
+    store = InMemoryTranscriptStore()
+    mid = store.seed_meeting(user_id=USER, platform=PLAT, native_meeting_id=NID, status=status)
+    return TestClient(create_app(store, redis=_NullRedis())), store, mid
+
+
+def _annotate(client, body, **params):
+    return client.post(f"/meetings/{PLAT}/{NID}/annotate", json=body, headers=H, params=params)
+
+
+# ---- the whole point: it works while the bot FSM owns the row ------------------------
+
+def test_annotate_works_on_a_live_meeting():
+    """PATCH answers 409 here. Annotating must not — a meeting is most worth describing while
+    it is happening."""
+    client, store, mid = _client(status="active")
+    r = _annotate(client, {"title": "Acme renewal", "metadata": {"crm_deal": "acme-42"}})
+    assert r.status_code == 200, r.text
+    assert store._meetings[mid]["status"] == "active", "annotating must not touch status"
+
+
+def test_patch_still_refuses_a_live_meeting():
+    """The complement: dispatch parameters stay protected. This branch widens what can be
+    written, not who owns the FSM."""
+    client, _store, _mid = _client(status="active")
+    r = client.patch(f"/meetings/{PLAT}/{NID}", json={"title": "nope"}, headers=H)
+    assert r.status_code == 409
+
+
+# ---- title round-trips (it lives in the data blob, not a column) ---------------------
+
+def test_title_is_persisted_and_read_back():
+    """Regression: the first implementation assigned `meeting.title`, which is not a column —
+    SQLAlchemy accepted the attribute and persisted nothing, and a forwarding-only test could
+    not see it. Assert the STORED value, not the request that was sent."""
+    client, store, mid = _client()
+    r = _annotate(client, {"title": "Fan vibration debug"})
+    assert r.status_code == 200, r.text
+    assert store._meetings[mid]["data"]["title"] == "Fan vibration debug"
+
+
+def test_empty_title_clears_it():
+    client, store, mid = _client()
+    _annotate(client, {"title": "temporary"})
+    _annotate(client, {"title": ""})
+    assert "title" not in store._meetings[mid]["data"]
+
+
+def test_title_is_capped_at_512_chars():
+    client, store, mid = _client()
+    _annotate(client, {"title": "x" * 900})
+    assert len(store._meetings[mid]["data"]["title"]) == 512
+
+
+# ---- metadata merge semantics --------------------------------------------------------
+
+def test_metadata_merges_key_wise():
+    client, store, mid = _client()
+    _annotate(client, {"metadata": {"crm_deal": "acme-42", "owner": "dmitry"}})
+    _annotate(client, {"metadata": {"stage": "discovery"}})
+    assert store._meetings[mid]["data"]["metadata"] == {
+        "crm_deal": "acme-42", "owner": "dmitry", "stage": "discovery",
+    }
+
+
+def test_explicit_null_deletes_one_key():
+    """The only way to take back a single annotation without replacing the whole object."""
+    client, store, mid = _client()
+    _annotate(client, {"metadata": {"crm_deal": "acme-42", "owner": "dmitry"}})
+    _annotate(client, {"metadata": {"owner": None}})
+    assert store._meetings[mid]["data"]["metadata"] == {"crm_deal": "acme-42"}
+
+
+def test_there_is_no_whole_object_replace():
+    """A caller must not be able to destroy annotations it never saw. Every writer on an account
+    shares one API key, so a replace would let any agent wipe keys written by another agent — or
+    by the human. `replace` was removed; the flag is now inert and merge is the only behaviour."""
+    client, store, mid = _client()
+    _annotate(client, {"metadata": {"crm_deal": "acme-42", "owner": "dmitry"}})
+    _annotate(client, {"metadata": {"only": "this"}}, replace="true")
+    assert store._meetings[mid]["data"]["metadata"] == {
+        "crm_deal": "acme-42", "owner": "dmitry", "only": "this",
+    }, "an unknown `replace` flag must not resurrect destructive behaviour"
+
+
+def test_a_writer_can_only_remove_keys_it_names():
+    """The positive form of the same property: deletion is per-key and explicit."""
+    client, store, mid = _client()
+    _annotate(client, {"metadata": {"written_by_someone_else": "keep me", "mine": "x"}})
+    _annotate(client, {"metadata": {"mine": None}})
+    assert store._meetings[mid]["data"]["metadata"] == {"written_by_someone_else": "keep me"}
+
+
+def test_title_and_metadata_are_independent():
+    """Writing one must not clear the other — they share the same data blob."""
+    client, store, mid = _client()
+    _annotate(client, {"title": "Acme renewal"})
+    _annotate(client, {"metadata": {"crm_deal": "acme-42"}})
+    data = store._meetings[mid]["data"]
+    assert data["title"] == "Acme renewal"
+    assert data["metadata"] == {"crm_deal": "acme-42"}
+
+
+# ---- refusals ------------------------------------------------------------------------
+
+def test_empty_body_is_refused():
+    client, _store, _mid = _client()
+    r = _annotate(client, {})
+    assert r.status_code == 422
+    assert "title" in r.text and "metadata" in r.text
+
+
+def test_non_object_metadata_is_refused():
+    client, _store, _mid = _client()
+    assert _annotate(client, {"metadata": ["not", "an", "object"]}).status_code == 422
+
+
+def test_unknown_meeting_is_404():
+    client, _store, _mid = _client()
+    r = client.post(
+        f"/meetings/{PLAT}/no-such-meeting/annotate", json={"title": "x"}, headers=H,
+    )
+    assert r.status_code == 404
+
+
+def test_another_users_meeting_is_404_not_403():
+    """Owner-scoped, and it must not confirm the row exists to a stranger."""
+    client, _store, _mid = _client()
+    r = client.post(
+        f"/meetings/{PLAT}/{NID}/annotate", json={"title": "x"}, headers={"x-user-id": "999"},
+    )
+    assert r.status_code == 404
+
+
+# ---- query by metadata: containment, in the store, not on a page ----------------------
+
+def _seed(store, native, metadata):
+    mid = store.seed_meeting(user_id=USER, platform=PLAT, native_meeting_id=native, status="completed")
+    store._meetings[mid]["data"]["metadata"] = metadata
+    return mid
+
+
+def test_list_filters_by_metadata_containment():
+    client, store, _mid = _client()
+    _seed(store, "deal-one", {"crm_deal": "acme-42", "stage": "discovery"})
+    _seed(store, "deal-two", {"crm_deal": "other-1"})
+    r = client.get("/meetings", params={"metadata": '{"crm_deal":"acme-42"}'}, headers=H)
+    assert r.status_code == 200, r.text
+    got = [m["native_meeting_id"] for m in r.json()["meetings"]]
+    assert got == ["deal-one"]
+
+
+def test_metadata_filter_is_containment_not_equality():
+    """Extra keys on the meeting must not disqualify it — mirrors JSONB `@>`."""
+    client, store, _mid = _client()
+    _seed(store, "deal-one", {"crm_deal": "acme-42", "stage": "discovery", "owner": "dmitry"})
+    r = client.get("/meetings", params={"metadata": '{"stage":"discovery"}'}, headers=H)
+    assert [m["native_meeting_id"] for m in r.json()["meetings"]] == ["deal-one"]
+
+
+def test_metadata_filter_requires_every_key_to_match():
+    client, store, _mid = _client()
+    _seed(store, "deal-one", {"crm_deal": "acme-42"})
+    r = client.get(
+        "/meetings", params={"metadata": '{"crm_deal":"acme-42","stage":"closed"}'}, headers=H,
+    )
+    assert r.json()["meetings"] == []
+
+
+def test_malformed_metadata_filter_is_422_not_a_silent_full_list():
+    """A filter that silently failed to apply would be a WRONG answer, not a slow one: the caller
+    would read an unfiltered list as 'these all match'."""
+    client, _store, _mid = _client()
+    assert client.get("/meetings", params={"metadata": "not-json"}, headers=H).status_code == 422
+    assert client.get("/meetings", params={"metadata": "[1,2]"}, headers=H).status_code == 422
+
+
+# ---- bounds: one caller's junk must not become everyone's cost ----------------------
+# Measured on the dogfood stack BEFORE these caps: a 10 MB metadata value was accepted in 3s,
+# after which GET /meetings returned 10.3 MB on EVERY call. The read side is the real blast
+# radius — an MCP client feeds a list response straight into a model's context window.
+
+def test_oversized_metadata_is_refused_with_413():
+    client, store, mid = _client()
+    r = _annotate(client, {"metadata": {"blob": "x" * 20000}})
+    assert r.status_code == 413
+    assert "too large" in r.text
+    assert "metadata" not in store._meetings[mid]["data"], "nothing may be written on refusal"
+
+
+def test_the_cap_is_on_the_MERGED_result_not_the_patch():
+    """A cap on each write is not a cap at all when writes merge: many small writes must not add
+    up past the ceiling."""
+    client, store, mid = _client()
+    for i in range(4):
+        r = _annotate(client, {"metadata": {f"chunk{i}": "x" * 5000}})
+        if r.status_code == 413:
+            break
+    else:
+        raise AssertionError("merged growth was never refused")
+    import json as _json
+    assert len(_json.dumps(store._meetings[mid]["data"]["metadata"])) <= 16 * 1024
+
+
+def test_too_many_keys_is_refused():
+    client, _store, _mid = _client()
+    r = _annotate(client, {"metadata": {f"k{i}": 1 for i in range(200)}})
+    assert r.status_code == 413
+    assert "too many metadata keys" in r.text
+
+
+def test_overlong_key_is_refused():
+    client, _store, _mid = _client()
+    r = _annotate(client, {"metadata": {"k" * 300: "v"}})
+    assert r.status_code == 413
+    assert "key too long" in r.text
+
+
+def test_a_realistic_annotation_still_fits():
+    """The cap must not get in the way of what this field is FOR: join keys, tags, a short summary."""
+    client, store, mid = _client()
+    r = _annotate(client, {"metadata": {
+        "crm_deal": "acme-42", "owner": "dmitry", "stage": "discovery",
+        "tags": ["renewal", "technical"],
+        "summary": "They want SSO before renewal. " * 40,
+    }})
+    assert r.status_code == 200, r.text
+    assert store._meetings[mid]["data"]["metadata"]["crm_deal"] == "acme-42"
+
+
+def test_bounds_hold_regardless_of_unknown_flags():
+    client, _store, _mid = _client()
+    assert _annotate(client, {"metadata": {"blob": "x" * 20000}}, replace="true").status_code == 413

--- a/core/meetings/services/meeting-api/tests/test_runtime_destroy_terminal_e2e.py
+++ b/core/meetings/services/meeting-api/tests/test_runtime_destroy_terminal_e2e.py
@@ -180,7 +180,7 @@ def test_runtime_destroy_completes_stopping_after_active_e2e():
         "lifecycle_contract_version": "2026-07-28",
     }
     assert repo.list_stale_stopping_sync() == []
-    assert len(redis.streams.get(f"tc:meeting:{m['id']}", [])) == 1
+    assert len([p for p in redis.streams.get(f"tc:meeting:{m['id']}", []) if p.get("type") == "session_end"]) == 1
 
 
 def test_runtime_destroy_with_invalid_time_does_not_fabricate_provenance():
@@ -243,7 +243,7 @@ def test_runtime_destroy_fails_pre_active_e2e():
     assert repo._meetings[m["id"]]["status"] == "failed"
     assert repo._meetings[m["id"]]["data"].get("failure_stage") == "awaiting_admission"
     assert repo._meetings[m["id"]]["data"].get("completion_reason") == "awaiting_admission_timeout"
-    assert len(redis.streams.get(f"tc:meeting:{m['id']}", [])) == 1
+    assert len([p for p in redis.streams.get(f"tc:meeting:{m['id']}", []) if p.get("type") == "session_end"]) == 1
 
 
 @pytest.mark.parametrize(
@@ -310,7 +310,7 @@ def test_runtime_destroy_noop_on_already_terminal_e2e():
     assert repo._meetings[m["id"]]["status"] == "completed"
     assert repo._meetings[m["id"]]["data"].get("completion_reason") == "left_alone"
     # Exactly ONE session_end (the bot's own completed), not a second from the trailing destroy.
-    assert len(redis.streams.get(f"tc:meeting:{m['id']}", [])) == 1
+    assert len([p for p in redis.streams.get(f"tc:meeting:{m['id']}", []) if p.get("type") == "session_end"]) == 1
 
 
 def test_runtime_nonterminal_state_does_not_advance_e2e():

--- a/core/meetings/services/meeting-api/tests/test_transcript_import.py
+++ b/core/meetings/services/meeting-api/tests/test_transcript_import.py
@@ -1,0 +1,193 @@
+"""Transcript IMPORT — a meeting completed from words it already has.
+
+The feature: bring a transcript Vexa did not record (a Zoom export, a TSC recording) into a
+meeting row so the product treats it exactly like a captured one. The same route is the rehearsal
+rig's capture double (`source="seed"`), which is why the audit's V4/N5 shell-out into this
+service's database has somewhere to go.
+
+Offline over the in-memory fake — no docker, no postgres:
+  * import → the row is `completed`, with the occurrence window the CALLER stated (the one fact a
+    bot run cannot express: it stamps start/end from `now()`);
+  * the segments read back through `GET /transcripts/by-id/{id}`, in order;
+  * a second import of the same source is a NO-OP — nothing rewritten, `imported: false`;
+  * a non-owner is refused, and refused identically to an unknown row (no existence oracle);
+  * a row with a bot in flight is refused 409 — the FSM is never fought;
+  * malformed bodies are refused whole (an import is one artifact; a hole a caller cannot see is
+    worse than a rejection they can read).
+"""
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from meeting_api.collector import create_app
+from meeting_api.collector.fakes import InMemoryTranscriptStore
+
+OWNER, STRANGER = 11, 12
+PLAT, NID = "jitsi", "dna-tsc-2026-08-03"
+WHEN = "2026-08-03T14:00:00Z"
+
+SEGS = [
+    {"start": 0.0, "end": 4.5, "speaker": "Larry", "text": "Welcome to the TSC call."},
+    {"start": 4.5, "end": 9.25, "speaker": "Marvin", "text": "Two items on the agenda today."},
+    {"start": 9.25, "end": 15.0, "speaker": "Larry", "text": "Let us start with the first."},
+]
+
+
+def _client(status="scheduled", user_id=OWNER):
+    store = InMemoryTranscriptStore()
+    mid = store.seed_meeting(user_id=user_id, platform=PLAT, native_meeting_id=NID,
+                             status=status, start_time=None, end_time=None)
+    return TestClient(create_app(store, redis=None)), store, mid
+
+
+def _import(client, mid, uid=OWNER, **over):
+    body = {"segments": SEGS, "started_at": WHEN, "source": "import"}
+    body.update(over)
+    return client.post(f"/meetings/{mid}/transcript-import", json=body,
+                       headers={"x-user-id": str(uid)})
+
+
+def test_import_completes_the_row_with_the_stated_occurrence_window():
+    client, _store, mid = _client()
+    r = _import(client, mid)
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["imported"] is True
+    assert body["status"] == "completed"
+    assert body["segments_imported"] == 3
+    # The window the CALLER stated, not `now()` — a meeting that happened last Tuesday is
+    # expressible, which is the whole reason the rig used to UPDATE the columns by hand.
+    assert body["start_time"].startswith("2026-08-03T14:00:00")
+    # No `ended_at` given → the transcript's own length (last segment's end = 15s).
+    assert body["end_time"].startswith("2026-08-03T14:00:15")
+    assert body["session_uid"] == f"import-import-{mid}"
+
+
+def test_explicit_ended_at_wins_over_the_transcripts_length():
+    client, _store, mid = _client()
+    r = _import(client, mid, ended_at="2026-08-03T15:30:00Z")
+    assert r.status_code == 200
+    assert r.json()["end_time"].startswith("2026-08-03T15:30:00")
+
+
+def test_imported_segments_read_back_through_the_by_id_transcript():
+    """The product read a terminal canvas uses — an imported meeting must look like a recorded one."""
+    client, _store, mid = _client()
+    _import(client, mid)
+    doc = client.get(f"/transcripts/by-id/{mid}", headers={"x-user-id": str(OWNER)})
+    assert doc.status_code == 200
+    body = doc.json()
+    assert body["status"] == "completed"
+    assert body["start_time"].startswith("2026-08-03T14:00:00")
+    texts = [s["text"] for s in body["segments"]]
+    assert texts == [s["text"] for s in SEGS]           # in order
+    assert body["segments"][1]["speaker"] == "Marvin"   # speakers survive
+
+
+def test_a_second_import_of_the_same_source_writes_nothing():
+    client, store, mid = _client()
+    first = _import(client, mid).json()
+    doc_before = client.get(f"/transcripts/by-id/{mid}", headers={"x-user-id": str(OWNER)}).json()
+
+    again = _import(client, mid)
+    assert again.status_code == 200
+    assert again.json()["imported"] is False
+    assert again.json()["segments_imported"] == first["segments_imported"]
+    assert again.json()["imported_at"] == first["imported_at"]  # the FIRST import's stamp
+
+    doc_after = client.get(f"/transcripts/by-id/{mid}", headers={"x-user-id": str(OWNER)}).json()
+    assert doc_after["segments"] == doc_before["segments"]      # not doubled, not rewritten
+    assert len(doc_after["segments"]) == 3
+
+
+def test_a_changed_transcript_from_the_same_source_is_still_one_import():
+    """Idempotency is on the SOURCE, not on the bytes: re-sending different words for the same
+    (source, meeting) is the same import, and does not silently rewrite the meeting."""
+    client, _store, mid = _client()
+    _import(client, mid)
+    again = _import(client, mid, segments=[{"start": 0.0, "end": 1.0, "speaker": "X", "text": "different"}])
+    assert again.status_code == 200 and again.json()["imported"] is False
+    doc = client.get(f"/transcripts/by-id/{mid}", headers={"x-user-id": str(OWNER)}).json()
+    assert [s["text"] for s in doc["segments"]] == [s["text"] for s in SEGS]
+
+
+def test_a_different_source_is_a_different_import():
+    """`seed` and `import` derive different session uids, so the double and a real import of the
+    same meeting are distinguishable — and neither is mistaken for the other's replay."""
+    client, _store, mid = _client()
+    assert _import(client, mid, source="seed").json()["session_uid"] == f"import-seed-{mid}"
+    assert _import(client, mid, source="seed").json()["imported"] is False
+
+
+def test_non_owner_is_refused_exactly_like_an_unknown_row():
+    client, _store, mid = _client()
+    mine = _import(client, mid, uid=STRANGER)
+    unknown = _import(client, 987654, uid=STRANGER)
+    assert mine.status_code == 404 and unknown.status_code == 404
+    assert mine.json()["detail"] == f"Meeting {mid} not found"
+    assert unknown.json()["detail"] == "Meeting 987654 not found"
+    # and nothing was written
+    doc = client.get(f"/transcripts/by-id/{mid}", headers={"x-user-id": str(OWNER)}).json()
+    assert doc["status"] == "scheduled" and doc["segments"] == []
+
+
+def test_a_row_with_a_bot_in_flight_is_refused():
+    for live in ("joining", "active", "awaiting_admission", "stopping"):
+        client, _store, mid = _client(status=live)
+        r = _import(client, mid)
+        assert r.status_code == 409, f"{live} → {r.status_code}"
+        assert live in r.json()["detail"]
+
+
+def test_an_already_completed_row_may_be_imported_into():
+    """A meeting whose bot ran and completed is terminal, not in flight — importing an external
+    transcript onto it is a legitimate act (a better recording of the same call)."""
+    client, _store, mid = _client(status="completed")
+    assert _import(client, mid).status_code == 200
+
+
+def test_malformed_bodies_are_refused_whole():
+    client, _store, mid = _client()
+    cases = [
+        ({"segments": [], "started_at": WHEN}, "non-empty"),
+        ({"segments": SEGS}, "started_at"),
+        ({"segments": SEGS, "started_at": "yesterday"}, "started_at"),
+        ({"segments": SEGS, "started_at": WHEN, "ended_at": "2026-08-03T13:00:00Z"}, "before"),
+        ({"segments": SEGS, "started_at": WHEN, "source": "recording"}, "source"),
+        ({"segments": [{"start": "x", "end": 1}], "started_at": WHEN}, "segment 0"),
+        ({"segments": [{"start": 0, "end": 1, "text": 5}], "started_at": WHEN}, "segment 0"),
+    ]
+    for body, needle in cases:
+        r = client.post(f"/meetings/{mid}/transcript-import", json=body,
+                        headers={"x-user-id": str(OWNER)})
+        assert r.status_code == 422, f"{body} → {r.status_code}"
+        assert needle in r.json()["detail"], f"{body} → {r.json()['detail']}"
+    # the row is untouched by every one of them
+    doc = client.get(f"/transcripts/by-id/{mid}", headers={"x-user-id": str(OWNER)}).json()
+    assert doc["status"] == "scheduled" and doc["segments"] == []
+
+
+def test_identity_is_required():
+    client, _store, mid = _client()
+    r = client.post(f"/meetings/{mid}/transcript-import",
+                    json={"segments": SEGS, "started_at": WHEN})
+    assert r.status_code == 401
+
+
+def test_the_import_route_does_not_shadow_the_share_pair_route():
+    """Three segments against four — and a non-numeric id is refused by validation here rather than
+    resolved as a platform name. The property the by-id share mint relies on, asserted again."""
+    client, _store, mid = _client()
+    r = client.post("/meetings/google_meet/transcript-import",
+                    json={"segments": SEGS, "started_at": WHEN}, headers={"x-user-id": str(OWNER)})
+    assert r.status_code == 422
+    ok = client.post(f"/meetings/{PLAT}/{NID}/share", json={"mode": "open"},
+                     headers={"x-user-id": str(OWNER)})
+    assert ok.status_code == 200
+
+
+def test_epoch_seconds_are_accepted_for_the_window():
+    client, _store, mid = _client()
+    r = _import(client, mid, started_at=1785765600)   # 2026-08-03T14:00:00Z
+    assert r.status_code == 200
+    assert r.json()["start_time"].startswith("2026-08-03T14:00:00")

--- a/core/meetings/services/meeting-api/tests/test_transcript_search.py
+++ b/core/meetings/services/meeting-api/tests/test_transcript_search.py
@@ -1,0 +1,152 @@
+"""GET /transcripts/search — full-text search over the caller's OWN transcript segments.
+
+Answers what metadata cannot: not "meetings I tagged X" but "meetings where someone SAID X".
+
+SCOPE OF THIS FILE: the route's CONTRACT — owner scoping, filters, paging, hit shape, refusals.
+NOT the search semantics. The in-memory fake is a crude stand-in (whole-word AND, quoted phrases,
+`-negation`); it does not stem, does not rank by cover density, and does not implement `or`.
+Real tsquery behaviour is a Postgres property and meeting-api has no `requires_docker` lane the
+way admin-api does — asserting it here would produce green tests over wrong production code.
+"""
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from meeting_api.collector import create_app
+from meeting_api.collector.fakes import InMemoryTranscriptStore
+
+USER, OTHER = 7, 99
+H = {"x-user-id": str(USER)}
+PLAT = "google_meet"
+
+
+class _NullRedis:
+    async def publish(self, channel, data):
+        return None
+
+
+def _seg(i, text, speaker="Dmitriy", start=0.0):
+    return {"segment_id": f"s{i}", "start": start, "end": start + 2, "text": text,
+            "speaker": speaker, "language": "en"}
+
+
+def _client():
+    store = InMemoryTranscriptStore()
+    store.seed_meeting(
+        user_id=USER, platform=PLAT, native_meeting_id="acme-call", meeting_id=1,
+        segments=[
+            _seg(1, "we should revisit the pricing before the renewal", start=0),
+            _seg(2, "the latency numbers look fine", speaker="Ana", start=10),
+            _seg(3, "lets align on scope before the demo", start=20),
+        ],
+    )
+    store.seed_meeting(
+        user_id=USER, platform="teams", native_meeting_id="globex-call", meeting_id=2,
+        segments=[_seg(4, "pricing came up again on the globex call", start=0)],
+    )
+    # Another tenant's meeting, same words — must never surface.
+    store.seed_meeting(
+        user_id=OTHER, platform=PLAT, native_meeting_id="secret-call", meeting_id=3,
+        segments=[_seg(5, "our pricing is confidential", speaker="Someone Else", start=0)],
+    )
+    return TestClient(create_app(store, redis=_NullRedis())), store
+
+
+def _search(client, q, **params):
+    return client.get("/transcripts/search", params={"q": q, **params}, headers=H)
+
+
+# ---- the core question -------------------------------------------------------------
+
+def test_finds_what_was_said_across_meetings():
+    client, _ = _client()
+    r = _search(client, "pricing")
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["count"] == 2
+    assert {h["native_meeting_id"] for h in body["hits"]} == {"acme-call", "globex-call"}
+
+
+def test_a_hit_carries_the_identity_needed_to_fetch_the_transcript():
+    """The whole point of a hit: an agent must be able to feed it straight into
+    get_meeting_transcript without inventing anything."""
+    client, _ = _client()
+    hit = _search(client, "latency").json()["hits"][0]
+    for field in ("platform", "native_meeting_id", "start", "end", "speaker", "snippet", "rank"):
+        assert field in hit, f"hit is missing {field}"
+    assert hit["platform"] == PLAT and hit["native_meeting_id"] == "acme-call"
+    assert hit["speaker"] == "Ana"
+
+
+def test_snippet_not_the_whole_corpus():
+    client, _ = _client()
+    hit = _search(client, "latency").json()["hits"][0]
+    assert "latency" in hit["snippet"].lower()
+
+
+# ---- isolation: the property that must never regress --------------------------------
+
+def test_another_tenants_transcript_never_surfaces():
+    """Owner-scoped, fail-closed. A search that over-returns is a disclosure, not a bug."""
+    client, _ = _client()
+    hits = _search(client, "pricing").json()["hits"]
+    assert all(h["native_meeting_id"] != "secret-call" for h in hits)
+    assert all(h["speaker"] != "Someone Else" for h in hits)
+
+
+def test_the_other_tenant_can_see_their_own():
+    client, _ = _client()
+    r = client.get("/transcripts/search", params={"q": "pricing"}, headers={"x-user-id": str(OTHER)})
+    assert [h["native_meeting_id"] for h in r.json()["hits"]] == ["secret-call"]
+
+
+# ---- filters + paging ---------------------------------------------------------------
+
+def test_platform_filter():
+    client, _ = _client()
+    hits = _search(client, "pricing", platform="teams").json()["hits"]
+    assert [h["native_meeting_id"] for h in hits] == ["globex-call"]
+
+
+def test_single_meeting_filter():
+    client, _ = _client()
+    hits = _search(client, "pricing", native_meeting_id="acme-call").json()["hits"]
+    assert [h["native_meeting_id"] for h in hits] == ["acme-call"]
+
+
+def test_limit_and_offset():
+    client, _ = _client()
+    assert len(_search(client, "pricing", limit=1).json()["hits"]) == 1
+    first = _search(client, "pricing", limit=1).json()["hits"][0]
+    second = _search(client, "pricing", limit=1, offset=1).json()["hits"][0]
+    assert first != second
+
+
+# ---- refusals ------------------------------------------------------------------------
+
+def test_blank_query_is_refused():
+    client, _ = _client()
+    assert client.get("/transcripts/search", params={"q": "   "}, headers=H).status_code == 422
+
+
+def test_missing_query_is_refused():
+    client, _ = _client()
+    assert client.get("/transcripts/search", headers=H).status_code == 422
+
+
+def test_no_identity_is_401():
+    client, _ = _client()
+    assert client.get("/transcripts/search", params={"q": "pricing"}).status_code == 401
+
+
+def test_no_match_is_an_empty_result_not_an_error():
+    client, _ = _client()
+    body = _search(client, "zzzznotpresent").json()
+    assert body["count"] == 0 and body["hits"] == []
+
+
+def test_search_is_not_swallowed_as_a_platform_name():
+    """`/transcripts/search` must route to search, not to
+    `/transcripts/{platform}/{native}` with platform='search'."""
+    client, _ = _client()
+    assert _search(client, "pricing").status_code == 200

--- a/core/meetings/services/meeting-api/tests/test_transcript_share.py
+++ b/core/meetings/services/meeting-api/tests/test_transcript_share.py
@@ -4,7 +4,9 @@ Offline over the in-memory fake:
   * owner mints a share link (open) → a different authenticated user redeems → is authorized to subscribe;
   * a user who never redeemed is refused (no workspace, no grant);
   * restricted mode admits only an allow-listed verified email;
-  * decoupled from workspaces entirely (no binding, no membership involved).
+  * decoupled from workspaces entirely (no binding, no membership involved);
+  * the mint is addressable by ROW ID as well as by (platform, native) — including on a row that
+    NO pair can address, which is the shape that broke the attendee mail on 2026-09-02.
 """
 from __future__ import annotations
 
@@ -97,3 +99,113 @@ def test_visitor_can_LOAD_the_transcript_after_redeem():
     assert ok.status_code == 200 and ok.json()["segments"]
     # a still-unrelated user remains refused
     assert client.get(f"/transcripts/by-id/{mid}", headers={"x-user-id": str(OTHER)}).status_code == 404
+
+
+# ── mint by ROW id ───────────────────────────────────────────────────────────────────────────
+# The (platform, native) pair is not an identity. Meeting 97 (2026-09-02) was planned from an
+# invite whose url matched no platform: platform='unknown', platform_specific_id='' — no pair
+# addressed it, `POST /meetings/unknown/96088138284/share` answered 404, and the attendee mail
+# shipped anyway with no capability, so every recipient landed in a chat that said "no meeting
+# with id 97 on my side". The row id always exists; these tests hold that door open.
+def test_mint_by_row_id_gives_the_owner_a_working_token():
+    store = InMemoryTranscriptStore()
+    mid = store.seed_meeting(user_id=OWNER, platform=PLAT, native_meeting_id=NID,
+                             segments=[{"segment_id": "s1", "text": "hello", "speaker": "A"}])
+    client = TestClient(create_app(store, redis=None))
+
+    r = client.post(f"/meetings/{mid}/share", json={"mode": "open"}, headers={"x-user-id": str(OWNER)})
+    assert r.status_code == 200
+    token = r.json()["token"]
+    assert token.split(".")[0] == str(mid)          # <meeting_id>.<secret>, and it names THIS row
+
+    # the token is a real capability, not just a well-formed string
+    assert client.post("/transcripts/share/accept", json={"token": token},
+                       headers={"x-user-id": str(VISITOR)}).status_code == 200
+    assert client.get(f"/transcripts/by-id/{mid}", headers={"x-user-id": str(VISITOR)}).status_code == 200
+
+
+def test_mint_by_row_id_works_on_a_row_NO_pair_can_address():
+    """The regression. platform='unknown' + an empty native is unaddressable by the pair route —
+    that route 404s here, and the by-id route must not."""
+    store = InMemoryTranscriptStore()
+    mid = store.seed_meeting(user_id=OWNER, platform="unknown", native_meeting_id="", status="scheduled")
+    client = TestClient(create_app(store, redis=None))
+
+    # what actually happened in production: the pair the flow could construct addresses nothing
+    assert client.post("/meetings/unknown/96088138284/share",
+                       json={"mode": "restricted", "allowed_emails": ["a@vexa.ai"]},
+                       headers={"x-user-id": str(OWNER)}).status_code == 404
+    # the row id still names it
+    r = client.post(f"/meetings/{mid}/share",
+                    json={"mode": "restricted", "allowed_emails": ["a@vexa.ai"]},
+                    headers={"x-user-id": str(OWNER)})
+    assert r.status_code == 200 and r.json()["token"].split(".")[0] == str(mid)
+
+
+def test_mint_by_row_id_keeps_restricted_semantics():
+    """`restricted` + this attendee's own address travels through the by-id route unchanged: a
+    forwarded mail must grant its new reader nothing."""
+    store = InMemoryTranscriptStore()
+    mid = store.seed_meeting(user_id=OWNER, platform=PLAT, native_meeting_id=NID)
+    client = TestClient(create_app(store, redis=None))
+    token = client.post(f"/meetings/{mid}/share",
+                        json={"mode": "restricted", "allowed_emails": ["ok@vexa.ai"]},
+                        headers={"x-user-id": str(OWNER)}).json()["token"]
+
+    bad = client.post("/transcripts/share/accept", json={"token": token},
+                      headers={"x-user-id": str(VISITOR), "x-user-email": "forwarded@x.com"})
+    assert bad.status_code == 403
+    good = client.post("/transcripts/share/accept", json={"token": token},
+                       headers={"x-user-id": str(OTHER), "x-user-email": "ok@vexa.ai"})
+    assert good.status_code == 200
+
+
+def test_mint_by_row_id_is_owner_scoped_and_leaks_no_existence():
+    """A row that is not the caller's reads exactly like one that does not exist. Minting a
+    capability on someone else's meeting must be impossible, and must not even confirm the id."""
+    store = InMemoryTranscriptStore()
+    mid = store.seed_meeting(user_id=OWNER, platform=PLAT, native_meeting_id=NID)
+    client = TestClient(create_app(store, redis=None))
+
+    theirs = client.post(f"/meetings/{mid}/share", json={"mode": "open"},
+                         headers={"x-user-id": str(VISITOR)})
+    unknown = client.post(f"/meetings/{mid + 9999}/share", json={"mode": "open"},
+                          headers={"x-user-id": str(OWNER)})
+    assert theirs.status_code == 404 and unknown.status_code == 404
+    # Same answer SHAPE: the only difference is the id the caller itself supplied, so nothing in
+    # the response distinguishes "exists but not yours" from "does not exist".
+    assert theirs.json()["detail"].replace(str(mid), "<id>") == \
+        unknown.json()["detail"].replace(str(mid + 9999), "<id>")
+
+    # and nothing was written to the row the non-owner aimed at
+    assert store._meetings[mid]["data"].get("share_grants") in (None, [])
+
+
+def test_the_pair_route_still_mints():
+    """Additive, not a replacement: 0.10 clients and the /transcripts/{platform}/{native}/share
+    alias still address the mint by pair."""
+    store = InMemoryTranscriptStore()
+    mid = store.seed_meeting(user_id=OWNER, platform=PLAT, native_meeting_id=NID)
+    client = TestClient(create_app(store, redis=None))
+    r = client.post(f"/meetings/{PLAT}/{NID}/share", json={"mode": "open"},
+                    headers={"x-user-id": str(OWNER)})
+    assert r.status_code == 200 and r.json()["token"].split(".")[0] == str(mid)
+
+
+def test_the_two_routes_do_not_shadow_each_other():
+    """Segment count keeps them apart, and both are reachable in the same app. A row id and a
+    platform name are never confused: `/meetings/{id}/share` is three segments, the pair route
+    four, so the router can only ever match one of them."""
+    store = InMemoryTranscriptStore()
+    mid = store.seed_meeting(user_id=OWNER, platform=PLAT, native_meeting_id=NID)
+    client = TestClient(create_app(store, redis=None))
+    hdr = {"x-user-id": str(OWNER)}
+
+    by_id = client.post(f"/meetings/{mid}/share", json={"mode": "open"}, headers=hdr)
+    by_pair = client.post(f"/meetings/{PLAT}/{NID}/share", json={"mode": "open"}, headers=hdr)
+    assert by_id.status_code == by_pair.status_code == 200
+    assert by_id.json()["id"] != by_pair.json()["id"]        # two distinct grants, one row
+    assert len(store._meetings[mid]["data"]["share_grants"]) == 2
+
+    # a non-numeric id is refused by validation, never resolved as some other kind of name
+    assert client.post("/meetings/not-a-row/share", json={}, headers=hdr).status_code == 422


### PR DESCRIPTION
The meetings bounded context: bot lifecycle, meeting rows, the transcript single-writer path and
the status stream. No agent, no terminal — the half of the product that joins, records and
transcribes.

| | |
|---|---|
| **Area** | the meetings domain |
| **Size** | +3457 / −643 across 30 files, against its base `review/01-foundation` |
| **Line range** | the 17 commits of `minutes-mcp-viewer` touching these paths, inside [`3f5c3c030...7d838534a`](https://github.com/Vexa-ai/vexa/compare/3f5c3c030198b5e3d0d8339d66bece6136ada0d5...7d838534ac29954a28a25cc24f8745a9aa976f0f) |
| **Base** | `review/01-foundation` — this PR shows only its own area; read the chain in order |
| **Open first** | core/meetings/services/meeting-api |

On the **merge track** (`[merge 2/5]`): the no-agents MCP product — identity, gateway, runtime, meetings, flows and their docs. No `core/agent`, no terminal. Base-chained, so it merges in order.

## Contribution rights
<!-- Select exactly ONE. This is a legal certification: an agent may explain the choices but
     must not select one for you. See CONTRIBUTOR_RIGHTS.md. -->

- [ ] **Independent:** I created this contribution, or otherwise have the right to submit it
  under Apache-2.0, and it is not owned or controlled by an employer, client, or other entity.
  <!-- rights:independent -->
- [ ] **Employer/client authorization required:** an employer, client, or other entity owns or
  may control this contribution. I am requesting Vexa's private corporate-authorization process.
  <!-- rights:corporate -->
- [ ] **Unsure:** I need a private rights review before merge.
  <!-- rights:uncertain -->

Every commit must also carry the contributor's own DCO `Signed-off-by` line. Selecting the
independent path means no individual CLA is required. Corporate and unsure paths do not stop
technical review, but they do block merge until resolved.

<!-- vexa-agent -->
