### PR TITLE
[DEV] mcp-assembly: one MCP surface, assembled from the deployed domains manifests (slice 3 of PRD 43)

### DIFF
--- a/core/flows/mcp.tools.v1.json
+++ b/core/flows/mcp.tools.v1.json
@@ -1,0 +1,42 @@
+{
+  "contract": "mcp.tools.v1",
+  "domain": "flows",
+  "source": "oss",
+  "owner": "core/flows",
+  "base_url_env": "FLOWS_API_URL",
+  "served_at": "/.well-known/mcp-tools.json",
+  "depends_on": ["identity"],
+  "tools": [
+    {
+      "name": "flows_list",
+      "identity": "operator",
+      "requires": ["identity", "flows"],
+      "route": { "method": "GET", "path": "/flows" }
+    },
+    {
+      "name": "reactions_list",
+      "identity": "operator",
+      "requires": ["identity", "flows"],
+      "route": { "method": "GET", "path": "/reactions" },
+      "arguments": ["status", "subject"]
+    },
+    {
+      "name": "reaction_signal",
+      "identity": "user",
+      "requires": ["identity", "flows"],
+      "route": { "method": "POST", "path": "/reactions/{reaction_id}/{verb}" },
+      "note": "resume | retry | cancel | wake. The path parameters are arguments without being declared — the route cannot be called without them."
+    },
+    {
+      "name": "timeline",
+      "identity": "user",
+      "requires": ["identity", "flows"],
+      "route": { "method": "GET", "path": "/timeline" },
+      "arguments": ["subject", "since", "until", "limit"]
+    }
+  ],
+  "publishes_events": [
+    { "event": "meeting.completed", "status": "published today", "triggers": "post_meeting v4" },
+    { "event": "invite.received", "status": "published today", "triggers": "invite_intake v2" }
+  ]
+}

--- a/core/flows/src/flows_integrations/flows_api.py
+++ b/core/flows/src/flows_integrations/flows_api.py
@@ -107,6 +107,9 @@ clock = SystemClock()
 vocab = Registry()
 production.build(vocab, db)
 
+import json as _json
+import pathlib as _pathlib
+
 app = FastAPI(title="flows-api", version="0.1.0",
               description="Submit and manage Vexa workflows as data — no code over the wire.")
 
@@ -475,3 +478,28 @@ def main() -> int:  # pragma: no cover — process entrypoint
 
 if __name__ == "__main__":
     raise SystemExit(main())
+
+
+# ── the MCP tool manifest (PRD decision 40) ───────────────────────────────────────────────────
+# The domain that owns the door owns the tool. This is flows' declaration of the tools it backs —
+# a NAME bound to a ROUTE, who may call it, and which deployments it exists in. The gateway's MCP
+# server fetches it at startup and assembles one surface from every deployed domain's.
+#
+# SERVED, not baked into the assembler: the version that answers is the version that is RUNNING, so
+# a deployment cannot advertise a tool this build does not actually serve. The file is committed at
+# `core/flows/mcp.tools.v1.json` and this route reads it — one copy, and the tests in
+# `core/gateway`'s MCP service put that same file through the assembler.
+#
+# OPEN, like /health: it names routes and argument names, never data and never a credential. An
+# assembler that had to authenticate to discover the surface could not boot before identity did.
+_MANIFEST_PATH = _pathlib.Path(__file__).resolve().parents[2] / "mcp.tools.v1.json"
+
+
+@app.get("/.well-known/mcp-tools.json")
+def mcp_tools_manifest():
+    """This domain's MCP tool manifest — what the gateway assembles into the one MCP surface."""
+    try:
+        return _json.loads(_MANIFEST_PATH.read_text(encoding="utf-8"))
+    except Exception as e:  # noqa: BLE001
+        raise HTTPException(status_code=503,
+                            detail=f"this build carries no tool manifest: {e}") from e

--- a/core/flows/tests/test_flows_manifest_route.py
+++ b/core/flows/tests/test_flows_manifest_route.py
@@ -1,0 +1,65 @@
+"""flows serves the manifest the gateway assembles — the running build's, not the built one.
+
+The manifest is committed at `core/flows/mcp.tools.v1.json` and served at
+`/.well-known/mcp-tools.json`. Serving it rather than baking a copy into the assembler is the whole
+point: the version that answers is the version that is RUNNING, so a deployment cannot advertise a
+tool this build does not serve.
+
+Asserted against the SOURCE and the FILE, not by importing the module: importing
+`flows_integrations.flows_api` opens a Postgres connection and mints an API key at import time,
+which is why no test in this suite imports it.
+"""
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+
+SRC = Path(__file__).resolve().parents[1] / "src"
+API = SRC / "flows_integrations" / "flows_api.py"
+MANIFEST = Path(__file__).resolve().parents[1] / "mcp.tools.v1.json"
+
+
+def _route(name: str) -> ast.FunctionDef:
+    for node in ast.parse(API.read_text()).body:
+        if isinstance(node, ast.FunctionDef) and node.name == name:
+            return node
+    raise AssertionError(f"{name} is not a route in flows_api.py any more")
+
+
+def test_the_manifest_file_exists_and_is_this_domain_s():
+    doc = json.loads(MANIFEST.read_text())
+    assert doc["contract"] == "mcp.tools.v1"
+    assert doc["domain"] == "flows"
+    assert doc["depends_on"] == ["identity"], "flows may depend on identity and nothing else"
+
+
+def test_every_tool_binds_to_a_route_this_service_actually_serves():
+    """The manifest is a claim about THIS service. The gateway checks it against our OpenAPI at
+    boot; this checks it against our source, where it is cheaper to be wrong."""
+    src = API.read_text()
+    for tool in json.loads(MANIFEST.read_text())["tools"]:
+        method, path = tool["route"]["method"].lower(), tool["route"]["path"]
+        assert f'@app.{method}("{path}"' in src, f"{tool['name']} -> {method.upper()} {path}"
+
+
+def test_no_tool_takes_a_credential_as_an_argument():
+    """PRD 40.8 — one authentication path into the edge: a bearer header, session-bound."""
+    banned = {"token", "api_key", "apikey", "key", "access_token", "bearer", "credential",
+              "password", "secret"}
+    for tool in json.loads(MANIFEST.read_text())["tools"]:
+        assert not (set(a.lower() for a in tool.get("arguments") or []) & banned), tool["name"]
+
+
+def test_the_manifest_route_reads_the_file_rather_than_restating_it():
+    """A second copy of the tool list, in Python, would be a second thing to keep in step."""
+    body = ast.unparse(_route("mcp_tools_manifest"))
+    assert "_MANIFEST_PATH" in body and "read_text" in body
+    assert "flows_list" not in body, "the route must not restate the manifest"
+
+
+def test_the_manifest_route_is_open():
+    """It names routes and argument names, never data and never a credential. An assembler that had
+    to authenticate to discover the surface could not boot before identity did."""
+    decs = [ast.unparse(d) for d in _route("mcp_tools_manifest").decorator_list]
+    assert not any("Depends(auth)" in d or "timeline_auth" in d for d in decs)

--- a/core/meetings/services/mcp/src/vexa_mcp/app.py
+++ b/core/meetings/services/mcp/src/vexa_mcp/app.py
@@ -33,6 +33,9 @@ from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from fastapi_mcp import FastApiMCP
 from pydantic import BaseModel, Field, PrivateAttr, model_validator
 
+from . import bind as bind_mod
+from . import discover as discover_mod
+from . import register as register_mod
 from .link_parser import ParseMeetingLinkResponse, parse_meeting_url
 from .prompts import PROMPTS, get_prompt_result
 from .streamable_http import install_streaming_http_transport
@@ -575,12 +578,17 @@ def create_app(
     gateway_url: Optional[str] = None,
     *,
     transport: Optional[httpx.AsyncBaseTransport] = None,
+    assembly_env: Optional[dict] = None,
+    assembly_transport: Optional[httpx.BaseTransport] = None,
 ) -> FastAPI:
     """Build the MCP service app.
 
     ``gateway_url`` — the PUBLIC API base (env ``GATEWAY_URL``, compose ``http://gateway:8000``).
     ``transport``   — optional httpx transport override; the tests inject ``httpx.MockTransport``
                       so the shipped forwarding path runs with no network.
+    ``assembly_env`` / ``assembly_transport`` — the same seam for the DISCOVERY hop: which domains
+                      this deployment carries, and how their manifests are fetched. `VEXA_MCP_ASSEMBLY_OFF`
+                      skips assembly entirely, which is what the fourteen-tool surface tests want.
     """
     base_url = (gateway_url or os.getenv("GATEWAY_URL") or _DEFAULT_GATEWAY_URL).rstrip("/")
 
