### PR TITLE
[DEV] the reap assertion waits for the reap — bounded, not a sleep (#1434)

### DIFF
--- a/core/agent/tests/test_entity_writeback_trim.py
+++ b/core/agent/tests/test_entity_writeback_trim.py
@@ -275,6 +275,31 @@ def test_a_phase_over_budget_leaves_no_child_process(tmp_path, monkeypatch):
     assert out[-1]["type"] == "writeback-truncated"
     assert len(seen) == 1
     proc = seen[0]
+
+    # WAIT FOR THE REAP — bounded, and not a sleep.
+    #
+    # The property is that the budget kills the CLI, and it is delivered by a cascade: `bounded`
+    # closes its iterator, GeneratorExit unwinds `parse_stream_json`, THAT frame's teardown drops
+    # the last reference to the `_exec_subprocess` generator, and only then does its `finally`
+    # reap. The last hop is finalization, not a call — so the guarantee the code offers is PROMPT,
+    # never INSTANTANEOUS, and an assertion taken on the next bytecode was reading a coin flip.
+    # It came up heads on every developer machine and tails on CI: red on three consecutive PRs
+    # into this line (#1426, #1428, #1431), and not reproducible in 40 single-CPU-pinned runs or a
+    # full-suite run on 3.12 and 3.14 (Vexa-ai/vexa#1434).
+    #
+    # This is a poll with a deadline, not `sleep(n)`: it returns the microsecond the reap lands, so
+    # a healthy run costs nothing, and 5s is far outside any scheduling delay while staying far
+    # inside the suite's patience. Every property the docstring above names survives it — with the
+    # kill path deleted, `_reap`'s bare `proc.wait()` still blocks inside the cascade and this test
+    # still hangs, which is the failure it was written to name.
+    #
+    # `events` is deliberately still referenced here. Dropping it would close the chain from the
+    # test instead of from `bounded`, and the test would then pass with `bounded`'s own
+    # `finally: gen.close()` deleted — proving the cascade, not the budget.
+    deadline = time.monotonic() + 5.0
+    while proc.poll() is None and time.monotonic() < deadline:
+        time.sleep(0.005)
+
     assert proc.poll() is not None, "the CLI is still running after the budget stopped reading it"
     with pytest.raises(ProcessLookupError):
         os.kill(proc.pid, 0)


### PR DESCRIPTION
**COMMITMENTS IN THIS DRAFT — none.** One test file, 25 added lines. Nothing merged, deployed, published or sent outside the org. No commit is signed off.

**Delivers issue:** [#1434](https://github.com/Vexa-ai/vexa/issues/1434). Base: `minutes-mcp-viewer` @ `7d838534a`.

## Contribution rights
<!-- Select exactly ONE. This is a legal certification: an agent may explain the choices but
     must not select one for you. See CONTRIBUTOR_RIGHTS.md. -->

- [ ] **Independent:** I created this contribution, or otherwise have the right to submit it
  under Apache-2.0, and it is not owned or controlled by an employer, client, or other entity.
  <!-- rights:independent -->
- [ ] **Employer/client authorization required:** an employer, client, or other entity owns or
  may control this contribution. I am requesting Vexa's private corporate-authorization process.
  <!-- rights:corporate -->
- [ ] **Unsure:** I need a private rights review before merge.
  <!-- rights:uncertain -->

**Unticked, and no commit carries a `Signed-off-by`.** Both are human certifications and an agent must not make either. `DCO` and `contribution-rights` are red on this PR and that is the truthful state.

## The defect

`test_a_phase_over_budget_leaves_no_child_process` has been red on `gate:python` on every PR into this line that reached it — [#1426](https://github.com/Vexa-ai/vexa/pull/1426), [#1428](https://github.com/Vexa-ai/vexa/pull/1428), [#1431](https://github.com/Vexa-ai/vexa/pull/1431) — and green everywhere else. Three sessions each read it as somebody else's red.

**The test is right about what it proves and wrong about when it may look.** The property is that the budget kills the CLI, and it is delivered by a cascade:

```
bounded()            closes its iterator                (engine.py:737)
  → parse_stream_json  unwinds on GeneratorExit
    → that frame's teardown drops the last reference to
      _exec_subprocess's generator
      → its finally runs → _reap → wait(0.3) → kill → wait   (claude_code.py:363)
```

**The last hop is finalization, not a call.** So the guarantee the code offers is *prompt*, never *instantaneous*, and `assert proc.poll() is not None` on the very next bytecode was reading a coin flip — heads on every developer machine, tails on a CI runner whose GC and scheduling timing differ.

## The change

One bounded poll before the assertion. It returns the microsecond the reap lands, so a healthy run costs nothing; 5s sits far outside any scheduling delay and far inside the suite's patience. **A deadline, not `sleep(n)`** — a fixed sleep would slow every green run and still race a slower one.

`events` is deliberately still referenced at the assertion, and now says so in the comment. Dropping it would close the chain from the *test* rather than from `bounded`, and the test would then pass with `bounded`'s own `finally: gen.close()` deleted — proving the cascade instead of the budget. The keep-alive is load-bearing.

## Observation bundle

- **C1 — ran the parent commit, could not reproduce, and say so rather than assume.** 40 single-CPU-pinned runs (`taskset -c 3`) of the failing test on Python 3.12 — CI's interpreter — **0 failures**. Full `core/agent` suite on 3.12 and on 3.14: **1612 passed** each. Concluded: the failure is timing on the runner, which is exactly what an instantaneous assertion on a finalization-delivered property is sensitive to. This is stated in the commit message too; an unreproduced red is a finding, not a licence to guess.
- **C2 — negative control, `_reap` neutered.** Patched `_reap` to `return` before its wait/kill, ran the test: **RED in 5.10s**, naming the same failure. The wait cannot paper over a missing reap.
- **C3 — negative control, the kill path.** Unchanged and unweakened: with `proc.kill()` removed, `_reap`'s bare `proc.wait()` still blocks *inside* the cascade and the test still hangs — the failure its own docstring was written to name. Not executed (it hangs by construction); the mechanism is unaltered by this diff.
- **C4 — not flaky.** 25 consecutive single-CPU-pinned runs on 3.12: **0 failures**.

## Acceptance floor

| Row | Evidence |
|---|---|
| The red is gone | full `core/agent` suite green on 3.12 (1612) and 3.14 (1612); 25/25 pinned runs of the test |
| The test still fails when the reap does not happen | C2 — RED in 5.10s with `_reap` neutered |
| No production code changed | diff is one test file, +25 lines, 0 deletions |
| Three blocked packages unblocked | `gatePython` returns at the first failing package and `core/agent` sorts first, so CI has been executing none of `core/flows` (257), `deploy/lite` (4) or `deploy/dogfood/rig` (24) since [#1431](https://github.com/Vexa-ai/vexa/pull/1431) added them. Confirmed on the next `gates` run of that PR rebased onto this. |

## Docs diff (D6c)

None, and none is needed: test-only, no user-visible surface, no changelog fragment (per [`docs/changelog.d/README.md`](../blob/main/docs/changelog.d/README.md) — a `:v012` user would not want to read about it). Requesting the `docs: none` label.

## Security checks

No dependency, no licence, no secret, no runtime code path touched. The diff adds a `time.monotonic()` deadline loop to one test.

## Validation request

Any competent non-author. What to watch: `gate:python` green on this PR, and then **16 packages** executed on the next `gates` run of [#1431](https://github.com/Vexa-ai/vexa/pull/1431) rebased onto this — that is the row this change exists for. Deployment validated: none; test-only.

Gates run on `bbb` before push, pushed **without** `--no-verify`.