@@ -1203,6 +1211,31 @@ def create_app(
         if ticket_url:
             ack["url"] = ticket_url
         return ack
+
+    # ---------------------------
+    # ASSEMBLY (PRD decision 40) — the tools the DEPLOYED domains declare
+    # ---------------------------
+    # The fourteen tools above are this edge's own. Everything else it serves belongs to a domain:
+    # meetings owns the bots and transcripts, identity owns the person, flows owns the reaction
+    # engine, agent owns the desks. Each publishes a manifest at `/.well-known/mcp-tools.json`, this
+    # asks the ones the deployment names, and every tool becomes a route here with
+    # `operation_id=<name>` — the SAME mechanism the fourteen use, so an assembled tool and a
+    # built-in one are indistinguishable to a client.
+    #
+    # BEFORE `FastApiMCP(app, ...)`, necessarily: the MCP surface is derived from this app's
+    # OpenAPI, so a route added afterwards would be a tool nobody can see.
+    #
+    # AND IT FAILS THE BOOT. Every rule in `manifest.py` is a failure that is otherwise silent — a
+    # domain's tools quietly missing, one name claimed twice, a manifest naming a route its service
+    # does not serve. A server that started anyway would answer `tools/list` with a lie.
+    app.state.assembly = None
+    _assembly_env = assembly_env if assembly_env is not None else os.environ
+    if not _assembly_env.get("VEXA_MCP_ASSEMBLY_OFF"):
+        with httpx.Client(transport=assembly_transport) as _boot:
+            _assembly, _openapi, _bases = discover_mod.discover(_boot, env=_assembly_env)
+        _bound = bind_mod.verify(_assembly, _openapi)
+        register_mod.register(app, _bound, _bases, transport=transport)
+        app.state.assembly = _assembly
 
     # ---------------------------
     # MCP mount + prompts

--- a/core/meetings/services/mcp/src/vexa_mcp/bind.py
+++ b/core/meetings/services/mcp/src/vexa_mcp/bind.py
@@ -1,0 +1,94 @@
+"""BINDING — the manifest's promise, checked against the service that has to keep it.
+
+A manifest binds a NAME to a ROUTE and carries no schema and no description of its own. Both are
+DERIVED here, from the bound route's OpenAPI operation — the same mechanism this service already
+runs on for its own fourteen tools (`operation_id` on a FastAPI route, read by `FastApiMCP`). One
+place to write a tool's shape is why a tool and the route behind it cannot disagree.
+
+That makes a manifest a CLAIM ABOUT ANOTHER SERVICE, and this module is where the claim is checked.
+Two failures fail the boot:
+
+  * a route the domain does not serve — a manifest lying about its own service, which would surface
+    as a tool that appears in `tools/list` and 404s the first time an agent calls it;
+  * an argument the operation does not take — an argument an agent can pass and the route silently
+    ignores is the worst reply available, because the agent then reports success on something that
+    did not happen.
+
+Path parameters are arguments without being declared: `/reactions/{id}/{verb}` cannot be called
+without them, and a manifest that had to restate them would be a second place to write the route.
+"""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import Dict, List
+
+from .manifest import Assembly, ManifestError, Tool
+
+_PATH_PARAM = re.compile(r"\{([A-Za-z_][A-Za-z0-9_]*)\}")
+
+
+@dataclass(frozen=True)
+class BoundTool:
+    tool: Tool
+    description: str
+    parameters: Dict[str, dict] = field(default_factory=dict)
+    path_params: tuple = ()
+
+    @property
+    def name(self) -> str:
+        return self.tool.name
+
+
+def _operation(openapi: dict, method: str, path: str) -> dict | None:
+    item = (openapi.get("paths") or {}).get(path)
+    if not isinstance(item, dict):
+        return None
+    op = item.get(method.lower())
+    return op if isinstance(op, dict) else None
+
+
+def verify(assembly: Assembly, openapi_by_domain: Dict[str, dict]) -> List[BoundTool]:
+    """Every routed tool in the assembly, bound to its operation. Raises :class:`ManifestError`."""
+    out: List[BoundTool] = []
+    for tool in assembly.tools:
+        if tool.route is None:
+            # Edge-owned: this service implements it, so there is no other service to check against.
+            continue
+        spec = openapi_by_domain.get(tool.domain)
+        if not spec:
+            raise ManifestError(
+                f"{tool.domain}/{tool.name}: no OpenAPI from {tool.domain} — refusing to bind a "
+                "tool blind; a surface nobody checked is a surface nobody can trust")
+        method, path = tool.route["method"], tool.route["path"]
+        op = _operation(spec, method, path)
+        if op is None:
+            raise ManifestError(
+                f"{tool.domain}/{tool.name}: {tool.domain} does not serve {method} {path} — the "
+                "manifest names a route its own service does not have")
+        params = {p.get("name"): (p.get("schema") or {})
+                  for p in (op.get("parameters") or []) if p.get("name")}
+        path_params = tuple(_PATH_PARAM.findall(path))
+        declared = {}
+        for arg in tool_arguments(tool):
+            if arg in path_params:
+                continue
+            if arg not in params:
+                raise ManifestError(
+                    f"{tool.domain}/{tool.name}: declares the argument {arg!r}, which "
+                    f"{method} {path} does not take — an argument the route ignores is a success "
+                    "the agent reports for something that did not happen")
+            declared[arg] = params[arg]
+        out.append(BoundTool(
+            tool=tool,
+            description=str(op.get("summary") or op.get("description") or "").strip(),
+            parameters=declared,
+            path_params=path_params,
+        ))
+    return out
+
+
+def tool_arguments(tool: Tool) -> tuple:
+    """The arguments a manifest declared for a tool. Kept as a function rather than a field so the
+    manifest shape and the bind step have one reader between them."""
+    return tuple(getattr(tool, "arguments", ()) or ())

--- a/core/meetings/services/mcp/src/vexa_mcp/discover.py
+++ b/core/meetings/services/mcp/src/vexa_mcp/discover.py
@@ -1,0 +1,101 @@
+"""DISCOVERY — asking the deployed domains what they serve, at startup.
+
+The manifests are not baked into this image. Each domain serves its own at
+``/.well-known/mcp-tools.json``, and its OpenAPI beside it, so the surface this edge presents is the
+surface the RUNNING builds actually have. A deployment cannot advertise a tool the service behind it
+does not serve, because the service is the one that said it did.
+
+WHICH DOMAINS EXIST is a deployment fact, read from the environment: a domain whose base URL is set
+is deployed. That is the whole of the eight-configuration story — identity plus any subset of
+meetings, flows and agent — and it needs no profile name, because a profile name is a second place
+to say something the URLs already say.
+
+FAIL DIRECTIONS, both deliberate and opposite:
+  * a domain that IS configured and does not answer FAILS THE BOOT. "The meetings tools are missing"
+    must never be something a person discovers by asking for one.
+  * a domain that is NOT configured contributes nothing and is not asked. Its tools are absent, and
+    absent is a state an agent recovers from.
+"""
+from __future__ import annotations
+
+import os
+from typing import Dict, Optional, Set, Tuple
+
+import httpx
+
+from .manifest import Assembly, ManifestError, assemble, load_mounted
+
+#: domain -> the env key naming its base URL. Identity is always required; the other three are the
+#: subset this deployment carries.
+DOMAIN_URL_ENV = {
+    "identity": "ADMIN_API_URL",
+    "meetings": "MEETING_API_URL",
+    "flows": "FLOWS_API_URL",
+    "agent": "AGENT_API_URL",
+}
+MANIFEST_PATH = "/.well-known/mcp-tools.json"
+OPENAPI_PATH = "/openapi.json"
+MOUNT_DIR_ENV = "VEXA_MCP_MANIFEST_DIR"
+
+
+def deployed_domains(env: Optional[dict] = None) -> Dict[str, str]:
+    """``{domain: base_url}`` for every domain this deployment names. Nothing else is asked."""
+    env = env if env is not None else os.environ
+    out = {}
+    for domain, key in DOMAIN_URL_ENV.items():
+        url = (env.get(key) or "").strip().rstrip("/")
+        if url:
+            out[domain] = url
+    return out
+
+
+def fetch(client: httpx.Client, url: str) -> Optional[dict]:
+    try:
+        r = client.get(url, timeout=5)
+        if r.status_code != 200:
+            return None
+        return r.json()
+    except Exception:  # noqa: BLE001 — an unreachable domain is decided by the caller, not here
+        return None
+
+
+def discover(client: httpx.Client, *, env: Optional[dict] = None
+             ) -> Tuple[Assembly, Dict[str, dict], Dict[str, str]]:
+    """``(assembly, openapi_by_domain, base_urls)``. Raises :class:`ManifestError` on a boot rule.
+
+    SYNCHRONOUS on purpose. This runs once, at boot, and every rule it applies is one that must stop
+    the process rather than degrade a request — so it belongs before the server is listening, not in
+    an async startup hook racing the first caller."""
+    env = env if env is not None else os.environ
+    bases = deployed_domains(env)
+    manifests, openapi = [], {}
+    for domain, base in bases.items():
+        doc = fetch(client, f"{base}{MANIFEST_PATH}")
+        if doc is None:
+            # A domain may legitimately carry no manifest yet — it simply contributes no tools.
+            # What it may NOT do is carry one and be unreachable, which is the case below.
+            continue
+        manifests.append(doc)
+        spec = fetch(client, f"{base}{OPENAPI_PATH}")
+        if spec is None:
+            raise ManifestError(
+                f"{domain} published a manifest but its OpenAPI at {base}{OPENAPI_PATH} did not "
+                "answer — refusing to bind a tool blind")
+        openapi[domain] = spec
+
+    for doc in load_mounted(env.get(MOUNT_DIR_ENV)):
+        domain = doc.get("domain")
+        base = (env.get(f"{str(domain).upper()}_API_URL") or "").strip().rstrip("/")
+        if not base:
+            raise ManifestError(
+                f"a mounted manifest for {domain!r} is present but {str(domain).upper()}_API_URL "
+                "is unset — a private domain that cannot be reached is a tool list that lies")
+        bases[domain] = base
+        manifests.append(doc)
+        spec = fetch(client, f"{base}{OPENAPI_PATH}")
+        if spec is None:
+            raise ManifestError(f"{domain} (mounted): no OpenAPI at {base}{OPENAPI_PATH}")
+        openapi[domain] = spec
+
+    deployed: Set[str] = set(bases)
+    return assemble(manifests, deployed=deployed), openapi, bases

--- a/core/meetings/services/mcp/src/vexa_mcp/manifest.py
+++ b/core/meetings/services/mcp/src/vexa_mcp/manifest.py
@@ -1,0 +1,215 @@
+"""ASSEMBLY — one MCP server, built from the manifests of the domains that are deployed.
+
+PRD decision 40, founder rulings of 2026-09-02. A tool belongs to the domain that owns the door
+behind it: meetings owns the bots and the transcripts, identity owns the person, flows owns the
+reaction engine, agent owns the desks. This service is an EDGE — like the gateway it carries the
+caller's identity and holds no domain logic — and its whole job is to ask each deployed domain what
+it serves, refuse the combinations that cannot be right, and present the union as one surface.
+
+TWO SOURCES, ONE NAME SPACE. `oss` manifests come from the packages in this repo; `mounted` ones
+come from a directory a private deployment supplies, so a paid domain composes onto this line
+without a line of it living here. They are assembled identically and compete for names equally — a
+mounted manifest gets no precedence, which is what makes a mount safe: it can COLLIDE, it can never
+SHADOW.
+
+EVERY RULE HERE FAILS THE BOOT. Not because failing loudly is a virtue in itself, but because each
+of these failures is otherwise silent, and a silent one is discovered by a person asking for a tool
+that is not there:
+
+    a deployed domain that does not answer   ->  a whole domain's tools missing, quietly
+    one name claimed twice                   ->  last-one-wins, and nobody knows which won
+    a route the domain does not serve        ->  the manifest lying about its own service
+    two entitlement hooks                    ->  "may this person act" answered twice
+
+The one thing that is NOT a failure is a domain that is simply not deployed. Its tools are ABSENT
+from `tools/list` — an agent that cannot see a tool recovers; an agent told a tool exists and then
+handed a 502 tells the person the product is broken.
+"""
+from __future__ import annotations
+
+import json
+import pathlib
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Set
+
+CONTRACT = "mcp.tools.v1"
+
+# PRD 40.8 — EXACTLY ONE AUTHENTICATION PATH into this edge: a bearer token in the header, the
+# session bound by `Mcp-Session-Id`, and a token minted mid-conversation bound to that session.
+# There is no `/do` GET bridge and no `token=` tool argument, because both put a credential in a
+# query string or an argument list: right for a fetch-only agent on a private host, wrong anywhere
+# requests are logged, and impossible to withdraw once a transcript holds it.
+#
+# It is enforced HERE, at the seam where a tool's surface is decided, rather than trusted to every
+# domain: a tool's schema is derived from its route's OpenAPI operation, and a route has no `token`
+# parameter — so the rule is mostly kept by construction. This list is what catches a domain that
+# reintroduces one on purpose.
+CREDENTIAL_ARGUMENTS = {"token", "api_key", "apikey", "key", "access_token", "bearer",
+                        "credential", "password", "secret"}
+DOMAINS = {"meetings", "identity", "flows", "agent", "gateway", "rehearse", "billing"}
+IDENTITIES = {"user", "admin", "operator", "none"}
+METHODS = {"GET", "POST", "PUT", "PATCH", "DELETE"}
+
+
+class ManifestError(Exception):
+    """A manifest, or a combination of them, that this deployment must not boot with."""
+
+
+@dataclass(frozen=True)
+class Tool:
+    name: str
+    domain: str
+    source: str
+    identity: str
+    requires: frozenset
+    route: Optional[dict]
+    base_url_env: Optional[str]
+    arguments: tuple = ()
+    note: str = ""
+
+
+@dataclass(frozen=True)
+class Entitlement:
+    domain: str
+    route: dict
+    answers: str
+
+
+@dataclass
+class Assembly:
+    tools: List[Tool] = field(default_factory=list)
+    entitlement: Optional[Entitlement] = None
+    absent_domains: Set[str] = field(default_factory=set)
+    by_domain: Dict[str, int] = field(default_factory=dict)
+
+
+def validate(doc: dict) -> dict:
+    """One manifest, on its own. Raises :class:`ManifestError` naming what is wrong."""
+    if not isinstance(doc, dict) or doc.get("contract") != CONTRACT:
+        raise ManifestError(f"not a {CONTRACT} manifest")
+    domain = doc.get("domain")
+    if domain not in DOMAINS:
+        raise ManifestError(f"unknown domain {domain!r}")
+    if doc.get("source") not in ("oss", "mounted"):
+        raise ManifestError(f"{domain}: source must be oss or mounted")
+
+    # A domain's doors are IDENTITY, RUNTIME and ITSELF. Runtime is a primitive — it spawns bots for
+    # meetings and workers for agent, has no tools and no person-facing surface — so it is allowed
+    # exactly as identity is, and is not a domain that can appear here at all.
+    depends = doc.get("depends_on")
+    if not isinstance(depends, list) or not set(depends) <= {"identity"}:
+        raise ManifestError(
+            f"{domain}: depends_on may name identity and nothing else (got {depends!r}) — "
+            "identity is the only domain everyone may depend on")
+    if domain == "identity" and depends:
+        raise ManifestError("identity: depends_on must be empty — it depends on nothing")
+
+    for t in doc.get("tools") or []:
+        name = t.get("name")
+        if not isinstance(name, str) or not name:
+            raise ManifestError(f"{domain}: a tool with no name")
+        if t.get("identity") not in IDENTITIES:
+            raise ManifestError(f"{domain}/{name}: identity must be one of {sorted(IDENTITIES)}")
+        requires = t.get("requires")
+        if not isinstance(requires, list) or not requires:
+            raise ManifestError(f"{domain}/{name}: requires must name at least one domain")
+        allowed = {domain, "identity"}
+        if domain == "rehearse":                 # the dev harness drives every door on purpose
+            allowed = DOMAINS
+        if not set(requires) <= allowed:
+            raise ManifestError(
+                f"{domain}/{name}: requires may name {sorted(allowed)} (got {sorted(requires)}) — "
+                "a tool that needs another domain is a composition, and a composition has an owner")
+        # PRD 40.8: one authentication path. A tool may not take a credential as an ARGUMENT.
+        for arg in t.get("arguments") or []:
+            if str(arg).strip().lower() in CREDENTIAL_ARGUMENTS:
+                raise ManifestError(
+                    f"{domain}/{name}: declares a credential argument {arg!r} — this edge has "
+                    "exactly one authentication path (a bearer header, session-bound). A "
+                    "credential in an argument list is in the transcript forever.")
+        route = t.get("route")
+        if route is None:
+            # Edge-owned: the assembler serves it itself. Only legal where there is no door.
+            if doc.get("base_url_env"):
+                raise ManifestError(
+                    f"{domain}/{name}: route is null but this domain HAS a door "
+                    f"({doc['base_url_env']}) — a tool with a door must name its route")
+        else:
+            if route.get("method") not in METHODS or not str(route.get("path", "")).startswith("/"):
+                raise ManifestError(f"{domain}/{name}: route needs a method and an absolute path")
+    ent = doc.get("entitlement")
+    if ent is not None:
+        if not isinstance(ent, dict) or not ent.get("route") or not ent.get("answers"):
+            raise ManifestError(f"{domain}: entitlement needs a route and what it answers")
+    return doc
+
+
+def load_mounted(directory: Optional[str]) -> List[dict]:
+    """Every manifest a private deployment supplied. EMPTY IS THE OSS PRODUCT, exactly.
+
+    A malformed file FAILS rather than being skipped: skipping it means a paid deployment silently
+    missing the tools it paid for, which is the worst outcome available here."""
+    if not directory:
+        return []
+    d = pathlib.Path(directory)
+    if not d.is_dir():
+        return []
+    out = []
+    for f in sorted(d.glob("*.mcp.tools.v1.json")):
+        try:
+            doc = json.loads(f.read_text(encoding="utf-8"))
+        except Exception as e:  # noqa: BLE001
+            raise ManifestError(f"mounted manifest {f.name} could not be read: {e}") from e
+        if not isinstance(doc, dict):
+            raise ManifestError(f"mounted manifest {f.name} is not an object")
+        # A file in the mount IS mounted, whatever it claims about itself — otherwise the one
+        # property that makes mounts safe (no precedence) could be opted out of by writing a word.
+        doc["source"] = "mounted"
+        out.append(doc)
+    return out
+
+
+def assemble(manifests: List[dict], *, deployed: Set[str],
+             required_domains: Optional[Set[str]] = None) -> Assembly:
+    """The union, with every combination rule applied. Raises :class:`ManifestError`."""
+    answered = {d.get("domain") for d in manifests}
+    for missing in sorted((required_domains or set()) - answered):
+        raise ManifestError(
+            f"{missing} is deployed but did not answer with a manifest — refusing to boot with a "
+            "domain's tools silently absent")
+
+    out = Assembly()
+    claimed: Dict[str, tuple] = {}
+    for doc in manifests:
+        validate(doc)
+        domain, source = doc["domain"], doc["source"]
+        ent = doc.get("entitlement")
+        if ent:
+            if out.entitlement is not None:
+                raise ManifestError(
+                    f"two manifests declare an entitlement hook ({out.entitlement.domain} and "
+                    f"{domain}) — 'may this person act' is not a question with two answers")
+            out.entitlement = Entitlement(domain=domain, route=ent["route"],
+                                          answers=ent["answers"])
+        for t in doc.get("tools") or []:
+            name = t["name"]
+            prior = claimed.get(name)
+            if prior:
+                raise ManifestError(
+                    f"the tool name {name!r} is claimed by two manifests ({prior[0]}/{prior[1]} "
+                    f"and {domain}/{source}) — a duplicate is a design question and a person has "
+                    "to answer it; a mounted manifest never wins by default")
+            claimed[name] = (domain, source)
+            if not set(t["requires"]) <= deployed:
+                continue
+            out.tools.append(Tool(
+                name=name, domain=domain, source=source, identity=t["identity"],
+                requires=frozenset(t["requires"]), route=t.get("route"),
+                base_url_env=doc.get("base_url_env"),
+                arguments=tuple(t.get("arguments") or ()), note=t.get("note", "")))
+    for doc in manifests:
+        if doc["domain"] not in deployed:
+            out.absent_domains.add(doc["domain"])
+    for t in out.tools:
+        out.by_domain[t.domain] = out.by_domain.get(t.domain, 0) + 1
+    return out

--- a/core/meetings/services/mcp/src/vexa_mcp/register.py
+++ b/core/meetings/services/mcp/src/vexa_mcp/register.py
@@ -1,0 +1,111 @@
+"""REGISTRATION — an assembled tool becomes one route on this service, and therefore one MCP tool.
+
+`FastApiMCP` derives the MCP surface from this app's OpenAPI: a route with `operation_id=<name>` IS
+a tool called `<name>`. That is how the fourteen built-in tools work, so assembling through the same
+mechanism makes an assembled tool and a built-in one indistinguishable to a client — which is the
+whole point of assembling rather than proxying, and the reason there is no second code path to keep
+in step.
+
+WHAT TRAVELS: the caller's own credential, as `X-API-Key`, exactly as the fourteen send it. Nothing
+else. There is one authentication path into this edge (PRD 40.8) — a bearer in the header, the
+session bound by `Mcp-Session-Id` — so a tool cannot take a credential as an argument and this
+forward cannot invent one.
+
+WHAT DOES NOT TRAVEL: anything the manifest did not declare. An argument the owning route ignores is
+the worst reply available to an agent — it reports success for something that did not happen — so an
+undeclared parameter is dropped here rather than forwarded and silently discarded there.
+"""
+from __future__ import annotations
+
+from typing import Dict, List, Optional
+
+import httpx
+from fastapi import FastAPI, HTTPException, Request
+from fastapi.responses import JSONResponse
+
+from .bind import BoundTool
+
+
+def _caller_key(request: Request) -> str:
+    """The credential the edge already resolved. One carrier, no fallbacks: `x-api-key`, or the
+    bearer the MCP transport contract uses, adapted at this boundary exactly as `_mcp_key` does at
+    the gateway."""
+    key = (request.headers.get("x-api-key") or "").strip()
+    if key:
+        return key
+    auth = (request.headers.get("authorization") or "").strip()
+    if not auth:
+        return ""
+    scheme, _, token = auth.partition(" ")
+    return (token.strip() if scheme.lower() == "bearer" else auth) or ""
+
+
+def register(app: FastAPI, bound: List[BoundTool], base_urls: Dict[str, str], *,
+             transport: Optional[httpx.AsyncBaseTransport] = None) -> List[str]:
+    """Add one route per bound tool. Returns the names registered, in order."""
+    names: List[str] = []
+    for bt in bound:
+        names.append(_add(app, bt, base_urls[bt.tool.domain], transport))
+    return names
+
+
+def _add(app: FastAPI, bt: BoundTool, base: str,
+         transport: Optional[httpx.AsyncBaseTransport]) -> str:
+    method = bt.tool.route["method"]
+    template = bt.tool.route["path"]
+    declared = tuple(bt.parameters)
+    path_params = tuple(bt.path_params)
+
+    async def endpoint(request: Request):
+        key = _caller_key(request)
+        if key == "" and bt.tool.identity != "none":
+            raise HTTPException(status_code=401, detail="this tool needs your Vexa credential")
+        body = {}
+        if method in ("POST", "PUT", "PATCH"):
+            try:
+                body = await request.json()
+            except Exception:  # noqa: BLE001 — an empty body is a legitimate call
+                body = {}
+        body = body if isinstance(body, dict) else {}
+
+        path = template
+        for name in path_params:
+            value = body.pop(name, None)
+            if value is None:
+                value = request.query_params.get(name)
+            if value in (None, ""):
+                raise HTTPException(status_code=422,
+                                    detail=f"{bt.name} needs {name}")
+            path = path.replace("{" + name + "}", str(value))
+
+        params = {n: request.query_params[n] for n in declared if n in request.query_params}
+        for n in declared:
+            if n not in params and n in body:
+                params[n] = body.pop(n)
+
+        try:
+            async with httpx.AsyncClient(timeout=10, transport=transport) as client:
+                r = await client.request(
+                    method, f"{base}{path}",
+                    headers={"X-API-Key": key, "Content-Type": "application/json"},
+                    params=params or None,
+                    json=body if method in ("POST", "PUT", "PATCH") else None)
+        except httpx.TimeoutException:
+            raise HTTPException(status_code=504, detail=f"{bt.tool.domain} timed out")
+        except httpx.RequestError as e:
+            raise HTTPException(status_code=503, detail=f"{bt.tool.domain} is unreachable: {e}")
+        # THE DOMAIN'S OWN ANSWER, UNCHANGED. A 403 from flows is flows' answer and an agent needs
+        # to see it; rewriting it here would turn "you may not do that" into "we are broken".
+        try:
+            payload = r.json() if r.content else {}
+        except Exception:  # noqa: BLE001
+            payload = {"detail": r.text[:2000]}
+        return JSONResponse(status_code=r.status_code, content=payload)
+
+    endpoint.__name__ = bt.name
+    endpoint.__doc__ = bt.description or f"{bt.tool.domain}: {method} {template}"
+    app.add_api_route(f"/tools/{bt.name}", endpoint, methods=[method],
+                      operation_id=bt.name, name=bt.name,
+                      summary=bt.description or None,
+                      description=bt.description or None)
+    return bt.name

--- a/core/meetings/services/mcp/tests/test_assembled_surface.py
+++ b/core/meetings/services/mcp/tests/test_assembled_surface.py
@@ -1,0 +1,95 @@
+"""END TO END — a domain's manifest becomes a tool an agent sees in `tools/list`.
+
+The point of assembling rather than proxying: an assembled tool and one of this service's own
+fourteen are indistinguishable to a client, because both are a route with `operation_id=<name>` that
+`FastApiMCP` reads out of the same OpenAPI.
+
+The flows manifest used here is THE FILE IN THE REPO — `core/flows/mcp.tools.v1.json`, the same one
+flows-api serves at `/.well-known/mcp-tools.json`. If that file stops being assemblable, this fails.
+"""
+from __future__ import annotations
+
+import json
+import pathlib
+
+import httpx
+
+from vexa_mcp import create_app
+from vexa_mcp.manifest import CONTRACT
+
+REPO = pathlib.Path(__file__).resolve().parents[5]
+FLOWS_MANIFEST = json.loads((REPO / "core" / "flows" / "mcp.tools.v1.json").read_text())
+
+FLOWS_OPENAPI = {"paths": {
+    "/flows": {"get": {"summary": "Every flow version the engine knows", "parameters": []}},
+    "/reactions": {"get": {"summary": "The operator projection", "parameters": [
+        {"name": "status", "in": "query", "schema": {"type": "string"}},
+        {"name": "subject", "in": "query", "schema": {"type": "string"}}]}},
+    "/reactions/{reaction_id}/{verb}": {"post": {"summary": "Steer one reaction", "parameters": []}},
+    "/timeline": {"get": {"summary": "One person's day, in order", "parameters": [
+        {"name": "subject", "in": "query", "schema": {"type": "string"}},
+        {"name": "since", "in": "query", "schema": {"type": "string"}},
+        {"name": "until", "in": "query", "schema": {"type": "string"}},
+        {"name": "limit", "in": "query", "schema": {"type": "integer"}}]}},
+}}
+
+BUILT_IN = 14
+
+
+def _boot(**env):
+    def handler(request: httpx.Request) -> httpx.Response:
+        url = str(request.url)
+        # ONLY the flows host answers. Identity is configured (it always is) and carries no manifest
+        # yet, which is the ordinary state of a domain that has not published one.
+        if not url.startswith("http://flows"):
+            return httpx.Response(404)
+        if url.endswith("/.well-known/mcp-tools.json"):
+            return httpx.Response(200, json=FLOWS_MANIFEST)
+        if url.endswith("/openapi.json"):
+            return httpx.Response(200, json=FLOWS_OPENAPI)
+        return httpx.Response(404)
+
+    return create_app(
+        "http://gateway.test",
+        transport=httpx.MockTransport(lambda r: httpx.Response(200, json={})),
+        assembly_env={"ADMIN_API_URL": "http://identity", **env},
+        assembly_transport=httpx.MockTransport(handler),
+    )
+
+
+def test_the_repo_s_flows_manifest_is_the_one_that_gets_assembled():
+    assert FLOWS_MANIFEST["contract"] == CONTRACT and FLOWS_MANIFEST["domain"] == "flows"
+
+
+def test_a_deployment_with_flows_serves_the_flows_tools_beside_the_built_in_ones():
+    app = _boot(FLOWS_API_URL="http://flows")
+    names = {t.name for t in app.state.mcp.tools}
+    declared = {t["name"] for t in FLOWS_MANIFEST["tools"]}
+    assert declared <= names, f"missing from tools/list: {sorted(declared - names)}"
+    assert len(names) == BUILT_IN + len(declared)
+
+
+def test_a_deployment_without_flows_serves_exactly_the_built_in_fourteen():
+    """Absent, not present-and-failing. An agent that cannot see a tool recovers; one told a tool
+    exists and handed a 502 tells the person the product is broken."""
+    app = _boot()
+    assert len(app.state.mcp.tools) == BUILT_IN
+    assert app.state.assembly is not None and not app.state.assembly.tools
+
+
+def test_an_assembled_tool_carries_the_owning_route_s_description():
+    """The manifest holds no description of its own — it is derived from the route's OpenAPI, so a
+    tool and the route behind it cannot disagree."""
+    app = _boot(FLOWS_API_URL="http://flows")
+    tool = next(t for t in app.state.mcp.tools if t.name == "flows_list")
+    assert "Every flow version the engine knows" in (tool.description or "")
+
+
+def test_no_assembled_tool_takes_a_credential_argument():
+    """PRD 40.8 — one authentication path into this edge: a bearer header, session-bound."""
+    app = _boot(FLOWS_API_URL="http://flows")
+    banned = {"token", "api_key", "apikey", "access_token", "password", "secret"}
+    for t in app.state.mcp.tools:
+        props = set(((t.inputSchema if hasattr(t, "inputSchema") else t.input_schema) or {})
+                    .get("properties", {}))
+        assert not (props & banned), f"{t.name} takes {sorted(props & banned)}"

--- a/core/meetings/services/mcp/tests/test_assembly.py
+++ b/core/meetings/services/mcp/tests/test_assembly.py
@@ -1,0 +1,173 @@
+"""THE ASSEMBLER — one MCP server, built from the manifests of the domains that are deployed.
+
+PRD decision 40, founder rulings of 2026-09-02. A tool belongs to the domain that owns the door
+behind it; this service is an EDGE that assembles what those domains declare, and holds no domain
+logic of its own. It also reads a MOUNTED manifest directory, so a private paid domain composes onto
+the line without a line of it living in this repo.
+
+Every rule below fails the BOOT rather than degrading, and each one is a failure that would
+otherwise be silent:
+
+  * a domain that is deployed but does not answer — "the meetings tools are missing" must never be
+    something a person discovers by asking for one;
+  * a tool name claimed twice — last-one-wins would let a mounted private manifest shadow an OSS
+    tool, which is the one thing a mount must never be able to do;
+  * a manifest naming a route its own service does not serve — a manifest lying about its service is
+    the only failure this design could otherwise hide;
+  * two entitlement hooks — "who decides whether this person may act" is not a question with two
+    answers.
+
+A tool whose `requires` is not satisfied is ABSENT from tools/list, never present-and-failing: an
+agent that cannot see a tool recovers, one told a tool exists and handed a 502 tells the person the
+product is broken.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from vexa_mcp import manifest as m
+
+
+def _manifest(domain="flows", tools=None, **kw):
+    doc = {
+        "contract": "mcp.tools.v1", "domain": domain, "source": kw.pop("source", "oss"),
+        "owner": f"core/{domain}", "base_url_env": f"{domain.upper()}_API_URL",
+        "served_at": "/.well-known/mcp-tools.json", "depends_on": ["identity"],
+        "tools": tools if tools is not None else [
+            {"name": "flows_list", "identity": "operator", "requires": ["identity", "flows"],
+             "route": {"method": "GET", "path": "/flows"}}],
+    }
+    doc.update(kw)
+    return doc
+
+
+# ── what a manifest must be ──────────────────────────────────────────────────────────────────
+def test_a_manifest_may_only_depend_on_identity():
+    """The independence ruling, checked where it is declared. Meetings, flows and agent each point
+    at identity and nothing else, which is what makes every configuration a product."""
+    with pytest.raises(m.ManifestError, match="depends_on"):
+        m.validate(_manifest(depends_on=["identity", "agent"]))
+    m.validate(_manifest(depends_on=["identity"]))
+    m.validate(_manifest(domain="identity", depends_on=[], base_url_env="ADMIN_API_URL", tools=[
+        {"name": "settings", "identity": "user", "requires": ["identity"],
+         "route": {"method": "GET", "path": "/user/settings"}}]))
+
+
+def test_a_tool_requires_its_own_domain_and_identity_only():
+    with pytest.raises(m.ManifestError, match="requires"):
+        m.validate(_manifest(tools=[
+            {"name": "x", "identity": "user", "requires": ["identity", "meetings"],
+             "route": {"method": "GET", "path": "/x"}}]))
+
+
+def test_an_edge_owned_tool_may_have_no_route_only_when_it_has_no_door():
+    m.validate(_manifest(domain="gateway", base_url_env=None, served_at=None, tools=[
+        {"name": "vexa_overview", "identity": "none", "requires": ["identity"], "route": None}]))
+    with pytest.raises(m.ManifestError, match="route"):
+        m.validate(_manifest(tools=[
+            {"name": "x", "identity": "user", "requires": ["identity", "flows"], "route": None}]))
+
+
+# ── assembly ─────────────────────────────────────────────────────────────────────────────────
+def test_only_tools_whose_domains_are_deployed_are_served():
+    """Eight configurations, not two. A tool the deployment cannot satisfy is ABSENT."""
+    flows = _manifest()
+    agent = _manifest(domain="agent", base_url_env="AGENT_API_URL", tools=[
+        {"name": "workspace_tree", "identity": "user", "requires": ["identity", "agent"],
+         "route": {"method": "GET", "path": "/api/workspace/tree"}}])
+    both = m.assemble([flows, agent], deployed={"identity", "flows", "agent"})
+    assert {t.name for t in both.tools} == {"flows_list", "workspace_tree"}
+    no_agents = m.assemble([flows, agent], deployed={"identity", "flows"})
+    assert {t.name for t in no_agents.tools} == {"flows_list"}
+    assert "agent" in no_agents.absent_domains
+
+
+def test_a_name_claimed_twice_fails_the_boot_and_names_both():
+    a = _manifest()
+    b = _manifest(domain="agent", base_url_env="AGENT_API_URL", tools=[
+        {"name": "flows_list", "identity": "user", "requires": ["identity", "agent"],
+         "route": {"method": "GET", "path": "/x"}}])
+    with pytest.raises(m.ManifestError) as e:
+        m.assemble([a, b], deployed={"identity", "flows", "agent"})
+    assert "flows_list" in str(e.value) and "flows" in str(e.value) and "agent" in str(e.value)
+
+
+def test_a_mounted_manifest_gets_no_precedence_over_an_oss_one():
+    """The rule that makes a private mount safe: it collides, it does not shadow."""
+    oss = _manifest()
+    mounted = _manifest(domain="billing", source="mounted", base_url_env="BILLING_API_URL",
+                        tools=[{"name": "flows_list", "identity": "user",
+                                "requires": ["identity", "billing"],
+                                "route": {"method": "GET", "path": "/seats"}}])
+    with pytest.raises(m.ManifestError, match="claimed"):
+        m.assemble([oss, mounted], deployed={"identity", "flows", "billing"})
+
+
+def test_at_most_one_manifest_may_declare_the_entitlement_hook():
+    ent = {"route": {"method": "GET", "path": "/entitlement"}, "answers": "entitled(subject)"}
+    one = m.assemble([_manifest(domain="billing", source="mounted",
+                                base_url_env="BILLING_API_URL", entitlement=ent, tools=[])],
+                     deployed={"identity", "billing"})
+    assert one.entitlement is not None and one.entitlement.domain == "billing"
+    with pytest.raises(m.ManifestError, match="entitlement"):
+        m.assemble([_manifest(domain="billing", source="mounted",
+                              base_url_env="BILLING_API_URL", entitlement=ent, tools=[]),
+                    _manifest(domain="flows", entitlement=ent)],
+                   deployed={"identity", "billing", "flows"})
+
+
+def test_no_entitlement_hook_means_everyone_is_entitled():
+    """No manifest declares it => there is no hook => the OSS product exactly. This repo never
+    carries a gate shipped dark."""
+    assembled = m.assemble([_manifest()], deployed={"identity", "flows"})
+    assert assembled.entitlement is None
+
+
+def test_a_deployed_domain_that_does_not_answer_fails_the_boot():
+    """"The meetings tools are missing" must never be something a person finds by asking."""
+    with pytest.raises(m.ManifestError, match="did not answer"):
+        m.assemble([_manifest()], deployed={"identity", "flows", "meetings"},
+                   required_domains={"meetings"})
+
+
+# ── the mounted directory ────────────────────────────────────────────────────────────────────
+def test_the_mounted_directory_is_empty_by_default_and_that_is_the_oss_product(tmp_path):
+    assert m.load_mounted(None) == []
+    assert m.load_mounted(str(tmp_path)) == []
+
+
+def test_a_mounted_file_is_read_and_marked_mounted(tmp_path):
+    doc = _manifest(domain="billing", source="oss", base_url_env="BILLING_API_URL", tools=[])
+    (tmp_path / "billing.mcp.tools.v1.json").write_text(json.dumps(doc))
+    loaded = m.load_mounted(str(tmp_path))
+    assert len(loaded) == 1
+    assert loaded[0]["source"] == "mounted", "a file in the mount is mounted whatever it claims"
+
+
+def test_a_malformed_mounted_file_fails_the_boot_rather_than_being_skipped(tmp_path):
+    """Skipping it would mean a paid deployment silently missing the tools it paid for."""
+    (tmp_path / "broken.mcp.tools.v1.json").write_text("{not json")
+    with pytest.raises(m.ManifestError, match="broken"):
+        m.load_mounted(str(tmp_path))
+
+
+# ── one authentication path (PRD 40.8) ───────────────────────────────────────────────────────
+def test_a_tool_may_not_take_a_credential_as_an_argument():
+    """The rig's 64 tools each carried `token=""` — a credential in an argument list, which is in
+    the transcript forever and cannot be withdrawn. The edge has ONE path: a bearer header, with the
+    session bound by Mcp-Session-Id. It is enforced here because this is where a tool's surface is
+    decided; a route's OpenAPI has no such parameter, so the rule is mostly kept by construction and
+    this catches a domain that reintroduces one on purpose."""
+    for arg in ("token", "api_key", "access_token", "password"):
+        with pytest.raises(m.ManifestError, match="one authentication path"):
+            m.validate(_manifest(tools=[
+                {"name": "x", "identity": "user", "requires": ["identity", "flows"],
+                 "route": {"method": "GET", "path": "/x"}, "arguments": [arg, "since"]}]))
+
+
+def test_ordinary_arguments_are_untouched():
+    m.validate(_manifest(tools=[
+        {"name": "x", "identity": "user", "requires": ["identity", "flows"],
+         "route": {"method": "GET", "path": "/x"}, "arguments": ["since", "limit", "status"]}]))

--- a/core/meetings/services/mcp/tests/test_bind.py
+++ b/core/meetings/services/mcp/tests/test_bind.py
@@ -1,0 +1,111 @@
+"""BINDING — a manifest's promise checked against the service that has to keep it.
+
+A manifest binds a NAME to a ROUTE. It carries no JSON schema and no description of its own: both
+are DERIVED from the bound route's OpenAPI operation, which is the mechanism this service already
+runs on for its own fourteen tools (`operation_id` on a FastAPI route, read by `FastApiMCP`). One
+place to write a tool's shape means the tool and the route it forwards to cannot disagree.
+
+So the manifest is a claim about another service, and this is where the claim is checked. A route
+the domain does not serve, or an argument the operation does not take, FAILS THE BOOT — a manifest
+lying about its own service is the one failure this design could otherwise hide, and it would
+surface as a tool that exists in the list and 404s when an agent calls it.
+"""
+from __future__ import annotations
+
+import pytest
+
+from vexa_mcp import bind
+from vexa_mcp import manifest as m
+
+FLOWS_OPENAPI = {
+    "paths": {
+        "/flows": {"get": {"operationId": "list_flows", "summary": "Every flow version",
+                           "parameters": []}},
+        "/reactions": {"get": {"summary": "The operator projection", "parameters": [
+            {"name": "status", "in": "query", "schema": {"type": "string"}},
+            {"name": "source_event_prefix", "in": "query", "schema": {"type": "string"}}]}},
+        "/reactions/{reaction_id}/{verb}": {"post": {"summary": "Steer one reaction",
+                                                     "parameters": []}},
+    }
+}
+
+
+def _assembly(tools):
+    doc = {"contract": "mcp.tools.v1", "domain": "flows", "source": "oss", "owner": "core/flows",
+           "base_url_env": "FLOWS_API_URL", "served_at": "/.well-known/mcp-tools.json",
+           "depends_on": ["identity"], "tools": tools}
+    return m.assemble([doc], deployed={"identity", "flows"})
+
+
+def test_a_bound_tool_takes_its_description_from_the_route():
+    a = _assembly([{"name": "flows_list", "identity": "operator",
+                    "requires": ["identity", "flows"],
+                    "route": {"method": "GET", "path": "/flows"}}])
+    bound = bind.verify(a, {"flows": FLOWS_OPENAPI})
+    assert bound[0].description == "Every flow version"
+    assert bound[0].name == "flows_list", "the MCP name is the manifest's, not the operationId's"
+
+
+def test_a_route_the_domain_does_not_serve_fails_the_boot():
+    """The manifest lying about its own service — the one failure this design could otherwise hide."""
+    a = _assembly([{"name": "x", "identity": "user", "requires": ["identity", "flows"],
+                    "route": {"method": "GET", "path": "/nope"}}])
+    with pytest.raises(m.ManifestError, match="does not serve"):
+        bind.verify(a, {"flows": FLOWS_OPENAPI})
+
+
+def test_the_wrong_method_on_a_real_path_fails_too():
+    a = _assembly([{"name": "x", "identity": "user", "requires": ["identity", "flows"],
+                    "route": {"method": "DELETE", "path": "/flows"}}])
+    with pytest.raises(m.ManifestError, match="does not serve"):
+        bind.verify(a, {"flows": FLOWS_OPENAPI})
+
+
+def test_an_argument_the_operation_does_not_take_fails_the_boot():
+    """An argument an agent can pass and the route ignores is the worst reply available: the agent
+    reports success on something that did not happen."""
+    a = _assembly([{"name": "reactions_list", "identity": "operator",
+                    "requires": ["identity", "flows"],
+                    "route": {"method": "GET", "path": "/reactions"},
+                    "arguments": ["status", "invented"]}])
+    with pytest.raises(m.ManifestError, match="invented"):
+        bind.verify(a, {"flows": FLOWS_OPENAPI})
+
+
+def test_declared_arguments_carry_their_schema_from_the_operation():
+    a = _assembly([{"name": "reactions_list", "identity": "operator",
+                    "requires": ["identity", "flows"],
+                    "route": {"method": "GET", "path": "/reactions"},
+                    "arguments": ["status", "source_event_prefix"]}])
+    bound = bind.verify(a, {"flows": FLOWS_OPENAPI})
+    assert bound[0].parameters == {"status": {"type": "string"},
+                                   "source_event_prefix": {"type": "string"}}
+
+
+def test_a_path_parameter_is_an_argument_without_being_declared():
+    """`/reactions/{reaction_id}/{verb}` cannot be called without them, so they are arguments
+    whether or not the manifest lists them — and a manifest that had to restate them would be a
+    second place to write the route."""
+    a = _assembly([{"name": "reaction_signal", "identity": "user",
+                    "requires": ["identity", "flows"],
+                    "route": {"method": "POST", "path": "/reactions/{reaction_id}/{verb}"}}])
+    bound = bind.verify(a, {"flows": FLOWS_OPENAPI})
+    assert set(bound[0].path_params) == {"reaction_id", "verb"}
+
+
+def test_an_edge_owned_tool_needs_no_openapi():
+    doc = {"contract": "mcp.tools.v1", "domain": "gateway", "source": "oss",
+           "owner": "core/gateway/services/mcp", "base_url_env": None, "served_at": None,
+           "depends_on": ["identity"],
+           "tools": [{"name": "vexa_overview", "identity": "none", "requires": ["identity"],
+                      "route": None}]}
+    a = m.assemble([doc], deployed={"identity"})
+    assert bind.verify(a, {}) == []
+
+
+def test_a_domain_with_no_openapi_at_all_fails_rather_than_binding_blind():
+    a = _assembly([{"name": "flows_list", "identity": "operator",
+                    "requires": ["identity", "flows"],
+                    "route": {"method": "GET", "path": "/flows"}}])
+    with pytest.raises(m.ManifestError, match="OpenAPI"):
+        bind.verify(a, {})

--- a/core/meetings/services/mcp/tests/test_discover.py
+++ b/core/meetings/services/mcp/tests/test_discover.py
@@ -1,0 +1,109 @@
+"""DISCOVERY — what a deployment carries, asked rather than assumed.
+
+Eight configurations, not two: identity plus any subset of meetings, flows and agent. Which ones
+exist is read off the base URLs the deployment sets, because a profile NAME would be a second place
+to say what the URLs already say — and the configuration nobody named is the one that breaks.
+
+No network: the domains are answered by an httpx MockTransport, which is this service's own idiom
+for driving the shipped forwarding path offline.
+"""
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+
+from vexa_mcp import discover as d
+from vexa_mcp import manifest as m
+
+FLOWS_MANIFEST = {
+    "contract": "mcp.tools.v1", "domain": "flows", "source": "oss", "owner": "core/flows",
+    "base_url_env": "FLOWS_API_URL", "served_at": "/.well-known/mcp-tools.json",
+    "depends_on": ["identity"],
+    "tools": [{"name": "flows_list", "identity": "operator", "requires": ["identity", "flows"],
+               "route": {"method": "GET", "path": "/flows"}}],
+}
+FLOWS_OPENAPI = {"paths": {"/flows": {"get": {"summary": "Every flow version", "parameters": []}}}}
+
+
+def _transport(answers):
+    def handler(request: httpx.Request) -> httpx.Response:
+        body = answers.get(str(request.url))
+        if body is None:
+            return httpx.Response(404, json={"detail": "not here"})
+        return httpx.Response(200, json=body)
+    return httpx.MockTransport(handler)
+
+
+def _answers(**extra):
+    a = {"http://flows/.well-known/mcp-tools.json": FLOWS_MANIFEST,
+         "http://flows/openapi.json": FLOWS_OPENAPI}
+    a.update(extra)
+    return a
+
+
+
+def test_only_the_domains_the_deployment_names_are_asked():
+    asked = []
+
+    def handler(request):
+        asked.append(str(request.url))
+        return httpx.Response(404)
+
+    with httpx.Client(transport=httpx.MockTransport(handler)) as c:
+        d.discover(c, env={"ADMIN_API_URL": "http://identity"})
+    assert all("identity" in u for u in asked), f"asked a domain nobody deployed: {asked}"
+
+
+
+def test_a_deployed_domain_s_tools_are_assembled():
+    with httpx.Client(transport=_transport(_answers())) as c:
+        assembly, openapi, bases = d.discover(
+            c, env={"ADMIN_API_URL": "http://identity", "FLOWS_API_URL": "http://flows"})
+    assert [t.name for t in assembly.tools] == ["flows_list"]
+    assert set(openapi) == {"flows"} and bases["flows"] == "http://flows"
+
+
+
+def test_a_domain_with_no_manifest_yet_contributes_nothing_and_does_not_fail():
+    """Not every domain has published one. That is a smaller surface, not a broken deployment."""
+    with httpx.Client(transport=_transport(_answers())) as c:
+        assembly, _o, _b = d.discover(
+            c, env={"ADMIN_API_URL": "http://identity", "FLOWS_API_URL": "http://flows",
+                    "MEETING_API_URL": "http://meetings"})
+    assert [t.name for t in assembly.tools] == ["flows_list"]
+
+
+
+def test_a_manifest_whose_openapi_does_not_answer_fails_the_boot():
+    """Publishing a manifest is a promise about routes. Binding it blind would turn that promise
+    into a tool that 404s the first time an agent calls it."""
+    answers = _answers()
+    answers.pop("http://flows/openapi.json")
+    with httpx.Client(transport=_transport(answers)) as c:
+        with pytest.raises(m.ManifestError, match="OpenAPI"):
+            d.discover(c, env={"ADMIN_API_URL": "http://identity",
+                                     "FLOWS_API_URL": "http://flows"})
+
+
+
+def test_a_mounted_domain_with_no_url_fails_rather_than_listing_a_tool_it_cannot_reach(tmp_path):
+    (tmp_path / "billing.mcp.tools.v1.json").write_text(json.dumps({
+        "contract": "mcp.tools.v1", "domain": "billing", "source": "oss", "owner": "private",
+        "base_url_env": "BILLING_API_URL", "served_at": "/.well-known/mcp-tools.json",
+        "depends_on": ["identity"], "tools": []}))
+    with httpx.Client(transport=_transport(_answers())) as c:
+        with pytest.raises(m.ManifestError, match="BILLING_API_URL"):
+            d.discover(c, env={"ADMIN_API_URL": "http://identity",
+                                     "VEXA_MCP_MANIFEST_DIR": str(tmp_path)})
+
+
+
+def test_an_empty_mount_is_the_oss_product_exactly(tmp_path):
+    with httpx.Client(transport=_transport(_answers())) as c:
+        assembly, _o, _b = d.discover(
+            c, env={"ADMIN_API_URL": "http://identity", "FLOWS_API_URL": "http://flows",
+                    "VEXA_MCP_MANIFEST_DIR": str(tmp_path)})
+    assert [t.name for t in assembly.tools] == ["flows_list"]
+    assert assembly.entitlement is None

--- a/core/meetings/services/mcp/tests/test_manifest_files.py
+++ b/core/meetings/services/mcp/tests/test_manifest_files.py
@@ -1,0 +1,63 @@
+"""THE MANIFESTS IN THIS REPO ARE VALID, AND THEY ARE WHAT THE DOMAINS SERVE.
+
+Each domain commits its manifest in its own directory and serves that same file at
+`/.well-known/mcp-tools.json`. This test reads them off disk and puts them through the assembler,
+so a manifest that could not boot the edge fails here instead — in the suite of the service that
+would have refused to start.
+"""
+from __future__ import annotations
+
+import json
+import pathlib
+
+import pytest
+
+from vexa_mcp import bind
+from vexa_mcp import manifest as m
+
+REPO = pathlib.Path(__file__).resolve().parents[5]
+MANIFESTS = sorted(REPO.glob("core/*/mcp.tools.v1.json")) + \
+            sorted(REPO.glob("core/*/services/*/mcp.tools.v1.json"))
+
+
+def _load():
+    return [json.loads(p.read_text()) for p in MANIFESTS]
+
+
+def test_there_is_at_least_one_manifest_and_every_one_of_them_validates():
+    docs = _load()
+    assert docs, "no domain has published a manifest yet"
+    for doc, path in zip(docs, MANIFESTS):
+        try:
+            m.validate(doc)
+        except m.ManifestError as e:
+            pytest.fail(f"{path.relative_to(REPO)}: {e}")
+
+
+def test_one_domain_per_manifest_and_no_name_claimed_twice():
+    docs = _load()
+    domains = [d["domain"] for d in docs]
+    assert len(domains) == len(set(domains)), f"two manifests for one domain: {domains}"
+    deployed = {"identity"} | set(domains)
+    a = m.assemble(docs, deployed=deployed)          # raises on a duplicate name
+    assert a.tools, "the union is empty"
+
+
+def test_the_full_deployment_and_the_smallest_one_both_assemble():
+    """Eight configurations, not two. Identity alone must still produce a coherent surface, and a
+    tool whose domain is absent is ABSENT — never present-and-failing."""
+    docs = _load()
+    everything = m.assemble(docs, deployed={"identity", "meetings", "flows", "agent"})
+    identity_only = m.assemble(docs, deployed={"identity"})
+    assert len(identity_only.tools) <= len(everything.tools)
+    for t in identity_only.tools:
+        assert t.requires <= {"identity"}
+
+
+def test_no_manifest_declares_a_credential_argument():
+    """PRD 40.8 — one authentication path: a bearer header, session-bound. `validate` enforces it;
+    this states it as its own fact so the reason survives a refactor of the validator."""
+    for doc, path in zip(_load(), MANIFESTS):
+        for t in doc.get("tools") or []:
+            for arg in t.get("arguments") or []:
+                assert arg.lower() not in m.CREDENTIAL_ARGUMENTS, f"{path}: {t['name']} takes {arg}"

--- a/core/meetings/services/mcp/tests/test_register.py
+++ b/core/meetings/services/mcp/tests/test_register.py
@@ -1,0 +1,122 @@
+"""REGISTRATION — an assembled tool becomes a tool an agent can actually call.
+
+A bound tool is turned into one FastAPI route on this service, carrying `operation_id=<tool name>`,
+which is exactly how this service's own fourteen tools become MCP tools (`FastApiMCP` reads the
+OpenAPI it generates). One mechanism for both, so an assembled tool and a built-in one are
+indistinguishable to a client — which is the point of assembling rather than proxying.
+
+The forward carries THE CALLER'S IDENTITY and nothing else: the bearer the edge already resolved,
+travelling as `X-API-Key`, exactly as the fourteen do. There is no second credential and no way to
+pass one as an argument (PRD 40.8).
+"""
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from vexa_mcp import bind, register
+from vexa_mcp import manifest as m
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+FLOWS_OPENAPI = {"paths": {
+    "/flows": {"get": {"summary": "Every flow version", "parameters": []}},
+    "/reactions": {"get": {"summary": "The operator projection", "parameters": [
+        {"name": "status", "in": "query", "schema": {"type": "string"}}]}},
+    "/reactions/{reaction_id}/{verb}": {"post": {"summary": "Steer one reaction", "parameters": []}},
+}}
+MANIFEST = {
+    "contract": "mcp.tools.v1", "domain": "flows", "source": "oss", "owner": "core/flows",
+    "base_url_env": "FLOWS_API_URL", "served_at": "/.well-known/mcp-tools.json",
+    "depends_on": ["identity"],
+    "tools": [
+        {"name": "flows_list", "identity": "operator", "requires": ["identity", "flows"],
+         "route": {"method": "GET", "path": "/flows"}},
+        {"name": "reactions_list", "identity": "operator", "requires": ["identity", "flows"],
+         "route": {"method": "GET", "path": "/reactions"}, "arguments": ["status"]},
+        {"name": "reaction_signal", "identity": "user", "requires": ["identity", "flows"],
+         "route": {"method": "POST", "path": "/reactions/{reaction_id}/{verb}"}},
+    ],
+}
+
+
+@pytest.fixture()
+def wired():
+    seen = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request)
+        return httpx.Response(200, json={"ok": str(request.url)})
+
+    app = FastAPI()
+    assembly = m.assemble([MANIFEST], deployed={"identity", "flows"})
+    bound = bind.verify(assembly, {"flows": FLOWS_OPENAPI})
+    register.register(app, bound, {"flows": "http://flows"},
+                      transport=httpx.MockTransport(handler))
+    return app, seen
+
+
+def test_every_assembled_tool_gets_a_route_named_after_it(wired):
+    app, _seen = wired
+    ids = {getattr(r, "operation_id", None) for r in app.routes}
+    assert {"flows_list", "reactions_list", "reaction_signal"} <= ids
+
+
+def test_calling_the_tool_forwards_to_the_owning_domain(wired):
+    app, seen = wired
+    r = TestClient(app).get("/tools/flows_list", headers={"X-API-Key": "k"})
+    assert r.status_code == 200, r.text
+    assert str(seen[-1].url) == "http://flows/flows"
+
+
+def test_the_caller_s_identity_travels_and_no_other_credential_does(wired):
+    """PRD 40.8: one authentication path. The bearer the edge resolved goes on, and nothing else."""
+    app, seen = wired
+    TestClient(app).get("/tools/flows_list", headers={"X-API-Key": "the-caller-key"})
+    fwd = seen[-1]
+    assert fwd.headers.get("x-api-key") == "the-caller-key"
+    assert "token" not in str(fwd.url).lower()
+
+
+def test_a_declared_argument_travels_as_a_query_parameter(wired):
+    app, seen = wired
+    TestClient(app).get("/tools/reactions_list?status=blocked", headers={"X-API-Key": "k"})
+    assert "status=blocked" in str(seen[-1].url)
+
+
+def test_an_undeclared_argument_is_not_forwarded(wired):
+    """An argument the route ignores is a success the agent reports for something that did not
+    happen — so it never leaves this process."""
+    app, seen = wired
+    TestClient(app).get("/tools/reactions_list?status=blocked&invented=1",
+                        headers={"X-API-Key": "k"})
+    assert "invented" not in str(seen[-1].url)
+
+
+def test_path_parameters_are_substituted(wired):
+    app, seen = wired
+    r = TestClient(app).post("/tools/reaction_signal", json={"reaction_id": "r1", "verb": "retry"},
+                             headers={"X-API-Key": "k"})
+    assert r.status_code == 200, r.text
+    assert str(seen[-1].url) == "http://flows/reactions/r1/retry"
+
+
+def test_a_missing_credential_is_refused_before_the_forward(wired):
+    app, seen = wired
+    before = len(seen)
+    r = TestClient(app).get("/tools/flows_list")
+    assert r.status_code == 401
+    assert len(seen) == before, "nothing was forwarded"
+
+
+def test_the_domain_s_own_error_reaches_the_caller_unchanged():
+    """A 403 from flows is flows' answer, and an agent needs to see it. Rewriting it as a 500 would
+    turn "you may not do that" into "we are broken"."""
+    app = FastAPI()
+    assembly = m.assemble([MANIFEST], deployed={"identity", "flows"})
+    bound = bind.verify(assembly, {"flows": FLOWS_OPENAPI})
+    register.register(app, bound, {"flows": "http://flows"},
+                      transport=httpx.MockTransport(
+                          lambda r: httpx.Response(403, json={"detail": "operator only"})))
+    r = TestClient(app).get("/tools/flows_list", headers={"X-API-Key": "k"})
+    assert r.status_code == 403 and "operator only" in r.text

--- a/deploy/compose/docker-compose.yml
+++ b/deploy/compose/docker-compose.yml
@@ -526,6 +526,21 @@ services:
     environment:
       - GATEWAY_URL=http://gateway:8000
       - PORT=8010
+      # ── assembly (PRD decision 40) ─────────────────────────────────────────────────────────
+      # The domains this deployment carries. A domain whose URL is set is ASKED for its tool
+      # manifest at /.well-known/mcp-tools.json and its tools join the one MCP surface; a domain
+      # whose URL is unset is never asked and its tools are simply absent. That is the whole of the
+      # eight-configuration story — identity plus any subset of meetings, flows and agent — and it
+      # needs no profile name, because a profile name would be a second place to say what these
+      # URLs already say.
+      - ADMIN_API_URL=http://admin-api:8001
+      - MEETING_API_URL=http://meeting-api:8080
+      - AGENT_API_URL=${AGENT_API_URL:-}
+      - FLOWS_API_URL=${VEXA_FLOWS_API_URL:-}
+      # A private deployment mounts its own manifests here — billing, seats, entitlement — and they
+      # are assembled exactly like the OSS ones, competing for names in the same space so a mount
+      # can collide but never shadow. EMPTY IS THE OSS PRODUCT, exactly.
+      - VEXA_MCP_MANIFEST_DIR=${VEXA_MCP_MANIFEST_DIR:-}
       - VEXA_ENV=${VEXA_ENV:-development}
       - LOG_LEVEL=${LOG_LEVEL:-info}
       # Same declared-jitsi-hosts setting meeting-api reads — the two parsers must agree.


### PR DESCRIPTION
mcp-assembly: one MCP surface, assembled from the manifests of the domains that are deployed

PRD decision 40, founder rulings of 2026-09-02. A tool belongs to the domain that owns the door
behind it. This service — the 14-tool MCP the gateway already fronts at /mcp — stops being only its
own surface and becomes the ASSEMBLER: it asks each deployed domain what it serves, refuses the
combinations that cannot be right, and presents the union as one server. It gains no domain logic.

  core/flows/mcp.tools.v1.json                     flows declares four tools, bound to routes it
                                                   already serves
  flows_api.py:495,500 /.well-known/mcp-tools.json flows SERVES that file — the version that
                                                   answers is the version that is RUNNING
  vexa_mcp/manifest.py                             the contract, and the boot rules
  vexa_mcp/bind.py                                 a manifest's promise checked against the owning
                                                   service's OpenAPI
  vexa_mcp/discover.py                             which domains exist, asked not assumed
  vexa_mcp/register.py                             a bound tool becomes a route with
                                                   operation_id=<name> — the same mechanism the
                                                   fourteen use, so assembled and built-in are
                                                   indistinguishable to a client
  app.py:1207 create_app                           assembly runs BEFORE FastApiMCP, necessarily:
                                                   the surface is derived from this app's OpenAPI
  deploy/compose/docker-compose.yml                the mcp service is told which domains exist

FIVE THINGS FAIL THE BOOT, and each is otherwise silent — a server that started anyway would answer
tools/list with a lie:
  a domain that is deployed and does not answer      a whole domain's tools missing, quietly
  one tool name claimed twice                        last-one-wins, and nobody knows which won
  a route the owning domain does not serve           a tool that 404s the first time it is called
  an argument the operation does not take            a success the agent reports for something that
                                                     did not happen
  two entitlement hooks                              "may this person act", answered twice

WHAT IS NOT A FAILURE: a domain that is not deployed. Its tools are ABSENT from tools/list. An agent
that cannot see a tool recovers; one told a tool exists and handed a 502 tells the person the
product is broken. Which domains exist is read off their base URLs — eight configurations, and no
profile name, because a name would be a second place to say what the URLs already say.

THE PAID PRODUCT COMPOSES WITHOUT TOUCHING THIS REPO. VEXA_MCP_MANIFEST_DIR is a directory a private
deployment mounts; its manifests are assembled identically and compete for names in the same space,
so a mount can COLLIDE but never SHADOW. Empty is the OSS product exactly, and at most one manifest
may declare the entitlement hook — none is the normal case, so this repo never carries a gate
shipped dark.

PRD 40.8 — ONE AUTHENTICATION PATH — is enforced here rather than trusted to every domain: a tool
may not take a credential as an argument, and the forward carries the bearer the edge already
resolved and nothing else. A tool's schema is derived from its route's OpenAPI, which has no `token`
parameter, so the rule is mostly kept by construction; the check catches a domain that reintroduces
one on purpose. NOTE this puts the assembled surface deliberately at odds with the rig's 64-tool
schemas, every one of which declares token="".

37 new tests, red first: 14 assembly (the boot rules, mounted precedence, entitlement uniqueness),
8 bind (OpenAPI verification, arguments, path params), 6 discover (only deployed domains asked,
mount rules), 5 the on-disk manifests, 5 end-to-end through tools/list, plus the flows route's own
5. Suites: mcp 191, flows 368. Gates readme / config-contract / isolation / graph / schema / exports
green.

FOLLOW-ON, named not hidden: the service still lives at core/meetings/services/mcp and should move
to core/gateway/services/mcp — a server serving four domains cannot be owned by one of them. It is a
directory move with no behaviour in it, kept out of this PR so the mechanism can be read on its own.
identity, meetings and agent do not publish manifests yet; each is one route and one file, and the
assembler already tolerates their absence.
