### PR TITLE
[review 5/9] the user-state rehearsal harness

### DIFF
--- a/deploy/dogfood/bin/rehearse.py
+++ b/deploy/dogfood/bin/rehearse.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""rehearse — enter a user state on the running stack, or wipe one subject out of it.
+
+PRD decision 38. The states live in `deploy/dogfood/rehearse/states.yaml`; this is the hand tool
+in front of them, and the control MCP's `rehearse` / `subject_reset` tools call the same functions.
+
+    rehearse.py states                                   # what the catalogue holds
+    rehearse.py plan organizer-invited olga@rehearse.test # resolve every step, execute none
+    rehearse.py enter organizer-invited olga@rehearse.test
+    rehearse.py enter attendee-stranger-minutes sam@rehearse.test --meeting 2026-03-16 --fresh
+    rehearse.py enter reply-pending sam@rehearse.test --runner openai-agent   # on the CCC Qwen
+    rehearse.py reset olga@rehearse.test
+    rehearse.py reset 131 --by-id                # a subject whose email is not an address
+    rehearse.py all                                      # the whole catalogue (run_all)
+
+Every address must be under $VEXA_REHEARSE_DOMAIN (default rehearse.test), and the tool refuses
+while a live meeting belongs to anyone outside it. Both refusals happen before the first door.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import pathlib
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+from rehearse import catalogue as cat                                    # noqa: E402
+from rehearse.doors import MAIL_ADDR, DoorRefused, LiveDoors            # noqa: E402
+from rehearse.engine import DEFAULT_MEETING, DEFAULT_WHEN, Refused       # noqa: E402
+from rehearse.engine import rehearse as enter_state                      # noqa: E402
+from rehearse.engine import subject_reset, subject_reset_malformed       # noqa: E402
+
+
+def cmd_states(a, catalog) -> int:
+    for name, st in catalog.states.items():
+        print(f"\n{name}\n  {' '.join(st.summary.split())}")
+        print(f"  story:  {st.story}")
+        for step in st.steps:
+            print(f"    {step.index:>2}. {step.do:<24} via {step.door}")
+        print(f"  verify: {', '.join(v['check'] for v in st.verify)}")
+    print(f"\ndomain: @{catalog.domain()}   fixtures: {catalog.fixtures_dir()}   "
+          f"mailbox: {MAIL_ADDR}")
+    return 0
+
+
+def cmd_plan(a, catalog) -> int:
+    res = enter_state(a.state, a.subject, meeting=a.meeting, when=a.when, doors=_doors(a),
+                      catalog=catalog, mailbox=MAIL_ADDR, dry_run=True, runner=a.runner)
+    print(json.dumps(res.to_dict(), indent=1, default=str))
+    return 0
+
+
+def cmd_enter(a, catalog) -> int:
+    res = enter_state(a.state, a.subject, meeting=a.meeting, when=a.when, doors=_doors(a),
+                      catalog=catalog, mailbox=MAIL_ADDR, fresh=a.fresh, runner=a.runner)
+    if a.json:
+        print(json.dumps(res.to_dict(), indent=1, default=str))
+    else:
+        print(f"{res.state} as {res.subject} — {'OK' if res.ok else 'FAILED'} in {res.wall_s:.1f}s")
+        for step in res.steps:
+            print(f"  {'ok ' if step.get('ok') else 'STOP'} {step['do']:<24} {step.get('why', '')}")
+        for name, url in res.links.items():
+            print(f"  link  {name}: {url}")
+        for v in res.verify:
+            print(f"  {'pass' if v['ok'] else 'FAIL'}  {v['check']:<20} {v['detail']}")
+        if res.error:
+            print(f"\n  {res.error}")
+    return 0 if res.ok else 1
+
+
+def cmd_reset(a, catalog) -> int:
+    doors = _doors(a)
+    if a.by_id:
+        # The one account the address guard cannot judge: a subject whose stored email is not an
+        # address at all. Refused unless that is true of it — see engine.subject_reset_malformed.
+        out = subject_reset_malformed(a.subject, doors=doors, catalog=catalog)
+    else:
+        out = subject_reset(a.subject, doors=doors, catalog=catalog)
+    print(json.dumps(out, indent=1, default=str))
+    return 0 if out["ok"] else 1
+
+
+def cmd_all(a, catalog) -> int:
+    from rehearse import run_all
+    argv = ["--meeting", a.meeting, "--when", a.when]
+    if a.only:
+        argv += ["--only", a.only]
+    if a.json:
+        argv.append("--json")
+    if a.stub:
+        argv.append("--stub")
+    return run_all.main(argv)
+
+
+def _doors(a):
+    if getattr(a, "stub", False):
+        from rehearse.stub_doors import StubDoors
+        return StubDoors()
+    return LiveDoors()
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(prog="rehearse.py", description=__doc__.split("\n")[0])
+    ap.add_argument("--stub", action="store_true",
+                    help="run against the offline door stub — proves the recipe, touches nothing")
+    sub = ap.add_subparsers(dest="cmd", required=True)
+
+    sub.add_parser("states", help="list the catalogue").set_defaults(fn=cmd_states)
+
+    for name, fn in (("plan", cmd_plan), ("enter", cmd_enter)):
+        p = sub.add_parser(name, help=f"{name} a state")
+        p.add_argument("state")
+        p.add_argument("subject", help="the address to be, under the test domain")
+        p.add_argument("--meeting", default=DEFAULT_MEETING, help="a DNA fixture date")
+        p.add_argument("--when", default=DEFAULT_WHEN, help="+30m · +3h · an epoch · ISO-8601")
+        p.add_argument("--json", action="store_true")
+        p.add_argument("--fresh", action="store_true",
+                       help="reset the subject and the derived organizer first (DELETES)")
+        p.add_argument("--runner", default="",
+                       help="pin this recipe's subjects to a harness (claude-code | openai-agent)")
+        p.set_defaults(fn=fn)
+
+    p = sub.add_parser("reset", help="remove one subject entirely")
+    p.add_argument("subject", help="the address, or the uid with --by-id")
+    p.add_argument("--by-id", action="store_true",
+                   help="treat SUBJECT as a uid; only for an account whose stored email is not an "
+                        "address at all (a parse artefact) — a well-formed one is refused")
+    p.set_defaults(fn=cmd_reset)
+
+    p = sub.add_parser("all", help="run every state (run_all)")
+    p.add_argument("--only", default="")
+    p.add_argument("--meeting", default=DEFAULT_MEETING)
+    p.add_argument("--when", default=DEFAULT_WHEN)
+    p.add_argument("--json", action="store_true")
+    p.set_defaults(fn=cmd_all)
+
+    a = ap.parse_args(argv)
+    try:
+        return a.fn(a, cat.load())
+    except (Refused, DoorRefused) as e:
+        # A refusal is the product, not a crash: it names what is in the way and what to do.
+        print(f"refused: {e}", file=sys.stderr)
+        return 2
+    except cat.CatalogueError as e:
+        print(f"catalogue: {e}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    os.environ.setdefault("PYTHONUNBUFFERED", "1")
+    sys.exit(main())

--- a/deploy/dogfood/rehearse/README.md
+++ b/deploy/dogfood/rehearse/README.md
@@ -1,0 +1,167 @@
+# `rehearse` — user states are data
+
+> *"let's get back to the flows, testing different user states — we need to be able to invoke
+> those without constant rebuilding."* — founder, 2026-09-02 (PRD decision 38)
+
+Every state a person can be in when a touch reaches them, written as a recipe of steps against the
+product's own doors. Entering one takes seconds, needs no image, and leaves the instance alone.
+
+```
+rehearse/
+  states.yaml     THE CATALOGUE — six states, as data
+  catalogue.py    loads and VALIDATES them against a closed vocabulary
+  doors.py        the only thing that talks to the stack; one method per verb
+  engine.py       rehearse() · subject_reset() — the executor and the two guards
+  stub_doors.py   the whole stack as a dict, so every recipe is provable offline
+  run_all.py      the catalogue as the test; failures become friction (decision 33)
+  tests/          the suite; no network, no docker, no home directory
+```
+
+The hand tool is [`../bin/rehearse.py`](../bin/rehearse.py); the control MCP serves the same two
+functions as `rehearse` and `subject_reset`.
+
+## The six states
+
+| state | who the subject is | the touch it ends at |
+|---|---|---|
+| `blank-admin` | nobody yet, on an unclaimed instance | the sign-in mail whose link CLAIMS the instance |
+| `organizer-invited` | a user with a desk who just put the mailbox on a meeting | `Prepare: <title>` → `/?s=` (kind `prep`) |
+| `attendee-stranger-minutes` | in the room, never signed in | the attendee follow-up → `/?s=` (kind `post-meeting`) |
+| `group-member` | a member of a group desk, after a `#group:` meeting | the follow-up whose intent is the group desk |
+| `warm-desk-recurring` | two prior reports of the same series on the desk | `Prepare:` again, warm branch |
+| `reply-pending` | replied to a minutes mail | the `email_chat` turn |
+
+```bash
+bin/rehearse.py states                                       # what the catalogue holds
+bin/rehearse.py plan  organizer-invited olga@rehearse.test   # resolve every step, execute none
+bin/rehearse.py enter organizer-invited olga@rehearse.test   # ← the link comes back
+bin/rehearse.py enter attendee-stranger-minutes sam@rehearse.test --meeting 2026-03-16 --fresh
+bin/rehearse.py reset olga@rehearse.test
+bin/rehearse.py all                                          # every state, per-state pass/fail
+```
+
+## The two refusals
+
+Both run **before the first door**, because this executes on a stack somebody's real work is
+living on.
+
+1. **Every address must be under `$VEXA_REHEARSE_DOMAIN`** (default `rehearse.test`). Not only the
+   one you typed: the check reads the whole resolved plan, so the organizer a recipe derives and
+   the room it pulls out of the fixture are checked too. The founder's identities, `_global`, the
+   DNA and OeNB groups are unreachable *by construction*, not by care. The one exception is the
+   address the mail double itself answers as (`VEXA_MAIL_ADDR`) — every invite is addressed to it.
+2. **No live meeting may belong to anyone outside that domain.** A rehearsal writes facts and
+   mail; a live meeting is the one thing here that cannot be re-recorded. The probe **fails
+   closed**: if it cannot be read, the run refuses.
+
+## What needs a swap, and what never does
+
+Decision 38.4, and the line is exact — **the tool writes DATA**.
+
+| change | needs an image / a swap? | why |
+|---|---|---|
+| a new state, or an edit to one | **no** | `states.yaml` is read at call time |
+| a preset (`_global/asks/*.md`) | **no** | read from `_global` when the link is clicked |
+| a mail template (`_global/mail/*.md`) | **no** | same — read at send time |
+| the company layer (`_global/README.md` …) | **no** | an admin edit is a commit in the `_global` repo |
+| a flow's steps or version | **no** | submitted flows are rows; the worker refreshes from the DB |
+| a fixture in `~/dna-fixtures` | **no** | read from disk per call |
+| `VEXA_REHEARSE_DOMAIN`, `VEXA_MAIL_ADDR`, `VEXA_UI_URL` | env only | a lane restart, never a build |
+| **a change to `doors.py`, `engine.py` or a service's code** | **yes** | code is code; a swap is a swap |
+| **`DELETE /admin/users/{id}`** (what `subject_reset` needs) | **yes, once** | the route ships on this branch; until admin-api is swapped, `subject_reset` reports the user as `remaining` and deletes everything else |
+
+`tests/test_hot.py` is the enforced half of this table: it asserts that every door a recipe uses is
+a service already running, that no recipe names a preset, a template or `_global`, that the package
+never builds or restarts anything, and that the only three places in `doors.py` that shell out are
+the three named in its module docstring. A README claiming "no image needed" would go stale the
+first time somebody reached for `docker` to make one awkward state work.
+
+## Where it does not go through a route, and why
+
+Three exceptions, all reads or per-subject deletes, all named in `doors.py`'s docstring and pinned
+by `MAY_SHELL_OUT` in the test:
+
+- **`live_meetings()`** — there is no instance-wide live-meeting route (`GET /bots/status` is
+  scoped to one caller), so the guard reads the meetings table through the postgres container.
+  Read-only, fail-closed. *This is a missing route, filed rather than habituated.*
+- **`session_keys_delete()` / `scaffold_keys_delete()`** — agent-api owns
+  `agent:sessions:<uid>`, `agent:session:<uid>:*`, `agent:scaffold:<id>` and
+  `agent:scaffolds:by:<address>` and exposes no delete. The prefixes are **listed, never globbed
+  on `agent:*`**, and there is no `FLUSH` anywhere: the same valkey carries the live transcript
+  streams.
+- **`friction_delete_for()`** — that subject's friction rows in the flows lane; no route removes
+  them.
+
+## Idempotence, and how a state is re-entered
+
+There is **no marker file**. Identity is derived: the ICS UID and the meeting's native id are
+functions of `(state, subject, meeting)`, and the fact's `source_event_id` names the meeting **row**
+that native id resolves to. So a second run dedups where the product already dedups — the mail
+poller on the ICS UID, `seed_meeting` adopting the completed row it already made, `admit()` on
+`(source_event_id, flow)`, `user_ensure` on the address.
+
+One state cannot be idempotent by nature: `attendee-stranger-minutes` needs somebody who has never
+been seen, and the drop gives them a desk. It **says so** on the second run rather than pretending,
+and the way back is `--fresh`, which resets the subject *and* the organizer the recipe derives
+(the meeting row belongs to the organizer, so resetting only the subject would leave the fact
+deduping the re-entry away).
+
+## `subject_reset(address)`
+
+One subject gone: user (admin-api), desk (the workspace route), sessions and pending scaffolds
+(the four redis prefixes above), friction rows, and every mail to or from that address. It
+**reads the emptiness back** and reports whatever it could not remove under `remaining` — a reset
+that half worked and said "done" is the ledger's phantom `_global` write one layer down. The
+instance is never blanked; blanking is [`../bin/blank-instance.sh`](../bin/blank-instance.sh) and
+it deletes everybody.
+
+## Running the tests
+
+```bash
+cd deploy/dogfood/rehearse && uv run pytest -q     # what gate:python runs
+python -m rehearse.run_all --stub                  # the catalogue, offline
+```
+
+The suite is offline by construction: no network, no docker, and no read of `~/dna-fixtures` — two
+small transcripts in the corpus's own shape live in `tests/fixtures/`. A suite that read the rig's
+home directory would pass on bbb and fail everywhere else, and would quietly start measuring
+whatever somebody left in that directory.
+
+## The lane a rehearsal runs against
+
+**Never the founder's lane.** The dogfood box carries two flows lanes over one stack: the founder's
+(db `flows`, api `:18200`, mailbox `vexa@storm.test`) and the sim lane (db `flows_sim`, api
+`:18201`, mailbox `vexa@sim.test`). They share agent-api, admin-api, the gateway and mailpit — all
+per-identity — and nothing else. A rehearsal runs on the sim lane.
+
+```bash
+deploy/dogfood/bin/sim-lane-up.sh        # api + worker, from THIS checkout's core/flows
+deploy/dogfood/bin/sim-mailbox-up.sh     # the inbound poller (admits facts — start it on purpose)
+```
+
+Both are twins of `~/.storm/flows-up.sh` with four lane-scoped values changed (db, port, mailbox,
+operator key) plus `rehearse.test` in `VEXA_FLOWS_ATTENDEE_DOMAINS` — without which every follow-up
+to an `@rehearse.test` attendee is filtered and the flow reports success having mailed nobody.
+Their `pkill` patterns are lane-scoped for the reason `flows-up.sh` wrote down the hard way:
+`-m flows_worker` is the FOUNDER lane's argv, and the sim worker keeps its renamed `argv[0]` so
+neither lane's restart can reach the other.
+
+**Check what the worker loaded before trusting a run.** It prints `4 flows · 21 steps`, the gate
+state, and how many versions it hot-loaded from the DB. Then `GET /flows` must show
+`shadowing_versions: []`. A flow version authored through the API is newest-wins and shadows the
+image's — the sim lane held `post_meeting@16` with a retired step list (`require_workspace`, no
+`drop_to_attendees`), so a run against it would have measured flows decision 29 deleted. Retire
+anything above the code's version before running:
+
+```sql
+UPDATE flow_version SET status='retired' WHERE name='post_meeting' AND version > 4;
+```
+
+## Against the running stack
+
+`run_all` on the live doors is the same code with `LiveDoors` in place of the stub. It clicks
+nothing: whether a link *works* when a person clicks it is a walk, and a founder's judgment. What
+the suite proves is everything up to the click — the touch exists, its link is a scaffold, the
+record resolves, the desk holds what it should. Failures are filed through decision 33's route
+(`POST /api/friction` on agent-api) with a repro line, so a fixing agent can re-enter the state
+without asking anybody how.

--- a/deploy/dogfood/rehearse/__init__.py
+++ b/deploy/dogfood/rehearse/__init__.py
@@ -1,0 +1,22 @@
+"""rehearse — user states as data (PRD decision 38).
+
+Enter any state a person can be in, on the RUNNING stack, without a rebuild:
+
+    from rehearse import load, LiveDoors, rehearse
+    rehearse("organizer-invited", "olga@rehearse.test", doors=LiveDoors())
+
+Four files and one rule. `states.yaml` is the catalogue — the recipes, as data. `catalogue.py`
+validates them against a closed vocabulary. `doors.py` is the only thing that talks to the stack,
+one method per verb. `engine.py` executes a recipe and verifies its artefacts. The rule is that a
+state is entered through the product's own doors: no DB writes, no volume edits, no image.
+
+`run_all.py` runs the whole catalogue and files what breaks as friction (decision 33).
+"""
+from .catalogue import Catalogue, CatalogueError, State, Step, load  # noqa: F401
+from .doors import DoorRefused, Doors, LiveDoors                     # noqa: F401
+from .engine import (Refused, Result, is_malformed, rehearse, subject_reset,  # noqa: F401
+                     subject_reset_malformed)
+
+__all__ = ["Catalogue", "CatalogueError", "State", "Step", "load", "Doors", "LiveDoors",
+           "DoorRefused", "rehearse", "subject_reset", "subject_reset_malformed", "is_malformed",
+           "Result", "Refused"]

--- a/deploy/dogfood/rehearse/catalogue.py
+++ b/deploy/dogfood/rehearse/catalogue.py
@@ -1,0 +1,328 @@
+"""The catalogue: `states.yaml` read, validated and interpolated.
+
+PRD decision 38.1 — *user states are data*. This module is the half that makes that claim true
+rather than decorative: the recipes are a data file, and the only thing code contributes is a
+CLOSED VOCABULARY of verbs and checks. A recipe naming a verb that does not exist, or naming the
+wrong door for a verb that does, is refused AT LOAD — before a single door is touched.
+
+Why load-time and not run-time: a recipe that half-executes and then discovers it cannot finish
+has already changed the running stack, and the person who has to work out what it left behind is
+the founder. The whole point of the catalogue is that entering a state is cheap and leaving one is
+possible; a partial run is neither.
+
+The `door:` column in every step is CHECKED against `VERBS[verb].door`. That is what stops it
+becoming decoration — if the engine ever changes which service answers a verb, every recipe that
+names the old one goes red in `tests/test_catalogue.py`, which is exactly the moment a human
+should be reading the file.
+"""
+from __future__ import annotations
+
+import os
+import pathlib
+import re
+from dataclasses import dataclass, field
+from typing import Any
+
+import yaml
+
+HERE = pathlib.Path(__file__).resolve().parent
+STATES_FILE = HERE / "states.yaml"
+
+# ── the closed vocabulary ────────────────────────────────────────────────────────────────────────
+#
+# verb -> (door, required args, optional args). The DOOR is the service that answers, in the
+# deployment's own vocabulary, and it is the string every recipe must repeat. `Doors` in doors.py
+# has one method per verb with the same name; the test asserts that correspondence both ways, so a
+# verb can never exist in the vocabulary with nothing behind it, nor behind it with nothing in the
+# vocabulary.
+
+
+@dataclass(frozen=True)
+class Verb:
+    door: str
+    required: tuple[str, ...] = ()
+    optional: tuple[str, ...] = ()
+    writes: bool = True          # does executing it change the stack?
+    #: A PRECONDITION verb asserts a fact about the world the recipe cannot create. When one
+    #: refuses, the state was not entered and nothing is broken — the stack is simply not in the
+    #: shape this state describes. Declared here rather than guessed from the verb's name, because
+    #: the difference decides how a failure is FILED, and a rough-edges loop that cannot tell a
+    #: correct refusal from a defect trains its readers to skim.
+    precondition: bool = False
+    what: str = ""
+
+
+VERBS: dict[str, Verb] = {
+    "require_instance_blank": Verb(
+        "admin-api", (), (), writes=False, precondition=True,
+        what="assert no admin has claimed the instance and the company layer is missing"),
+    "require_subject_absent": Verb(
+        "admin-api", ("address",), (), writes=False, precondition=True,
+        what="assert this address has no user — the stranger precondition"),
+    "user_ensure": Verb(
+        "admin-api", ("address",), ("as",),
+        what="resolve or create the platform user for this address"),
+    "desk_init": Verb(
+        "agent-api", ("subject",), (),
+        what="POST /api/workspace/init — the person's own desk, idempotent"),
+    "desk_entity": Verb(
+        "agent-api", ("subject", "kind", "name"), ("facts", "source", "summary", "slug"),
+        what="POST /api/workspace/entity — the product's own write door for a desk page"),
+    "group_new": Verb(
+        "agent-api", ("owner", "name"), ("purpose", "as"),
+        what="POST /api/workspace/shared/new — a group desk with an owner"),
+    "group_join": Verb(
+        "agent-api", ("group", "owner", "member"), ("member_email", "role"),
+        what="mint an invite as the owner and redeem it as the member — the only join there is"),
+    "request_sign_in_link": Verb(
+        "terminal", ("address",), (),
+        what="POST /api/auth/request-link — the magic-link front door a person uses"),
+    "drop_invite": Verb(
+        "smtp", ("organizer", "title", "start"), ("attendees_from_fixture", "ics_uid", "group",
+                                                  "attendees"),
+        what="SMTP an ICS invite into the mail double, exactly as a calendar would"),
+    "seed_meeting": Verb(
+        "gateway", ("owner", "native"), ("as", "title", "started_at", "source"),
+        what="POST /meetings then POST /meetings/{id}/transcript-import with a DNA fixture"),
+    "emit_fact": Verb(
+        "flows-api", ("event_type", "source_event_id", "refs"), (),
+        what="POST /events — the fact intake for a producer that is not the mailbox"),
+    "await_mail": Verb(
+        "mailpit", ("to",), ("subject_contains", "as", "budget_s", "since"), writes=False,
+        what="wait for one message in the mail double, and capture it"),
+    "reply_to_mail": Verb(
+        "smtp", ("to_mail", "from_address", "body"), ("as",),
+        what="SMTP a reply with In-Reply-To set, so the poller routes it by thread"),
+    "cancel_bot_leg": Verb(
+        "flows-api", ("flow",), ("source_contains",),
+        what="cancel this recipe's parked invite reaction, so no bot is ever dispatched at a "
+             "fixture URL after the run has finished"),
+    "await_reaction": Verb(
+        "flows-api", ("flow",), ("since", "as", "budget_s"), writes=False,
+        what="wait for a reaction of this flow to appear"),
+}
+
+# check -> required args. Every one is answered from an artefact the run already captured or from
+# a read door; none of them needs a human eye. A state whose success cannot be checked this way
+# does not belong in the catalogue (README § What a state is).
+CHECKS: dict[str, tuple[str, ...]] = {
+    "mail_present": ("of",),
+    "link_present": ("of", "must_match"),
+    "scaffold_resolves": ("link",),
+    "no_user": ("address",),
+    "user_exists": ("address",),
+    "meeting_status": ("of", "is"),
+    "desk_nonempty": ("subject",),
+    "group_member": ("group", "address"),
+    "reaction_admitted": ("of",),
+}
+
+_TOKEN = re.compile(r"\{\{\s*([A-Za-z_][A-Za-z0-9_.]*)\s*\}\}")
+
+
+class CatalogueError(ValueError):
+    """A recipe this module refuses to hand to the engine. Carries the state and the row."""
+
+
+@dataclass
+class Step:
+    do: str
+    door: str
+    args: dict[str, Any]
+    index: int
+
+    @property
+    def capture(self) -> str:
+        return str(self.args.get("as") or "")
+
+
+@dataclass
+class State:
+    name: str
+    summary: str
+    story: str
+    steps: list[Step]
+    verify: list[dict]
+    artefacts: dict = field(default_factory=dict)
+    preconditions: list = field(default_factory=list)
+
+    @property
+    def writes(self) -> bool:
+        return any(VERBS[s.do].writes for s in self.steps)
+
+
+@dataclass
+class Catalogue:
+    version: int
+    domain_env: str
+    default_domain: str
+    fixtures_env: str
+    default_fixtures: str
+    states: dict[str, State]
+
+    def __getitem__(self, name: str) -> State:
+        try:
+            return self.states[name]
+        except KeyError:
+            raise CatalogueError(
+                f"{name!r} is not a state. The catalogue holds: {', '.join(sorted(self.states))}"
+            ) from None
+
+    def domain(self, env: dict | None = None) -> str:
+        env = os.environ if env is None else env
+        return (env.get(self.domain_env) or self.default_domain).strip().lstrip("@").lower()
+
+    def fixtures_dir(self, env: dict | None = None) -> pathlib.Path:
+        env = os.environ if env is None else env
+        raw = env.get(self.fixtures_env) or self.default_fixtures
+        return pathlib.Path(raw).expanduser()
+
+
+def load(path: pathlib.Path | str | None = None) -> Catalogue:
+    """Read and VALIDATE the catalogue. Raises CatalogueError with the offending row named."""
+    p = pathlib.Path(path or STATES_FILE)
+    raw = yaml.safe_load(p.read_text())
+    if not isinstance(raw, dict):
+        raise CatalogueError(f"{p} is not a mapping")
+    for key in ("version", "domain_env", "default_domain", "states"):
+        if key not in raw:
+            raise CatalogueError(f"{p} has no `{key}`")
+
+    states: dict[str, State] = {}
+    for name, body in (raw["states"] or {}).items():
+        if not isinstance(body, dict):
+            raise CatalogueError(f"state {name!r} is not a mapping")
+        for key in ("summary", "steps", "verify"):
+            if not body.get(key):
+                raise CatalogueError(f"state {name!r} has no `{key}` — "
+                                     f"a state with no verify block is a state nobody can check")
+        steps = [_step(name, i, row) for i, row in enumerate(body["steps"])]
+        _check_captures(name, steps, body["verify"])
+        states[name] = State(
+            name=name, summary=str(body["summary"]).strip(), story=str(body.get("story") or ""),
+            steps=steps, verify=[_verify(name, v) for v in body["verify"]],
+            artefacts=body.get("artefacts") or {}, preconditions=body.get("preconditions") or [])
+
+    if not states:
+        raise CatalogueError(f"{p} declares no states")
+    return Catalogue(
+        version=int(raw["version"]), domain_env=str(raw["domain_env"]),
+        default_domain=str(raw["default_domain"]),
+        fixtures_env=str(raw.get("fixtures_env") or "VEXA_DNA_FIXTURES"),
+        default_fixtures=str(raw.get("default_fixtures") or "~/dna-fixtures"),
+        states=states)
+
+
+def _step(state: str, i: int, row: Any) -> Step:
+    if not isinstance(row, dict) or "do" not in row:
+        raise CatalogueError(f"{state} step {i}: every row needs a `do:`")
+    verb = str(row["do"])
+    if verb not in VERBS:
+        raise CatalogueError(
+            f"{state} step {i}: {verb!r} is not a verb. The vocabulary is closed: "
+            f"{', '.join(sorted(VERBS))}. Add the verb to catalogue.VERBS and the method to "
+            f"doors.Doors together, or the recipe is naming something nothing can execute.")
+    spec = VERBS[verb]
+    door = str(row.get("door") or "")
+    if door != spec.door:
+        raise CatalogueError(
+            f"{state} step {i} ({verb}): declares door {door!r} but {verb} is answered by "
+            f"{spec.door!r}. The column is checked, not documentation — fix whichever is wrong.")
+    args = {k: v for k, v in row.items() if k not in ("do", "door")}
+    missing = [a for a in spec.required if a not in args]
+    if missing:
+        raise CatalogueError(f"{state} step {i} ({verb}): missing {missing}")
+    unknown = [a for a in args if a not in spec.required + spec.optional + ("as",)]
+    if unknown:
+        raise CatalogueError(
+            f"{state} step {i} ({verb}): unknown argument(s) {unknown}. An argument the verb "
+            f"ignores is a recipe that reads as if it does something it does not.")
+    return Step(do=verb, door=door, args=args, index=i)
+
+
+def _verify(state: str, row: Any) -> dict:
+    if not isinstance(row, dict) or "check" not in row:
+        raise CatalogueError(f"{state}: every verify row needs a `check:`")
+    kind = str(row["check"])
+    if kind not in CHECKS:
+        raise CatalogueError(f"{state}: {kind!r} is not a check. Available: "
+                             f"{', '.join(sorted(CHECKS))}")
+    missing = [a for a in CHECKS[kind] if a not in row]
+    if missing:
+        raise CatalogueError(f"{state}: check {kind} missing {missing}")
+    return dict(row)
+
+
+def _check_captures(state: str, steps: list[Step], verify: list) -> None:
+    """A verify row may only name something a step actually captured.
+
+    This is the load-time half of the same rule the door column enforces: a check pointing at a
+    capture nobody makes passes vacuously at run time, and a vacuous check is worse than no check —
+    it reports green for a state nobody proved.
+    """
+    captured = {s.capture for s in steps if s.capture}
+    for row in verify:
+        if not isinstance(row, dict):
+            continue
+        for key in ("of", "link"):
+            ref = row.get(key)
+            if not ref:
+                continue
+            root = str(ref).split(".", 1)[0]
+            if root not in captured and key == "of":
+                raise CatalogueError(
+                    f"{state}: check {row.get('check')} names `{ref}`, which no step captures "
+                    f"with `as:`. Captured here: {sorted(captured) or 'nothing'}.")
+
+
+#: What `interpolate(..., lenient=True)` leaves where a token cannot be resolved yet. It is
+#: deliberately not an empty string and deliberately not email-shaped: the lenient pass exists so
+#: the safety guard can read every address a recipe WILL say, and a placeholder that looked like an
+#: address would be checked as one.
+UNBOUND = "<unbound>"
+
+
+def interpolate(value: Any, bindings: dict, lenient: bool = False) -> Any:
+    """`{{name}}` and `{{name.field}}` out of the run's bindings, recursively over dicts/lists.
+
+    A WHOLE-STRING token keeps the bound value's TYPE (a list of attendees stays a list, an epoch
+    stays a number); a token inside a longer string renders as text. The distinction matters:
+    `participants: "{{fixture_attendees}}"` must reach `POST /events` as a JSON array, and a fact
+    whose participants arrived as the string "['a@x', 'b@x']" fans out to nobody while looking
+    entirely successful.
+
+    An unbound token RAISES. It is the same class of failure as the door column: silently
+    rendering `{{meeting_row.meeting_id}}` as empty produces a fact about meeting "" that admits
+    fine and reacts to nothing.
+
+    `lenient=True` renders unbound tokens as `UNBOUND` instead of raising. It has exactly ONE
+    caller — the pre-flight pass that reads every address a recipe will utter before any door is
+    touched — and it exists because that guard must see the addresses a step CAN resolve even when
+    the same step also names a capture only a later step will make. Without it, one
+    `{{meeting_row.meeting_id}}` in a row would hide that row's whole participant list from the
+    domain check.
+    """
+    if isinstance(value, dict):
+        return {k: interpolate(v, bindings, lenient) for k, v in value.items()}
+    if isinstance(value, list):
+        return [interpolate(v, bindings, lenient) for v in value]
+    if not isinstance(value, str):
+        return value
+    whole = _TOKEN.fullmatch(value.strip())
+    if whole:
+        return _resolve(whole.group(1), bindings, lenient)
+    return _TOKEN.sub(lambda m: str(_resolve(m.group(1), bindings, lenient)), value)
+
+
+def _resolve(dotted: str, bindings: dict, lenient: bool = False) -> Any:
+    cur: Any = bindings
+    for part in dotted.split("."):
+        if isinstance(cur, dict) and part in cur:
+            cur = cur[part]
+        else:
+            if lenient:
+                return UNBOUND
+            raise CatalogueError(
+                f"nothing is bound to {{{{{dotted}}}}}. Bound here: "
+                f"{', '.join(sorted(k for k in bindings if not k.startswith('_')))}")
+    return cur

--- a/deploy/dogfood/rehearse/doors.py
+++ b/deploy/dogfood/rehearse/doors.py
@@ -1,0 +1,990 @@
+"""The doors — one method per catalogue verb, plus the reads the verify block and the reset need.
+
+THE RULE THIS FILE EXISTS TO KEEP: a state is entered through the product's own doors. Not a
+`docker exec … psql`, not a write into the workspace volume, not a redis SET. Every write below is
+an HTTP call to a service route or an SMTP message into the mail double — the same calls a person,
+a calendar or a mail client makes. That is what makes a state re-enterable on a stack that is
+running someone else's work, and it is why `states.yaml` names the door on every row.
+
+THREE DELIBERATE EXCEPTIONS, all of them READS or per-subject deletes, all of them named here
+rather than discovered later:
+
+  1. `live_meetings()` reads the meetings table through the postgres container. There is no
+     instance-wide live-meeting route (`GET /bots/status` is per-caller), and the refusal it feeds
+     — never touch the stack while somebody's meeting is running — is the one guard that protects
+     the founder's data. Fail CLOSED: if the probe cannot run, `rehearse()` refuses. Filed as a
+     missing route rather than smuggled in as a habit.
+  2. `session_keys_delete()` / `scaffold_keys_delete()` in `subject_reset` clear redis by the
+     exact per-subject prefixes `blank-instance.sh` documents, and nothing else. agent-api owns
+     those keys and exposes no delete for them.
+  3. `lane_rows_delete_for()` deletes that subject's rows from the flows lanes — the reactions the
+     engine admitted for them, their receipts and signals, their mail threads, and their friction.
+     Same shape as the other two: the rows are per-subject and no route removes them. It is the
+     one that makes a state RE-ENTERABLE — `admit()` dedups on (source_event_id, flow), so a
+     reaction from an earlier run silently swallows the next invite (`admitted 0`, no prepare
+     mail, a step that waits out its budget for a touch nothing will send).
+
+`Doors` is a plain class with no HTTP in it, so `stub_doors.StubDoors` subclasses it and
+`run_all.py --stub` proves every recipe offline. `LiveDoors` is the only thing that talks to the
+stack.
+"""
+from __future__ import annotations
+
+import json
+import os
+import pathlib
+import re
+import smtplib
+import subprocess
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from email.message import EmailMessage
+from email.utils import formatdate, make_msgid
+
+# ── deployment values, every one of them named ───────────────────────────────────────────────────
+ADMIN_API = os.environ.get("VEXA_ADMIN_API_URL", "http://localhost:18457")
+AGENT_API = os.environ.get("VEXA_AGENT_API_URL", "http://localhost:18500")
+GATEWAY = os.environ.get("VEXA_GATEWAY_URL", "http://localhost:18456")
+FLOWS_API = os.environ.get("VEXA_FLOWS_API_URL", "http://localhost:18200")
+MAILPIT = os.environ.get("VEXA_MAILPIT_URL", os.environ.get("MAILPIT_URL", "http://localhost:8025"))
+SMTP_ADDR = os.environ.get("VEXA_SMTP", "127.0.0.1:1025")
+TERMINAL = os.environ.get("VEXA_UI_URL", "http://localhost:18300").rstrip("/")
+MAIL_ADDR = os.environ.get("VEXA_MAIL_ADDR", "vexa@storm.test")
+STACK = os.environ.get("VEXA_DOGFOOD_STACK", "vexa-dogfood")
+
+# ── which harness a rehearsed subject runs on (PRD decisions 37 + 38) ────────────────────────────
+#
+# A runner is a per-SUBJECT dial, never a deployment one: `rehearse(..., runner="openai-agent")`
+# pins one scratch subject to our own agent loop over the CCC box's Qwen while every other person
+# on the instance — the founder included — keeps the deployment's default. The mechanism is the
+# per-subject model config admin-api already resolves (`/internal/users/{id}/model-config`), which
+# `dispatch.overlay_model_config` stamps into the worker's env; `runner` is one more field of it.
+#
+# THE TABLE IS THE VOCABULARY. `runner=` accepts exactly these names, and a typo is refused with
+# the list rather than passed through — a runner nothing recognises is dropped silently at
+# dispatch, which is a preference that reads as set and does nothing. Every value is overridable
+# from the environment so the endpoint is a deployment fact, not a constant in this file.
+RUNNER_DIALS: dict[str, dict] = {
+    # The deployment's own harness: no custom endpoint, no model pin — clearing the fields returns
+    # the subject to whatever the instance runs.
+    "claude-code": {"mode": "", "base_url": "", "model": "", "extra_body": ""},
+    # PRD decision 37's first test target. `extra_body` is load-bearing, not decoration: vLLM/Qwen
+    # returns no valid JSON at all unless thinking is disabled.
+    "openai-agent": {
+        "mode": "custom",
+        "base_url": os.environ.get("VEXA_REHEARSE_LLM_BASE_URL", "http://192.168.1.6:8001/v1"),
+        "model": os.environ.get("VEXA_REHEARSE_LLM_MODEL", "qwen3.8-27b"),
+        "extra_body": os.environ.get(
+            "VEXA_REHEARSE_LLM_EXTRA_BODY",
+            '{"chat_template_kwargs":{"enable_thinking":false}}'),
+    },
+}
+
+
+def runner_config(runner: str) -> dict:
+    """The model config that pins a subject to `runner`, or raise with the names that work."""
+    dials = RUNNER_DIALS.get(runner)
+    if dials is None:
+        raise DoorRefused(
+            f"{runner!r} is not a runner this tool knows. Available: "
+            f"{', '.join(sorted(RUNNER_DIALS))}. A name passed through unchecked would be dropped "
+            f"at dispatch and the subject would quietly run on the deployment's default — a "
+            f"preference that reads as set and does nothing.")
+    return {"runner": runner, **dials}
+
+
+
+class DoorRefused(RuntimeError):
+    """A door answered no, and the answer is the product. Never swallowed, never retried blind."""
+
+
+class Doors:
+    """The interface. Every method is a verb in `catalogue.VERBS` or a read a check needs.
+
+    The base class raises: an unimplemented door must be loud. A stub that silently returns None
+    would let `run_all.py` report a state green having proved nothing, which is the exact failure
+    the verify block exists to prevent.
+    """
+
+    # ── verbs ────────────────────────────────────────────────────────────────────────────────
+    def require_instance_blank(self) -> dict: raise NotImplementedError
+    def require_subject_absent(self, address: str) -> dict: raise NotImplementedError
+    def user_ensure(self, address: str) -> dict: raise NotImplementedError
+    def desk_init(self, subject: str) -> dict: raise NotImplementedError
+    def desk_entity(self, subject: str, kind: str, name: str, facts=(), source: str = "",
+                    summary: str = "", slug: str = "") -> dict: raise NotImplementedError
+    def group_new(self, owner: str, name: str, purpose: str = "") -> dict: raise NotImplementedError
+    def group_join(self, group: str, owner: str, member: str, member_email: str = "",
+                   role: str = "contributor") -> dict: raise NotImplementedError
+    def request_sign_in_link(self, address: str) -> dict: raise NotImplementedError
+    def drop_invite(self, organizer: str, title: str, start: float, attendees=(),
+                    ics_uid: str = "", group: str = "", url: str = "") -> dict:
+        raise NotImplementedError
+    def seed_meeting(self, owner: str, native: str, title: str, segments: list,
+                     started_at: float, source: str = "seed") -> dict: raise NotImplementedError
+    def emit_fact(self, event_type: str, source_event_id: str, refs: dict) -> dict:
+        raise NotImplementedError
+    def await_mail(self, to: str, subject_contains: str = "", budget_s: int = 180,
+                   since: float = 0.0) -> dict: raise NotImplementedError
+    def reply_to_mail(self, message: dict, from_address: str, body: str) -> dict:
+        raise NotImplementedError
+    def await_reaction(self, flow: str, since: float = 0.0, budget_s: int = 300) -> dict:
+        raise NotImplementedError
+    def cancel_bot_leg(self, flow: str, source_contains: str = "") -> dict:
+        raise NotImplementedError
+
+    # ── the per-subject harness (decisions 37 + 38) ──────────────────────────────────────────
+    def bind_runner(self, subject: str, runner: str) -> dict: raise NotImplementedError
+
+    # ── reads the verify block needs ─────────────────────────────────────────────────────────
+    def user_find(self, address: str): raise NotImplementedError
+    def user_email(self, uid: str) -> str: raise NotImplementedError
+    def meeting_get(self, owner: str, meeting_id) -> dict: raise NotImplementedError
+    def desk_tree(self, subject: str, slug: str = "") -> list: raise NotImplementedError
+    def group_members(self, owner: str, group: str) -> list: raise NotImplementedError
+    def scaffold_get(self, scaffold_id: str, subject: str = "") -> dict: raise NotImplementedError
+
+    # ── the guard, and the reset ─────────────────────────────────────────────────────────────
+    def live_meetings(self) -> list: raise NotImplementedError
+    def user_delete(self, uid: str) -> dict: raise NotImplementedError
+    def desk_delete(self, subject: str) -> dict: raise NotImplementedError
+    def meetings_delete_for(self, subject: str) -> int: raise NotImplementedError
+    def session_keys_delete(self, subject: str) -> int: raise NotImplementedError
+    def scaffold_keys_delete(self, address: str) -> int: raise NotImplementedError
+    def friction_delete_for(self, subject: str) -> int: raise NotImplementedError
+    def lane_rows_delete_for(self, subject: str, address: str) -> dict:
+        raise NotImplementedError
+    def mail_delete_for(self, address: str) -> int: raise NotImplementedError
+
+
+# ── the live implementation ──────────────────────────────────────────────────────────────────────
+
+#: `GET /meetings` caps `limit` at 100 and answers 422 above it. Named here because asking for
+#: more than a route allows is not a bigger answer, it is no answer — and the shape of the refusal
+#: (a dict with `detail`) reads as an empty list to anything that does `.get("meetings", [])`.
+MEETINGS_PAGE_MAX = 100
+
+
+def _http(method: str, url: str, headers: dict | None = None, body=None, timeout: float = 40):
+    h = {"content-type": "application/json", **(headers or {})}
+    req = urllib.request.Request(
+        url, method=method,
+        data=json.dumps(body).encode() if body is not None else None, headers=h)
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as r:
+            raw = r.read().decode()
+            try:
+                return r.status, json.loads(raw)
+            except ValueError:
+                return r.status, raw
+    except urllib.error.HTTPError as e:
+        raw = e.read().decode()
+        try:
+            return e.code, json.loads(raw)
+        except ValueError:
+            return e.code, raw
+    except Exception as e:                                        # noqa: BLE001 — transport
+        return 0, f"{type(e).__name__}: {e}"
+
+
+class LiveDoors(Doors):
+    """The doors of the running dogfood stack."""
+
+    def __init__(self, *, admin_key: str = "", flows_key: str = "", stack: str = STACK):
+        self.stack = stack
+        self._admin_key = admin_key or _admin_key(stack)
+        self._flows_key = flows_key or _flows_key()
+        self._keys: dict[str, str] = {}
+
+    # -- identity -------------------------------------------------------------------------------
+    def _ak(self) -> dict:
+        return {"X-Admin-API-Key": self._admin_key}
+
+    def _user_key(self, uid: str) -> str:
+        """One gateway key per subject per process. Minted once and remembered — the rig learned
+        this the expensive way (66 live credentials for one account, none of them revocable)."""
+        uid = str(uid)
+        if uid not in self._keys:
+            st, tok = _http("POST", f"{ADMIN_API}/admin/users/{uid}/tokens", self._ak(),
+                            {"scopes": ["bot", "browser", "tx"]})
+            key = (tok or {}).get("token") if isinstance(tok, dict) else ""
+            if not key:
+                raise DoorRefused(f"admin-api would not mint a key for uid {uid} ({st})")
+            self._keys[uid] = key
+        return self._keys[uid]
+
+    def _gw(self, uid: str, method: str, path: str, body=None, timeout: float = 60):
+        return _http(method, f"{GATEWAY}{path}", {"X-API-Key": self._user_key(uid)}, body, timeout)
+
+    # -- verbs ----------------------------------------------------------------------------------
+    def require_instance_blank(self) -> dict:
+        st, body = _http("GET", f"{AGENT_API}/api/global/state", None)
+        if st != 200 or not isinstance(body, dict):
+            st, body = _http("GET", f"{ADMIN_API}/internal/instance-state", self._ak())
+        if st != 200 or not isinstance(body, dict):
+            raise DoorRefused(
+                "could not read the instance gate — refusing rather than guessing that a stack "
+                f"is blank ({st}). The gate is what tells a blank instance from a claimed one.")
+        claimed = bool(body.get("admin_exists") or body.get("admin"))
+        layer = str(body.get("global_setup") or body.get("setup") or "")
+        if claimed or layer == "completed":
+            raise DoorRefused(
+                "the instance is NOT blank: an admin has claimed it"
+                + (f" and the company layer is {layer}" if layer else "")
+                + ". `blank-admin` asserts this state, it never creates it — blanking deletes "
+                  "every person on the stack and is `bin/blank-instance.sh`, run on purpose.")
+        return {"blank": True, "admin_exists": claimed, "global_setup": layer}
+
+    def require_subject_absent(self, address: str) -> dict:
+        uid = self.user_find(address)
+        if uid:
+            raise DoorRefused(
+                f"{address} already has a user (uid {uid}) and this state needs a stranger. "
+                f"Run subject_reset({address!r}) first.")
+        return {"absent": True, "address": address}
+
+    def user_ensure(self, address: str) -> dict:
+        st, u = _http("GET", f"{ADMIN_API}/admin/users/email/{urllib.parse.quote(address)}",
+                      self._ak())
+        existed = st == 200
+        if not existed:
+            st, u = _http("POST", f"{ADMIN_API}/admin/users", self._ak(),
+                          {"email": address, "name": address.split("@")[0].replace(".", " ").title()})
+        if not isinstance(u, dict) or not u.get("id"):
+            raise DoorRefused(f"admin-api would not resolve or create {address}: {st} {str(u)[:200]}")
+        return {"uid": str(u["id"]), "email": address, "existed": existed}
+
+    def desk_init(self, subject: str) -> dict:
+        st, body = _http("POST", f"{AGENT_API}/api/workspace/init", {"X-User-Id": str(subject)}, {})
+        if st not in (200, 201):
+            raise DoorRefused(f"workspace/init refused for {subject}: {st} {str(body)[:200]}")
+        return {"subject": str(subject), "status": st}
+
+    def desk_entity(self, subject: str, kind: str, name: str, facts=(), source: str = "",
+                    summary: str = "", slug: str = "") -> dict:
+        payload = {"kind": kind, "name": name, "facts": list(facts), "source": source}
+        if summary:
+            payload["summary"] = summary
+        if slug:
+            payload["slug"] = slug
+        st, body = _http("POST", f"{AGENT_API}/api/workspace/entity",
+                         {"X-User-Id": str(subject)}, payload)
+        if st not in (200, 201):
+            raise DoorRefused(f"entity write refused for {subject}: {st} {str(body)[:300]}")
+        return body if isinstance(body, dict) else {"status": st}
+
+    def group_new(self, owner: str, name: str, purpose: str = "") -> dict:
+        st, r = _http("POST", f"{AGENT_API}/api/workspace/shared/new",
+                      {"X-User-Id": str(owner)}, {"name": name})
+        if st not in (200, 201) or not isinstance(r, dict) or not r.get("workspace_id"):
+            raise DoorRefused(f"could not create the group {name!r}: {st} {str(r)[:200]}")
+        wid = str(r["workspace_id"])
+        if purpose:
+            _http("POST", f"{AGENT_API}/api/workspace/purpose", {"X-User-Id": str(owner)},
+                  {"slug": wid, "purpose": purpose})
+        return {"workspace_id": wid, "name": name, "owner": str(owner)}
+
+    def group_join(self, group: str, owner: str, member: str, member_email: str = "",
+                   role: str = "contributor") -> dict:
+        already = [m for m in self.group_members(owner, group)
+                   if str(m.get("subject")) == str(member) or m.get("email") == member_email]
+        if already:
+            return {"group": group, "member": str(member), "joined": False, "already": True}
+        body = {"workspace_id": group, "role": role, "expires_in_sec": 3600, "max_uses": 1,
+                "mode": "restricted" if member_email else "open"}
+        if member_email:
+            body["allowed_emails"] = [member_email]
+        st, r = _http("POST", f"{AGENT_API}/api/workspace/invites", {"X-User-Id": str(owner)}, body)
+        if st not in (200, 201) or not isinstance(r, dict) or not r.get("token"):
+            raise DoorRefused(f"could not mint an invite to {group}: {st} {str(r)[:200]}")
+        hdr = {"X-User-Id": str(member)}
+        if member_email:
+            hdr["X-User-Email"] = member_email
+        st2, r2 = _http("POST", f"{AGENT_API}/api/workspace/invites/accept", hdr,
+                        {"token": r["token"]})
+        if st2 not in (200, 201):
+            raise DoorRefused(f"{member} could not redeem the invite to {group}: "
+                              f"{st2} {str(r2)[:200]}")
+        return {"group": group, "member": str(member), "joined": True}
+
+    def request_sign_in_link(self, address: str) -> dict:
+        st, body = _http("POST", f"{TERMINAL}/api/auth/request-link", None, {"email": address})
+        # The route answers 200 whether or not the address is known — deliberately, so it cannot be
+        # used to enumerate accounts. So "sent" is not proved here; the mail is.
+        if st not in (200, 202):
+            raise DoorRefused(f"the sign-in door refused {address}: {st} {str(body)[:200]}. "
+                              f"VEXA_UI_URL is {TERMINAL} — is that this deployment's terminal?")
+        return {"requested": address, "status": st, "terminal": TERMINAL}
+
+    def drop_invite(self, organizer: str, title: str, start: float, attendees=(),
+                    ics_uid: str = "", group: str = "", url: str = "") -> dict:
+        """SMTP an ICS invite to the mailbox the poller answers as — the calendar's own door.
+
+        Deliberately identical in shape to `bin/drop-invite.py`, which is the hand tool; this is
+        the same message built in-process so a recipe does not shell out.
+        """
+        start = float(start)
+        fmt = lambda t: time.strftime("%Y%m%dT%H%M%SZ", time.gmtime(t))          # noqa: E731
+        uid = ics_uid or f"rehearse-{int(start)}@vexa.local"
+        url = url or "https://us02web.zoom.us/j/84123456789?pwd=aBcD1234efGH"
+        lines = [
+            "BEGIN:VCALENDAR", "PRODID:-//Vexa//rehearse//EN", "VERSION:2.0", "METHOD:REQUEST",
+            "BEGIN:VEVENT", f"DTSTART:{fmt(start)}", f"DTEND:{fmt(start + 3600)}", f"UID:{uid}",
+            f"DTSTAMP:{fmt(time.time())}",
+            f"ORGANIZER;CN={organizer.split('@')[0]}:mailto:{organizer}",
+        ]
+        for name, addr in attendees:
+            lines.append("ATTENDEE;CUTYPE=INDIVIDUAL;ROLE=REQ-PARTICIPANT;PARTSTAT=NEEDS-ACTION;"
+                         f"CN={name}:mailto:{addr}")
+        lines.append(f"ATTENDEE;CN=Vexa;PARTSTAT=NEEDS-ACTION:mailto:{MAIL_ADDR}")
+        desc = "Join Zoom Meeting" + (f" #group:{group}" if group else "") + f"\\n{url}"
+        lines += [f"SUMMARY:{title}", f"DESCRIPTION:{desc}", f"LOCATION:{url}",
+                  "END:VEVENT", "END:VCALENDAR", ""]
+        m = EmailMessage()
+        m["From"] = f"{organizer.split('@')[0]} <{organizer}>"
+        m["To"] = MAIL_ADDR
+        m["Subject"] = (f"Invitation: {title} @ "
+                        f"{time.strftime('%a %b %d, %Y %H:%M', time.gmtime(start))} (UTC)")
+        m["Date"] = formatdate(usegmt=True)
+        m["Message-ID"] = make_msgid(domain="rehearse.local")
+        m.set_content(f"You have been invited to {title}.\n{url}\n")
+        m.add_attachment("\r\n".join(lines).encode(), maintype="text", subtype="calendar",
+                         filename="invite.ics", params={"method": "REQUEST", "charset": "utf-8"})
+        host, _, port = SMTP_ADDR.partition(":")
+        with smtplib.SMTP(host, int(port or 1025), timeout=20) as s:
+            s.send_message(m)
+        return {"ics_uid": uid, "to": MAIL_ADDR, "organizer": organizer, "start": start,
+                "attendees": [a for _, a in attendees], "message_id": m["Message-ID"]}
+
+    def seed_meeting(self, owner: str, native: str, title: str, segments: list,
+                     started_at: float, source: str = "seed") -> dict:
+        """`POST /meetings` then `POST /meetings/{id}/transcript-import` — two gateway calls.
+
+        A jitsi URL, so the native id survives verbatim (meeting-api's google_meet rule would force
+        a synthetic code and break the row's addressability — and an unaddressable row is a mail
+        with a button that opens nothing).
+        """
+        duration = max((float(s["end"]) for s in segments), default=0.0)
+        started = float(started_at)
+        ended = started + duration
+        iso = lambda t: time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(t))       # noqa: E731
+        # ADOPT BEFORE CREATING. The unique index on (user, platform, native) is PARTIAL — it does
+        # not cover completed rows — so a second seed of the same native id would happily mint a
+        # SECOND completed meeting. The recipe's fact id names the row, so that second row would
+        # produce a second fan-out: a duplicate mail to everybody, from a call whose whole contract
+        # is idempotence. Adopting is also the truthful answer: this transcript is already imported
+        # into that row, and the import route is itself idempotent on (source, row).
+        existing = self._find_meeting(owner, native)
+        if existing and existing.get("status") == "completed":
+            return self._row(existing, started, ended, imported=False)
+        st, m = self._gw(owner, "POST", "/meetings", {
+            "title": title, "scheduled_at": iso(started),
+            "meeting_url": f"https://meet.jit.si/{native}"})
+        if st == 409:
+            row = self._find_meeting(owner, native)
+            if row and row.get("status") == "completed":
+                return self._row(row, started, ended, imported=False)
+            raise DoorRefused(
+                f"a non-terminal meeting already holds native id {native} — seed under a different "
+                f"native id, or delete the leftover row first")
+        if st not in (200, 201) or not isinstance(m, dict):
+            raise DoorRefused(f"meeting create refused: {st} {str(m)[:300]}")
+        if m.get("platform") in (None, "", "unknown") or not m.get("native_meeting_id"):
+            raise DoorRefused(
+                f"the seed made an UNADDRESSABLE row (id {m.get('id')}): no share can be minted "
+                f"against it, so the attendee mail would ship with a button that opens nothing")
+        mid = m["id"]
+        st, body = self._gw(owner, "POST", f"/meetings/{mid}/transcript-import", {
+            "segments": [{"start": float(s["start"]), "end": float(s["end"]),
+                          "speaker": s.get("speaker"), "text": s.get("text") or "",
+                          "language": s.get("language") or "en"} for s in segments],
+            "started_at": iso(started), "ended_at": iso(ended),
+            # `source` is a CLOSED vocabulary on the route — `import` | `seed` — and it refuses
+            # anything else with the list. It sent "rehearse" and got a 422 on the first live run.
+            # The route is RIGHT and the tool was wrong: these words did not come from a recording,
+            # they were imported from a fixture by a double, which is exactly what `seed` means.
+            # Widening the vocabulary to admit a caller's own name for itself would make the column
+            # unreadable, which is the column's whole job.
+            "source": source or "seed"},
+            timeout=180)
+        if st != 200 or not isinstance(body, dict):
+            raise DoorRefused(f"transcript-import refused on meeting {mid}: {st} {str(body)[:300]}")
+        return self._row({**m, **body, "id": mid}, started, ended, imported=True)
+
+    @staticmethod
+    def _row(m: dict, started: float, ended: float, imported: bool) -> dict:
+        return {"meeting_id": m.get("id"), "native_meeting_id": m.get("native_meeting_id"),
+                "platform": m.get("platform"), "status": m.get("status"),
+                "segments_loaded": m.get("segments_imported"), "imported": imported,
+                "started_epoch": int(started), "ended_epoch": int(ended),
+                "start_time": m.get("start_time"), "end_time": m.get("end_time")}
+
+    def _meetings_of(self, owner: str) -> list:
+        """This subject's meetings — and a REFUSAL IS NOT AN EMPTY LIST.
+
+        Both callers used to read the response as `(b or {}).get("meetings", [])`, which turns any
+        non-2xx into "this person has no meetings". Found live: the list was requested with
+        `?limit=200`, the route caps it at 100 and answered 422, and `subject_reset` reported
+        `meetings: 0` with a row sitting right there — then the next run of that state was refused
+        with a 409 nobody could explain. The other caller is worse: `seed_meeting` asks this to
+        decide whether a completed row already exists, so a swallowed refusal would have minted a
+        SECOND completed meeting and mailed the whole room twice.
+
+        This is the defect the whole package is written against, in its own code: a call that fails
+        and is read as "nothing to do".
+        """
+        st, b = self._gw(owner, "GET", f"/meetings?limit={MEETINGS_PAGE_MAX}")
+        if st != 200 or not isinstance(b, dict) or "meetings" not in b:
+            raise DoorRefused(
+                f"could not list meetings for {owner}: {st} {str(b)[:200]}. Refusing to read that "
+                f"as 'no meetings' — every caller here decides something destructive from it.")
+        return list(b.get("meetings") or [])
+
+    def _find_meeting(self, owner: str, native: str) -> dict | None:
+        rows = self._meetings_of(owner)
+        return next((r for r in rows if str(r.get("native_meeting_id")) == str(native)), None)
+
+    def emit_fact(self, event_type: str, source_event_id: str, refs: dict) -> dict:
+        """`POST /events` on flows-api — the intake for a producer that is not the mailbox.
+
+        NOT the control MCP's `fact_emit`: that verb is gated to an instance ADMIN because it
+        injects facts naming an arbitrary organizer, and a harness is not a person. flows-api's
+        own intake with the lane key is the door built for exactly this caller.
+        """
+        st, body = _http("POST", f"{FLOWS_API}/events",
+                         {"X-Flows-Admin-Key": self._flows_key, "X-Actor": "rehearse"},
+                         {"event_type": event_type, "source_event_id": source_event_id,
+                          "refs": refs})
+        if st not in (200, 202) or not isinstance(body, dict):
+            raise DoorRefused(f"the fact intake refused {event_type}: {st} {str(body)[:300]}")
+        return {"event_type": event_type, "source_event_id": source_event_id,
+                "reactions_created": body.get("reactions_created"),
+                "duplicate": bool(body.get("duplicate")), "at": time.time()}
+
+    def await_mail(self, to: str, subject_contains: str = "", budget_s: int = 180,
+                   since: float = 0.0) -> dict:
+        deadline = time.time() + budget_s
+        query = urllib.parse.quote(f"to:{to}")
+        last: list = []
+        while True:
+            st, body = _http("GET", f"{MAILPIT}/api/v1/search?query={query}&limit=60", None)
+            msgs = (body or {}).get("messages", []) if isinstance(body, dict) else []
+            last = msgs
+            unplaceable = 0
+            for msg in msgs:
+                if subject_contains and subject_contains.lower() not in (msg.get("Subject") or "").lower():
+                    continue
+                when = _mail_epoch(msg)
+                if since and when is not None and when < since - 5:
+                    continue                        # a previous run's touch, definitely
+                if since and when is None:
+                    # We cannot place it in time. INCLUDE it and say so: a false accept is a check
+                    # that needs tightening, a false reject is a touch reported as never sent.
+                    unplaceable += 1
+                return self._mail(msg["ID"])
+            if time.time() >= deadline:
+                # The refusal NAMES what it saw and why each candidate was rejected — the previous
+                # version listed the very mail it had just discarded, which reads as a product
+                # failure and was a reader's.
+                seen = "; ".join(sorted({(m.get("Subject") or "") for m in last})[:6])
+                raise DoorRefused(
+                    f"no mail to {to}"
+                    + (f" whose subject contains {subject_contains!r}" if subject_contains else "")
+                    + f" arrived within {budget_s}s (only counting mail newer than "
+                      f"{time.strftime('%H:%M:%SZ', time.gmtime(since))} — this run's start)"
+                    + f". {len(last)} message(s) to that address exist: {seen}")
+            time.sleep(3)
+
+    def _mail(self, message_id: str) -> dict:
+        st, body = _http("GET", f"{MAILPIT}/api/v1/message/{message_id}", None)
+        if st != 200 or not isinstance(body, dict):
+            raise DoorRefused(f"mailpit would not read message {message_id}: {st}")
+        text = str(body.get("Text") or "")
+        html = str(body.get("HTML") or "")
+        return {"id": message_id, "subject": body.get("Subject") or "",
+                "to": [t.get("Address") for t in body.get("To") or []],
+                "from": (body.get("From") or {}).get("Address"),
+                "message_id": body.get("MessageID") or "",
+                "text": text, "html": html, "body": text + "\n" + html,
+                "links": _links(text + "\n" + html), "at": time.time()}
+
+    def reply_to_mail(self, message: dict, from_address: str, body: str) -> dict:
+        orig = str(message.get("message_id") or "")
+        if not orig:
+            raise DoorRefused(
+                "the mail we are replying to carries no Message-ID, so `mail_thread` cannot route "
+                "the reply and the poller would treat it as a new sender. Not sending.")
+        if not orig.startswith("<"):
+            orig = f"<{orig}>"
+        m = EmailMessage()
+        m["From"] = from_address
+        m["To"] = MAIL_ADDR
+        m["Subject"] = "Re: " + str(message.get("subject") or "")
+        m["Date"] = formatdate(usegmt=True)
+        m["Message-ID"] = make_msgid(domain="rehearse.local")
+        m["In-Reply-To"] = orig
+        m["References"] = orig
+        m.set_content(body.strip() + "\n")
+        host, _, port = SMTP_ADDR.partition(":")
+        with smtplib.SMTP(host, int(port or 1025), timeout=20) as s:
+            s.send_message(m)
+        return {"in_reply_to": orig, "message_id": m["Message-ID"], "from": from_address,
+                "sent_at": time.time()}
+
+    def await_reaction(self, flow: str, since: float = 0.0, budget_s: int = 300) -> dict:
+        deadline = time.time() + budget_s
+        while True:
+            st, body = _http("GET", f"{FLOWS_API}/reactions?limit=80",
+                             {"X-Flows-Admin-Key": self._flows_key})
+            rows = (body or {}).get("reactions", []) if isinstance(body, dict) else []
+            for r in rows:
+                if r.get("flow") != flow:
+                    continue
+                if since and float(r.get("created_at") or r.get("admitted_at") or 0) < since - 5:
+                    continue
+                return {"flow": flow, "state": r.get("state"), "id": r.get("id"),
+                        "reaction": r, "admitted": True}
+            if time.time() >= deadline:
+                raise DoorRefused(
+                    f"no `{flow}` reaction appeared within {budget_s}s. The fact reached the "
+                    f"intake but nothing reacted — check that the lane is running the flow "
+                    f"version that declares it.")
+            time.sleep(4)
+
+    def bind_runner(self, subject: str, runner: str) -> dict:
+        """Pin ONE subject to a harness, through admin-api's per-user model config.
+
+        `PUT /admin/users/{id}/models`, not `PUT /user/models`: the self-serve route takes the
+        caller's own identity, and this caller is binding a config to somebody else. And not the
+        platform setting either — that would change the model for every person on the instance,
+        which is the exact opposite of what a rehearsal is for.
+        """
+        cfg = runner_config(runner)
+        st, body = _http("PUT", f"{ADMIN_API}/admin/users/{subject}/models", self._ak(), cfg)
+        if st in (404, 405):
+            raise DoorRefused(
+                f"admin-api has no PUT /admin/users/{{id}}/models on the running image ({st}). "
+                "The route ships on this branch; the deployment needs the admin-api swap before a "
+                "runner can be pinned per subject. Nothing was bound.")
+        if not 200 <= st < 300:
+            raise DoorRefused(f"admin-api refused the runner binding for {subject}: "
+                              f"{st} {str(body)[:200]}")
+        return {"subject": str(subject), "runner": runner, "config": cfg}
+
+    def cancel_bot_leg(self, flow: str, source_contains: str = "") -> dict:
+        """Cancel this recipe's own parked reaction — `POST /reactions/{id}/cancel`, the product's
+        audited lifecycle verb.
+
+        A REHEARSAL MUST LEAVE NOTHING ARMED. `invite_intake` parks on `await_start` until
+        start−2min and then dispatches a REAL bot at the invite's URL, and the states that use an
+        invite are rehearsing the PREPARE TOUCH — the bot leg is not what they measure. Leaving the
+        reaction parked means the run has armed a live dispatch at a fixture Zoom URL that fires on
+        the clock, long after the state was reported green. It happened: meeting 115 reached
+        `joining` at 19:20Z while the catalogue was still running.
+
+        Scoped by `source_contains` so it can only reach a reaction this recipe's own derived ids
+        name — never another lane user's parked work.
+        """
+        st, body = _http("GET", f"{FLOWS_API}/reactions?limit=100",
+                         {"X-Flows-Admin-Key": self._flows_key})
+        rows = (body or {}).get("reactions", []) if isinstance(body, dict) else []
+        if st != 200 or not isinstance(body, dict):
+            raise DoorRefused(f"could not list reactions to cancel the bot leg: {st}")
+        targets = [r for r in rows
+                   if r.get("flow") == flow
+                   and str(r.get("status")) in ("admitted", "retrying")
+                   and (not source_contains
+                        or source_contains in str(r.get("source_event_id") or ""))]
+        cancelled, refused = [], []
+        for r in targets:
+            rid = r.get("reaction_id") or r.get("id")
+            cst, cb = _http("POST", f"{FLOWS_API}/reactions/{rid}/cancel",
+                            {"X-Flows-Admin-Key": self._flows_key}, {})
+            (cancelled if 200 <= cst < 300 else refused).append(f"{rid}:{cst}")
+        if refused:
+            raise DoorRefused(
+                f"cancelled {len(cancelled)}, REFUSED {refused} — a parked invite reaction left "
+                f"behind will dispatch a real bot at a fixture URL when its clock arrives")
+        return {"flow": flow, "cancelled": len(cancelled), "ids": cancelled}
+
+    # ── reads ─────────────────────────────────────────────────────────────────────────────────
+    def user_find(self, address: str):
+        st, u = _http("GET", f"{ADMIN_API}/admin/users/email/{urllib.parse.quote(address)}",
+                      self._ak())
+        return str(u["id"]) if st == 200 and isinstance(u, dict) and u.get("id") else None
+
+    def user_email(self, uid: str) -> str:
+        st, u = _http("GET", f"{ADMIN_API}/admin/users/{uid}", self._ak())
+        if st != 200 or not isinstance(u, dict):
+            raise DoorRefused(f"no user {uid} on this instance ({st})")
+        return str(u.get("email") or "")
+
+    def meeting_get(self, owner: str, meeting_id) -> dict:
+        st, b = self._gw(owner, "GET", f"/meetings/{meeting_id}")
+        if st == 200 and isinstance(b, dict):
+            return b
+        row = self._find_meeting(owner, meeting_id)
+        if row:
+            return row
+        raise DoorRefused(f"meeting {meeting_id} is not readable as uid {owner} ({st})")
+
+    def desk_tree(self, subject: str, slug: str = "") -> list:
+        """One desk's files, READ AS `subject`. `slug` selects a group desk they belong to.
+
+        The reader is always a person: agent-api resolves a group by membership, so asking for a
+        group desk without saying who is asking is a question the product cannot answer — and the
+        404 it would return reads as "the desk is empty", which is the wrong finding entirely."""
+        url = f"{AGENT_API}/api/workspace/tree"
+        if slug:
+            url += f"?slug={urllib.parse.quote(str(slug))}"
+        st, b = _http("GET", url, {"X-User-Id": str(subject)})
+        if st != 200 or not isinstance(b, dict):
+            raise DoorRefused(f"could not read the desk {slug or subject} as {subject}: {st}")
+        files = b.get("files") or b.get("tree") or []
+        return [f if isinstance(f, str) else (f.get("path") or "") for f in files]
+
+    def group_members(self, owner: str, group: str) -> list:
+        st, r = _http("GET", f"{AGENT_API}/api/workspace/members?workspace_id={urllib.parse.quote(group)}",
+                      {"X-User-Id": str(owner)})
+        if st != 200 or not isinstance(r, dict):
+            return []
+        return list(r.get("members") or [])
+
+    def scaffold_get(self, scaffold_id: str, subject: str = "") -> dict:
+        hdr = {"X-Internal-Secret": _internal_secret()} if not subject else {"X-User-Id": str(subject)}
+        st, b = _http("GET", f"{AGENT_API}/api/scaffolds/{scaffold_id}", hdr)
+        if st != 200 or not isinstance(b, dict):
+            raise DoorRefused(
+                f"scaffold {scaffold_id} does not resolve ({st}). A link whose record cannot be "
+                f"read opens onto nothing — that is the defect, not the check.")
+        return b
+
+    # ── the guard ─────────────────────────────────────────────────────────────────────────────
+    LIVE_STATUSES = ("active", "joining", "requested", "awaiting_admission", "needs_help",
+                     "stopping")
+
+    def live_meetings(self) -> list:
+        """Every live meeting on the stack, with the owner's address.
+
+        READ-ONLY, and through the postgres container because there is no instance-wide route
+        (`GET /bots/status` is scoped to one caller). It FAILS CLOSED: an unreadable probe raises,
+        and `rehearse()` refuses. The guard exists so a rehearsal can never run beside somebody's
+        real meeting, and a guard that degrades to "probably fine" is not one.
+        """
+        sql = ("SELECT m.id, m.status, u.email FROM meetings m JOIN users u ON u.id = m.user_id "
+               f"WHERE m.status IN ({', '.join(chr(39) + s + chr(39) for s in self.LIVE_STATUSES)});")
+        r = subprocess.run(
+            ["docker", "exec", f"{self.stack}-postgres-1", "psql", "-U", "postgres", "-d", "vexa",
+             "-tAF", "|", "-c", sql], capture_output=True, text=True, timeout=30)
+        if r.returncode != 0:
+            raise DoorRefused(
+                "could not read the live-meeting probe, so the rehearsal refuses rather than "
+                "running blind beside a real meeting: " + (r.stderr or "").strip()[:300])
+        out = []
+        for line in r.stdout.splitlines():
+            parts = line.strip().split("|")
+            if len(parts) == 3:
+                out.append({"id": parts[0], "status": parts[1], "email": parts[2].lower()})
+        return out
+
+    # ── the reset ─────────────────────────────────────────────────────────────────────────────
+    def user_delete(self, uid: str) -> dict:
+        st, b = _http("DELETE", f"{ADMIN_API}/admin/users/{uid}", self._ak())
+        if st in (200, 204):
+            return {"deleted": True, "via": "admin-api"}
+        if st in (404, 405):
+            raise DoorRefused(
+                f"admin-api has no DELETE /admin/users/{{id}} on the running image ({st}). "
+                "The route exists on this branch; the deployment needs the admin-api swap before "
+                "subject_reset can remove a user. Nothing was deleted.")
+        raise DoorRefused(f"admin-api refused to delete uid {uid}: {st} {str(b)[:200]}")
+
+    def meetings_delete_for(self, subject: str) -> int:
+        """Every meeting this subject owns, deleted through the product's own `DELETE /meetings/{id}`.
+
+        Needed on its own, not only as part of the user delete: a run that fails BETWEEN
+        `POST /meetings` and the transcript import leaves a non-terminal row, and the next attempt
+        at that state is refused — correctly — with `409 a non-terminal meeting already holds this
+        native id`. Found live on run 2, where three states could not be re-entered for that
+        reason. Without this the only way out was a hand-written call.
+        """
+        rows = self._meetings_of(subject)
+        gone, refused = 0, []
+        for row in rows:
+            dst, body = self._gw(subject, "DELETE", f"/meetings/{row.get('id')}")
+            if dst in (200, 204):
+                gone += 1
+            else:
+                refused.append(f"{row.get('id')}:{dst}")
+        if refused:
+            # A delete that did not happen must not be counted as one. The caller reports this
+            # under `remaining`, and the next run of that state would otherwise meet a 409 it
+            # cannot explain.
+            raise DoorRefused(f"deleted {gone} meeting(s); refused: {', '.join(refused)}")
+        return gone
+
+    def desk_delete(self, subject: str) -> dict:
+        st, b = _http("DELETE", f"{AGENT_API}/api/workspace/{urllib.parse.quote(str(subject))}",
+                      {"X-User-Id": str(subject)})
+        if st in (200, 204, 404):
+            return {"deleted": st != 404, "status": st}
+        # The baseline desk refuses DELETE by design; reset is its delete-equivalent.
+        st2, b2 = _http("POST", f"{AGENT_API}/api/workspace/reset", {"X-User-Id": str(subject)},
+                        {"target": "personal"})
+        if st2 in (200, 201):
+            return {"deleted": False, "reset": True, "status": st2}
+        raise DoorRefused(f"could not remove the desk of {subject}: {st} {str(b)[:150]} / "
+                          f"{st2} {str(b2)[:150]}")
+
+    def session_keys_delete(self, subject: str) -> int:
+        """`agent:sessions:<uid>` and every `agent:session:<uid>:*` it indexes. NOTHING ELSE.
+
+        The prefixes are listed, never globbed on `agent:*`: a list is reviewable and a glob
+        silently adopts whatever the next feature names. The same valkey carries `tc:meeting:*`
+        live transcript streams, which is why no FLUSH appears anywhere in this file.
+        """
+        return self._redis_del([f"agent:sessions:{subject}", f"agent:session:{subject}:*"])
+
+    def scaffold_keys_delete(self, address: str) -> int:
+        """That recipient's pending-scaffold index, and each record it names.
+
+        A scaffold outliving a reset is a live capability minted for an address — the reason it is
+        cleared rather than left to expire.
+        """
+        idx = f"agent:scaffolds:by:{_recipient_key(address)}"
+        ids = self._redis(["SMEMBERS", idx]).split()
+        keys = [idx] + [f"agent:scaffold:{i.strip()}" for i in ids if i.strip()]
+        return self._redis_del(keys)
+
+    def _redis_del(self, patterns: list[str]) -> int:
+        cli = self._redis_cli()
+        n = 0
+        for pat in patterns:
+            if "*" in pat:
+                out = self._redis(["--scan", "--pattern", pat, "--count", "500"])
+                keys = [k for k in out.split() if k.strip()]
+            else:
+                keys = [pat] if self._redis(["EXISTS", pat]).strip() == "1" else []
+            for k in keys:
+                self._redis(["DEL", k])
+                n += 1
+        del cli
+        return n
+
+    def _redis_cli(self) -> str:
+        r = subprocess.run(["docker", "exec", f"{self.stack}-redis-1", "sh", "-lc",
+                            "command -v valkey-cli || command -v redis-cli"],
+                           capture_output=True, text=True, timeout=20)
+        cli = (r.stdout or "").strip()
+        if not cli:
+            raise DoorRefused(f"no valkey-cli/redis-cli in {self.stack}-redis-1 — a pending "
+                              "scaffold would survive the reset, and a scaffold is a capability")
+        return cli
+
+    def _redis(self, args: list[str]) -> str:
+        cli = getattr(self, "_cli_cache", "") or self._redis_cli()
+        self._cli_cache = cli
+        r = subprocess.run(["docker", "exec", f"{self.stack}-redis-1", cli, *args],
+                           capture_output=True, text=True, timeout=60)
+        return r.stdout or ""
+
+    #: The lane tables that hold ONE PERSON'S rows, in FK order — receipts and signals reference a
+    #: reaction, so the reaction goes last. The same order `blank-instance.sh` documents, and the
+    #: same list minus the lane-wide ones (`mail_cursor` is the poller's watermark and belongs to
+    #: the deployment, not to a subject; deleting it would replay the whole box).
+    LANE_TABLES = ("effect_receipt", "signal", "reaction", "mail_thread", "mail_outbox_sent")
+
+    def lane_rows_delete_for(self, subject: str, address: str) -> dict:
+        """One subject's rows in every flows lane. THIS is what makes a state re-enterable.
+
+        `admit()` dedups on (source_event_id, flow), and a rehearsal's source ids are derived from
+        (state, subject, meeting) precisely so a re-run is idempotent. The other side of that coin:
+        after a reset the SAME ids must be admissible again, and they are not while the earlier
+        reaction is still in the lane. Found live — the poller logged `admitted 0` for a fresh
+        invite, no prepare mail was sent, and the step waited out its whole budget for a touch
+        nothing was ever going to produce.
+
+        MATCHED ON THE SUBJECT, never on a bare number: `"uid": "13"` must not take uid 130 with
+        it. Both JSON spellings, plus the address, which is how the invite lineage names a person.
+        """
+        out: dict = {}
+        for db in self._flow_lanes():
+            for table in self.LANE_TABLES:
+                where = self._lane_where(table, str(subject), address)
+                if not where:
+                    continue
+                r = subprocess.run(
+                    ["docker", "exec", f"{self.stack}-postgres-1", "psql", "-U", "postgres",
+                     "-d", db, "-tAc", f"DELETE FROM {table} WHERE {where};"],
+                    capture_output=True, text=True, timeout=30)
+                if r.returncode != 0:
+                    if "does not exist" in (r.stderr or ""):
+                        continue                     # lanes differ; absent is not a failure
+                    raise DoorRefused(
+                        f"could not clear {db}.{table} for {address}: "
+                        f"{(r.stderr or '').strip()[:200]}. Refusing to report a reset that would "
+                        f"leave this state un-re-enterable.")
+                n = _int((r.stdout or "").replace("DELETE", ""))
+                if n:
+                    out[f"{db}.{table}"] = n
+        return out
+
+    @staticmethod
+    def _lane_where(table: str, subject: str, address: str) -> str:
+        """The per-subject predicate for one lane table, or "" when the table names no person —
+        in which case it is left alone rather than guessed at."""
+        def q(v: str) -> str:
+            return "'" + str(v).replace("'", "''") + "'"
+
+        # MATCHED ON THE SUBJECT, never on a bare number: `%13%` would take uid 130 with it. Both
+        # JSON spellings of the key, plus the address, which is how the invite lineage names a
+        # person before any uid exists.
+        naming = " OR ".join(
+            f"{{col}} LIKE {q('%' + pat + '%')}"
+            for pat in (f'"uid": "{subject}"', f'"uid":"{subject}"', address))
+        if table in ("effect_receipt", "signal"):
+            inner = naming.format(col="r.subject_refs")
+            return f"reaction_id IN (SELECT reaction_id FROM reaction r WHERE {inner})"
+        if table == "reaction":
+            return naming.format(col="subject_refs")
+        if table in ("mail_thread", "mail_outbox_sent"):
+            return f"subject_uid = {q(subject)}"
+        return ""
+
+    def friction_delete_for(self, subject: str) -> int:
+        n = 0
+        for db in self._flow_lanes():
+            r = subprocess.run(
+                ["docker", "exec", f"{self.stack}-postgres-1", "psql", "-U", "postgres", "-d", db,
+                 "-tAc", f"DELETE FROM friction WHERE subject = '{subject}';"],
+                capture_output=True, text=True, timeout=30)
+            if r.returncode == 0:
+                n += _int(r.stdout.replace("DELETE", ""))
+        return n
+
+    def _flow_lanes(self) -> list[str]:
+        r = subprocess.run(
+            ["docker", "exec", f"{self.stack}-postgres-1", "psql", "-U", "postgres", "-tAc",
+             "SELECT datname FROM pg_database WHERE datname LIKE 'flows%' ORDER BY 1;"],
+            capture_output=True, text=True, timeout=30)
+        return [x.strip() for x in (r.stdout or "").split() if x.strip()]
+
+    def mail_delete_for(self, address: str) -> int:
+        n = 0
+        for q in (f"to:{address}", f"from:{address}"):
+            st, body = _http("GET", f"{MAILPIT}/api/v1/search?query={urllib.parse.quote(q)}&limit=500",
+                             None)
+            ids = [m["ID"] for m in ((body or {}).get("messages") or [])] if isinstance(body, dict) else []
+            if ids:
+                _http("DELETE", f"{MAILPIT}/api/v1/messages", None, {"IDs": ids})
+                n += len(ids)
+        return n
+
+
+# ── small helpers ────────────────────────────────────────────────────────────────────────────────
+
+_LINK = re.compile(r"https?://[^\s\"'<>)\]]+")
+
+
+def _links(text: str) -> list[str]:
+    seen, out = set(), []
+    for m in _LINK.finditer(text or ""):
+        u = m.group(0).rstrip(".,;")
+        if u not in seen:
+            seen.add(u)
+            out.append(u)
+    return out
+
+
+def _mail_epoch(msg: dict) -> float | None:
+    """When mailpit says this message was created, or None when the stamp cannot be read.
+
+    NONE IS NOT ZERO, and that distinction cost a whole run. This used to return 0.0 on a stamp it
+    could not parse, and the caller's filter was `_mail_epoch(msg) < since`, so an unreadable
+    timestamp meant "older than this run" — every message rejected. Run 4 failed three states with
+    the message *"no mail whose subject contains 'Prepare' arrived within 180s. 2 message(s) to
+    that address exist: Accepted: …; Prepare: …"* — naming, in its own refusal, the mail it had
+    just thrown away.
+
+    It is the same defect as the 422 read as an empty list, one layer down: a parse that fails is
+    not an answer, and code that turns it into one produces a confident wrong result. A stamp we
+    cannot read now means "I cannot place this message in time", and the caller decides — it
+    includes the message rather than dropping it, because a false accept is a check that needs
+    tightening while a false reject is a touch that never happened.
+
+    Parsed with `datetime.fromisoformat`, which takes mailpit's RFC3339 (Go trims trailing zeros
+    from the fraction, so `.5Z` sits next to `.503Z` — the old fixed-width slicing could not).
+    """
+    raw = str(msg.get("Created") or "").strip()
+    if not raw:
+        return None
+    import datetime as _dt
+    text = raw.replace("Z", "+00:00")
+    try:
+        return _dt.datetime.fromisoformat(text).timestamp()
+    except ValueError:
+        pass
+    # Pre-3.11 spellings and over-long fractions: trim the fraction to microseconds and retry.
+    m = re.match(r"(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2})(\.\d+)?(.*)$", text)
+    if m:
+        frac = (m.group(2) or "")[:7]
+        try:
+            return _dt.datetime.fromisoformat(m.group(1) + frac + (m.group(3) or "")).timestamp()
+        except ValueError:
+            return None
+    return None
+
+
+def _int(s: str) -> int:
+    try:
+        return int(str(s).strip())
+    except ValueError:
+        return 0
+
+
+def _recipient_key(address: str) -> str:
+    """The index key agent-api writes a recipient under. Mirrors scaffolds._recipient_key."""
+    import hashlib
+    return hashlib.sha256(address.strip().lower().encode()).hexdigest()[:32]
+
+
+def _admin_key(stack: str = STACK) -> str:
+    key = (os.environ.get("VEXA_ADMIN_API_TOKEN") or "").strip()
+    if key:
+        return key
+    r = subprocess.run(
+        ["docker", "inspect", f"{stack}-admin-api-1", "--format",
+         "{{range .Config.Env}}{{println .}}{{end}}"], capture_output=True, text=True)
+    if r.returncode != 0 or "ADMIN_API_TOKEN=" not in r.stdout:
+        raise DoorRefused("no admin-api token: set VEXA_ADMIN_API_TOKEN, or run where the "
+                          f"{stack}-admin-api-1 container is inspectable")
+    return r.stdout.split("ADMIN_API_TOKEN=")[1].split("\n")[0].strip()
+
+
+def _flows_key() -> str:
+    key = (os.environ.get("VEXA_FLOWS_API_KEY") or "").strip()
+    if key:
+        return key
+    for cand in ("flows-api-key", "sim-flows-api-key"):
+        f = pathlib.Path.home() / ".storm" / cand
+        if f.is_file() and f.read_text().strip():
+            return f.read_text().strip()
+    raise DoorRefused("no flows-api key: set VEXA_FLOWS_API_KEY or place ~/.storm/flows-api-key")
+
+
+def _internal_secret() -> str:
+    # ONE name (F95): INTERNAL_API_SECRET, the compose/helm secret key. The two prefixed spellings
+    # are read after it so a shell mid-upgrade still works; this file papering over the drift in one
+    # place is what let it survive everywhere else.
+    key = (os.environ.get("INTERNAL_API_SECRET")
+           or os.environ.get("VEXA_INTERNAL_SECRET")
+           or os.environ.get("VEXA_INTERNAL_API_SECRET") or "").strip()
+    if key:
+        return key
+    f = pathlib.Path.home() / ".storm/internal-secret"
+    if f.is_file():
+        return f.read_text().strip()
+    raise DoorRefused("no internal secret: set INTERNAL_API_SECRET or place "
+                      "~/.storm/internal-secret (mode 600)")

--- a/deploy/dogfood/rehearse/engine.py
+++ b/deploy/dogfood/rehearse/engine.py
@@ -1,0 +1,570 @@
+"""`rehearse(state, as, meeting, when)` and `subject_reset(address)` — PRD decision 38.2 / 38.3.
+
+    rehearse("organizer-invited", "olga@rehearse.test")
+      → the person exists, the desk exists, the invite is in the mail double, and the prepare
+        mail's `/?s=` link is in the return value. Nothing was clicked and nothing was rebuilt.
+
+TWO REFUSALS COME BEFORE THE FIRST DOOR, and both are about the same thing — this runs on a stack
+somebody else's work is living on:
+
+  1. **Every address must be under `$VEXA_REHEARSE_DOMAIN`** (default `rehearse.test`). Not just
+     the subject: the check runs over the fully interpolated arguments of every step, so an
+     organizer, an attendee or a group member outside the domain stops the run. The founder's
+     identities, `_global`, the DNA and OeNB groups are unreachable by construction rather than by
+     care.
+  2. **No live meeting may belong to a real subject.** A rehearsal writes facts and mail; a live
+     meeting is the one thing on this stack that cannot be re-recorded. The probe fails closed.
+
+IDEMPOTENCE IS BY DERIVED IDENTITY, not by a marker. The ICS UID, the fact's `source_event_id` and
+the meeting's native id are all functions of (state, subject, meeting), so the second run of a
+state dedups where the product already dedups — the mail poller on the ICS UID, `admit()` on
+(source_event_id, flow), `user_ensure` on the address. There is nowhere for a marker to live that
+a `subject_reset` would not also have to know about, and a marker that gets out of step with the
+data is worse than none.
+"""
+from __future__ import annotations
+
+import json
+import pathlib
+import re
+import time
+from dataclasses import dataclass, field
+from typing import Any
+
+from . import catalogue as cat
+from .doors import DoorRefused, Doors
+
+DEFAULT_MEETING = "2026-03-02"
+# FAR ENOUGH OUT THAT A RUN CANNOT OUTLIVE IT. `invite_intake` parks on `await_start` until
+# start−2min and then dispatches a REAL bot at the invite's URL. At +30m a catalogue run — three
+# states with a 677-segment import and an agent turn each — reached start−2min while it was still
+# going, and a bot was dispatched at the fixture Zoom URL (meeting 115, status `joining`, 2026-09-02
+# 19:20Z). +3h is the ledger's own figure, chosen for this exact reason at station 2; not carrying
+# it over is what cost this.
+#
+# The default is a floor, not the fix: `cancel_bot_leg` below is the fix, because a rehearsal must
+# leave nothing armed no matter how long it ran.
+DEFAULT_WHEN = "+3h"
+
+
+class Refused(RuntimeError):
+    """A guard said no. The message is the whole product — it names what is in the way."""
+
+
+@dataclass
+class Result:
+    state: str
+    subject: str
+    ok: bool = False
+    links: dict = field(default_factory=dict)
+    mails: list = field(default_factory=list)
+    subjects: dict = field(default_factory=dict)
+    meeting_row: dict = field(default_factory=dict)
+    verify: list = field(default_factory=list)
+    steps: list = field(default_factory=list)
+    wall_s: float = 0.0
+    error: str = ""
+    #: The run stopped on a PRECONDITION, not a defect: the stack is not in the shape this state
+    #: describes, and nothing is wrong. `blank-admin` on a claimed instance is the standing case.
+    refused: bool = False
+
+    def to_dict(self) -> dict:
+        return {"state": self.state, "as": self.subject, "ok": self.ok, "refused": self.refused,
+                "links": self.links,
+                "mails": self.mails, "subjects": self.subjects, "meeting_row": self.meeting_row,
+                "verify": self.verify, "steps": self.steps, "wall_s": round(self.wall_s, 1),
+                **({"error": self.error} if self.error else {})}
+
+
+# ── the guards ───────────────────────────────────────────────────────────────────────────────────
+
+_ADDR = re.compile(r"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}")
+
+
+def addresses_in(value: Any) -> list[str]:
+    """Every email-shaped string anywhere in an interpolated argument tree."""
+    out: list[str] = []
+    if isinstance(value, dict):
+        for v in value.values():
+            out += addresses_in(v)
+    elif isinstance(value, (list, tuple)):
+        for v in value:
+            out += addresses_in(v)
+    elif isinstance(value, str):
+        out += _ADDR.findall(value)
+    return out
+
+
+def guard_domain(addresses, domain: str, mailbox: str = "") -> None:
+    """Refuse anything outside the test domain — the whole safety story, in one function.
+
+    `mailbox` is the address the deployment's own mail double answers as (`VEXA_MAIL_ADDR`). It is
+    the product's identity, not a person's, and every invite is addressed to it; excluding it here
+    is the one exception and it is named rather than pattern-matched.
+
+    IT CHECKS THE SHAPE, NOT ONLY THE SUFFIX. `endswith("@" + domain)` passes anything ending in
+    those characters and says nothing about the rest, so a value that is not an address at all —
+    a timestamp, an empty local part, a whole sentence — is judged only on its tail. That is how
+    a domainless account (`20260902t183213z`) reached the instance on 2026-09-02: not through this
+    guard, which never saw it, but the guard could not have stopped it either, and a safety check
+    that would have waved it through is not one.
+    """
+    def refused(value: str) -> bool:
+        a = value.lower().strip()
+        if a == mailbox.lower().strip() and mailbox:
+            return False
+        local, sep, host = a.rpartition("@")
+        # No whitespace anywhere: `a b@rehearse.test` has the right tail and is not an address,
+        # and the display form `Real Person <a@b.test>` is the shape a header hands you unparsed.
+        return not (sep and local and host == domain and not any(c.isspace() for c in a))
+
+    bad = sorted({a.lower() for a in addresses if refused(a)})
+    if bad:
+        raise Refused(
+            f"refusing: {', '.join(bad)} " + ("is" if len(bad) == 1 else "are") +
+            f" not under @{domain}. A rehearsal writes real facts and real mail on a stack real "
+            f"people are using; the test domain is the only thing keeping it off them. Set "
+            f"VEXA_REHEARSE_DOMAIN to change the domain, never to reach outside one.")
+
+
+def guard_no_live_real_meeting(doors: Doors, domain: str) -> list:
+    live = doors.live_meetings()
+    real = [m for m in live if not str(m.get("email", "")).lower().endswith("@" + domain)]
+    if real:
+        who = "; ".join(f"meeting {m['id']} ({m['status']}) — {m['email']}" for m in real[:5])
+        raise Refused(
+            f"refusing: {len(real)} live meeting(s) belong to a real subject — {who}. A live "
+            f"meeting is the only thing on this stack that cannot be re-recorded. Wait for it to "
+            f"finish.")
+    return live
+
+
+# ── fixtures ─────────────────────────────────────────────────────────────────────────────────────
+
+def load_fixture(fixtures_dir: pathlib.Path, meeting: str) -> dict:
+    p = pathlib.Path(fixtures_dir).expanduser() / f"{meeting}.transcript.json"
+    if not p.is_file():
+        have = sorted(x.name.split(".")[0] for x in
+                      pathlib.Path(fixtures_dir).expanduser().glob("*.transcript.json")) \
+            if pathlib.Path(fixtures_dir).expanduser().is_dir() else []
+        raise Refused(f"no fixture {p}. Available: {', '.join(have) or 'none'}")
+    fx = json.loads(p.read_text())
+    m = fx.get("meeting") or {}
+    segs = [{"start": float(s.get("t", s.get("start", 0.0))), "end": float(s.get("end", 0.0)),
+             "speaker": s.get("speaker") or "?", "text": s.get("text") or ""}
+            for s in fx.get("segments") or []]
+    return {"title": m.get("title") or meeting, "native": m.get("native_meeting_id") or meeting,
+            "participants": list(m.get("participants") or []), "segments": segs}
+
+
+def attendee_address(display_name: str, domain: str) -> str:
+    """A fixture's speaker label → a rehearse-domain address.
+
+    "Olga Avramenko (Sony Pictures Imageworks)" → olga-avramenko@rehearse.test. The org in
+    parentheses is dropped: it is the person's employer, not part of their name, and putting it in
+    the local part would make the room read as a set of companies.
+    """
+    base = re.sub(r"\(.*?\)", " ", display_name or "").strip().lower()
+    base = re.sub(r"[^a-z0-9]+", "-", base).strip("-") or "someone"
+    return f"{base[:40]}@{domain}"
+
+
+def parse_when(when: str, now: float | None = None) -> float:
+    """`+30m` / `+3h` / `-45m` / an epoch / an ISO stamp → an epoch.
+
+    A RELATIVE value is the normal case and the default is `+30m` on purpose: `invite_intake`
+    parks on `await_start` until start-2min, so a future start means the prepare touch fires at
+    once and no bot is ever dispatched at a fixture URL. A past start would spawn a real bot that
+    cannot join, and the flow would fail non-retryably — the state would look broken when the
+    recipe was.
+    """
+    now = time.time() if now is None else now
+    s = str(when).strip()
+    m = re.fullmatch(r"([+-])\s*(\d+)\s*([smhd])", s)
+    if m:
+        mult = {"s": 1, "m": 60, "h": 3600, "d": 86400}[m.group(3)]
+        delta = int(m.group(2)) * mult
+        return now + (delta if m.group(1) == "+" else -delta)
+    try:
+        return float(s)
+    except ValueError:
+        pass
+    try:
+        import datetime as dt
+        return dt.datetime.fromisoformat(s.replace("Z", "+00:00")).timestamp()
+    except ValueError:
+        raise Refused(f"{when!r} is not a time. Use +30m, +3h, an epoch, or an ISO-8601 stamp. "
+                      f"A stamp we silently defaulted would put the meeting at the wrong moment, "
+                      f"which is the one thing the argument exists to control.") from None
+
+
+# ── the executor ─────────────────────────────────────────────────────────────────────────────────
+
+def rehearse(state: str, as_: str, meeting: str = DEFAULT_MEETING, when: str = DEFAULT_WHEN, *,
+             doors: Doors, catalog: cat.Catalogue | None = None, env: dict | None = None,
+             mailbox: str = "", dry_run: bool = False, fresh: bool = False,
+             runner: str = "") -> Result:
+    """Enter `state` as `as_`, on the running stack, through the product's own doors.
+
+    `runner` (PRD decisions 37 + 38) pins every subject this recipe resolves to a harness — today
+    `openai-agent` against the CCC box's Qwen — at the moment it resolves them, so the binding is
+    in place before any dispatch that subject could cause. It is PER SUBJECT: it writes that
+    person's model config through admin-api, never the platform setting, so the founder's
+    dispatches are untouched by construction rather than by care. `doors.RUNNER_DIALS` is the
+    vocabulary and an unknown name is refused with the list.
+
+    `fresh=True` resets the room this recipe owns first — the subject AND the organizer the recipe
+    derives from them — so a state that cannot be re-entered idempotently (a stranger stops being
+    one the moment the drop gives them a desk) can be entered again from nothing. It is off by
+    default because a reset DELETES, and deleting is never a side effect of asking for a state.
+    """
+    started = time.time()
+    catalog = catalog or cat.load()
+    domain = catalog.domain(env)
+    st = catalog[state]
+    subject = str(as_).strip().lower()
+    res = Result(state=state, subject=subject)
+
+    guard_domain([subject], domain, mailbox)
+    if runner:
+        # Fail on the NAME before anything is touched: the same reason the domain guard is first.
+        from .doors import runner_config
+        runner_config(runner)
+    if fresh and not dry_run:
+        # The room a recipe owns is exactly two addresses: the subject, and the organizer derived
+        # from them. Both are under the guarded domain by construction, and `subject_reset` re-runs
+        # its own refusal on each — one function, one rule, never a second spelling of it.
+        res.steps.append({"do": "(fresh)", "door": "reset", "ok": True, "out": [
+            subject_reset(a, doors=doors, catalog=catalog, env=env)
+            for a in (subject, f"organizer-{subject.split('@')[0]}@{domain}")]})
+    fixture = load_fixture(catalog.fixtures_dir(env), meeting)
+    start_epoch = parse_when(when)
+
+    attendees = [(n, attendee_address(n, domain)) for n in fixture["participants"]]
+    local = subject.split("@")[0]
+    bindings: dict[str, Any] = {
+        "state": state, "meeting": meeting, "when": start_epoch, "domain": domain,
+        "subject": subject, "subject_local": local,
+        "organizer": f"organizer-{local}@{domain}",
+        "title": fixture["title"], "native": fixture["native"],
+        "fixture_attendees": [a for _, a in attendees] + [subject],
+        "fixture_attendee_names": {a: n for n, a in attendees},
+        "_attendee_pairs": attendees,
+        # The floor every `await_mail` measures against — see `_execute`.
+        "_started": started,
+    }
+
+    # Everything the recipe will say, resolved as far as it can be, BEFORE anything is done. This
+    # is what makes the domain guard TOTAL: it sees the organizer the recipe derives and the
+    # attendees the fixture supplies, not only the address the caller typed. Tokens that only a
+    # later step can bind render as `<unbound>` rather than hiding their whole row from the check.
+    plan = [(s, cat.interpolate(s.args, bindings, lenient=True)) for s in st.steps]
+    guard_domain(addresses_in([a for _, a in plan] + [bindings]), domain, mailbox)
+
+    if dry_run:
+        res.ok = True
+        res.steps = [{"do": s.do, "door": s.door, "planned": a} for s, a in plan]
+        res.wall_s = time.time() - started
+        return res
+
+    guard_no_live_real_meeting(doors, domain)
+
+    try:
+        for step in st.steps:
+            t0 = time.time()
+            args = cat.interpolate(step.args, bindings)
+            out = _execute(step, args, doors, bindings, fixture, start_epoch)
+            if runner and step.do == "user_ensure" and isinstance(out, dict) and out.get("uid"):
+                # The moment a subject exists is the moment to bind their harness — before any
+                # step can cause a dispatch for them. Binding afterwards would leave the turns the
+                # recipe itself triggers (the post-meeting run, the prepare compose) on the
+                # deployment's default, which is precisely the thing being measured.
+                out["runner"] = doors.bind_runner(out["uid"], runner)["runner"]
+            if step.capture:
+                bindings[step.capture] = out
+            res.steps.append({"do": step.do, "door": step.door, "ok": True,
+                              "s": round(time.time() - t0, 1),
+                              "out": _brief(out)})
+            _absorb(res, step, out)
+        res.verify = [_verify(row, bindings, doors, res) for row in
+                      [cat.interpolate(v, bindings) for v in st.verify]]
+        res.ok = all(v["ok"] for v in res.verify)
+    except (DoorRefused, cat.CatalogueError, Refused) as e:
+        res.ok = False
+        res.error = str(e)
+        # WHICH step stopped decides how this is filed. A precondition that says no is not a rough
+        # edge; a door that says no is.
+        stopped = len([x for x in res.steps if x.get("ok")])
+        if stopped < len(st.steps) and cat.VERBS[st.steps[stopped].do].precondition:
+            res.refused = True
+        res.steps.append({"do": "(stopped)", "door": "", "ok": False, "why": str(e),
+                          "refused": res.refused})
+    res.subjects = {k: v for k, v in bindings.items()
+                    if isinstance(v, dict) and "uid" in v and "email" in v}
+    res.wall_s = time.time() - started
+    return res
+
+
+def _brief(out: Any) -> Any:
+    if isinstance(out, dict):
+        return {k: (v[:120] + "…" if isinstance(v, str) and len(v) > 120 else v)
+                for k, v in out.items() if k not in ("text", "html", "body")}
+    return out
+
+
+def _absorb(res: Result, step: cat.Step, out: Any) -> None:
+    """Fold a step's output into the caller-facing shape (links · mails · meeting_row)."""
+    if not isinstance(out, dict):
+        return
+    if step.do == "await_mail":
+        res.mails.append({"to": out.get("to"), "subject": out.get("subject"),
+                          "id": out.get("id"), "links": out.get("links")})
+    elif step.do == "seed_meeting":
+        res.meeting_row = out
+    # `res.links` is filled by the `link_present` CHECKS, not here: a link is named only once it
+    # has been matched against the pattern the recipe declared. Listing every URL in a mail body
+    # as "the link" would hand the caller an unsubscribe footer with the same confidence.
+
+
+def _execute(step: cat.Step, args: dict, doors: Doors, bindings: dict, fixture: dict,
+             start_epoch: float) -> Any:
+    v = step.do
+    if v == "require_instance_blank":
+        return doors.require_instance_blank()
+    if v == "require_subject_absent":
+        return doors.require_subject_absent(args["address"])
+    if v == "user_ensure":
+        return doors.user_ensure(args["address"])
+    if v == "desk_init":
+        return doors.desk_init(str(args["subject"]))
+    if v == "desk_entity":
+        return doors.desk_entity(str(args["subject"]), args["kind"], args["name"],
+                                 facts=args.get("facts") or (), source=args.get("source") or "",
+                                 summary=args.get("summary") or "", slug=args.get("slug") or "")
+    if v == "group_new":
+        return doors.group_new(str(args["owner"]), args["name"], args.get("purpose") or "")
+    if v == "group_join":
+        return doors.group_join(str(args["group"]), str(args["owner"]), str(args["member"]),
+                                args.get("member_email") or "",
+                                args.get("role") or "contributor")
+    if v == "request_sign_in_link":
+        return doors.request_sign_in_link(args["address"])
+    if v == "drop_invite":
+        att = list(bindings["_attendee_pairs"]) if args.get("attendees_from_fixture") \
+            else [tuple(x) for x in (args.get("attendees") or [])]
+        return doors.drop_invite(args["organizer"], args["title"], float(args["start"]),
+                                 attendees=att, ics_uid=args.get("ics_uid") or "",
+                                 group=args.get("group") or "")
+    if v == "seed_meeting":
+        return doors.seed_meeting(str(args["owner"]), args["native"],
+                                  args.get("title") or fixture["title"], fixture["segments"],
+                                  float(args.get("started_at") or (start_epoch - 3600)),
+                                  source=str(args.get("source") or "seed"))
+    if v == "emit_fact":
+        return doors.emit_fact(args["event_type"], args["source_event_id"], args["refs"])
+    if v == "await_mail":
+        # `since` IS THE CHECK. Without it the step matched a message a PREVIOUS run had sent —
+        # found live on run 2, where `warm-desk-recurring` "found" run 1's Prepare mail, verified
+        # run 1's scaffold, and reported a state this run had not produced. A touch is evidence
+        # only if it is this run's touch; the floor is when this run started, and a recipe may
+        # raise it but never lower it.
+        return doors.await_mail(args["to"], args.get("subject_contains") or "",
+                                int(args.get("budget_s") or 180),
+                                since=float(args.get("since") or bindings["_started"]))
+    if v == "reply_to_mail":
+        return doors.reply_to_mail(bindings[args["to_mail"]], args["from_address"], args["body"])
+    if v == "await_reaction":
+        return doors.await_reaction(args["flow"], float(args.get("since") or 0.0),
+                                    int(args.get("budget_s") or 300))
+    if v == "cancel_bot_leg":
+        return doors.cancel_bot_leg(args["flow"], args.get("source_contains") or "")
+    raise cat.CatalogueError(f"no executor for verb {v!r} — catalogue.VERBS and engine._execute "
+                             f"have drifted apart")
+
+
+def _verify(row: dict, bindings: dict, doors: Doors, res: Result) -> dict:
+    kind = row["check"]
+    out = {"check": kind, "ok": False, "detail": ""}
+    try:
+        if kind == "mail_present":
+            m = bindings[str(row["of"]).split(".")[0]]
+            out["ok"] = bool(m.get("id"))
+            out["detail"] = str(m.get("subject") or "")
+        elif kind == "link_present":
+            m = bindings[str(row["of"]).split(".")[0]]
+            pat = re.compile(row["must_match"])
+            hit = next((u for u in m.get("links") or [] if pat.search(u)), "")
+            out["ok"] = bool(hit)
+            out["detail"] = hit or f"no link matching {row['must_match']} in {m.get('subject')!r}"
+            if hit and row.get("as"):
+                res.links[str(row["as"])] = hit
+                bindings.setdefault("_links", {})[str(row["as"])] = hit
+        elif kind == "scaffold_resolves":
+            url = res.links.get(str(row["link"])) or bindings.get("_links", {}).get(str(row["link"]), "")
+            sid = _scaffold_id(url)
+            if not sid:
+                out["detail"] = f"no ?s= id in {url!r}"
+            else:
+                rec = doors.scaffold_get(sid)
+                out["ok"] = True
+                out["detail"] = f"{sid[:12]}… kind={rec.get('kind')}"
+                if row.get("kind") and rec.get("kind") != row["kind"]:
+                    out["ok"] = False
+                    out["detail"] += f" — expected kind {row['kind']}"
+                if row.get("desk_state"):
+                    # `refs.state` is an OBJECT — `{"desk": "new|pile|warm", "group": …}` — and
+                    # reading it as a string could never match, so the check FAILED on a state that
+                    # had worked. A check that cannot pass is worse than no check: it reports a
+                    # product defect where there is only a reader that guessed a shape.
+                    state = (rec.get("refs") or {}).get("state")
+                    got = state.get("desk") if isinstance(state, dict) else state
+                    if got != row["desk_state"]:
+                        out["ok"] = False
+                        out["detail"] += f" — desk state {got!r}, expected {row['desk_state']!r}"
+        elif kind == "no_user":
+            uid = doors.user_find(row["address"])
+            out["ok"] = uid is None
+            out["detail"] = "absent" if uid is None else f"uid {uid} exists"
+        elif kind == "user_exists":
+            uid = doors.user_find(row["address"])
+            out["ok"] = uid is not None
+            out["detail"] = f"uid {uid}" if uid else "absent"
+        elif kind == "meeting_status":
+            m = bindings[str(row["of"]).split(".")[0]]
+            out["ok"] = str(m.get("status")) == str(row["is"])
+            out["detail"] = f"status={m.get('status')}"
+        elif kind == "desk_nonempty":
+            files = doors.desk_tree(str(row["subject"]), str(row.get("slug") or ""))
+            real = [f for f in files if f and not f.startswith(".")]
+            out["ok"] = bool(real)
+            out["detail"] = f"{len(real)} file(s)"
+        elif kind == "group_member":
+            members = doors.group_members(str(row.get("owner") or ""), str(row["group"]))
+            out["ok"] = any(m.get("email") == row["address"] for m in members)
+            out["detail"] = f"{len(members)} member(s)"
+        elif kind == "reaction_admitted":
+            r = bindings[str(row["of"]).split(".")[0]]
+            out["ok"] = bool(r.get("admitted"))
+            out["detail"] = f"{r.get('flow')} state={r.get('state')}"
+        else:
+            out["detail"] = f"no runner for check {kind!r}"
+    except (DoorRefused, KeyError, cat.CatalogueError) as e:
+        out["detail"] = f"{type(e).__name__}: {e}"
+    return out
+
+
+def _scaffold_id(url: str) -> str:
+    m = re.search(r"[?&]s=([A-Za-z0-9_\-]+)", url or "")
+    return m.group(1) if m else ""
+
+
+# ── the reset ────────────────────────────────────────────────────────────────────────────────────
+
+def is_malformed(address: str) -> bool:
+    """Is this stored email not an address at all?
+
+    The test is deliberately the SHAPE only and deliberately generous about what counts as an
+    address: it decides whether `subject_reset_malformed` may delete an account, so every doubt
+    has to resolve towards "this might be a person". A real user's email is well-formed by
+    construction — admin-api validates on create — so a stored value that fails this cannot name
+    anybody real. That asymmetry is the whole safety argument for the by-id path.
+    """
+    a = str(address or "").strip()
+    local, sep, host = a.rpartition("@")
+    return not (sep and local and "." in host and not any(c.isspace() for c in a))
+
+
+def subject_reset_malformed(uid: str, *, doors: Doors, catalog: cat.Catalogue | None = None,
+                            env: dict | None = None) -> dict:
+    """Remove an account BY ID — and only one whose stored email is not an address.
+
+    `subject_reset` refuses anything outside the test domain, which is right and must stay right:
+    the guard is the only thing keeping a rehearsal off real people. But it cannot clean up the one
+    account a rehearsal is most likely to create by accident — a subject with no domain at all.
+    User 131 (`20260902t183213z`) was minted by `ensure_user` from a mis-parsed ICS, and the
+    address guard could not pass judgement on it because there is nothing to judge.
+
+    So this path exists, and it is bounded by the fact that makes it safe: **it refuses any account
+    whose email IS well-formed.** A real person's address is well-formed, so this can never reach
+    one. It is not a domain exemption and it is not an override — it is a narrower rule that only
+    covers values no person could have.
+    """
+    catalog = catalog or cat.load()
+    email = doors.user_email(str(uid))
+    if not is_malformed(email):
+        raise Refused(
+            f"uid {uid} is {email!r}, which is a well-formed address — this path exists only for "
+            f"accounts whose email is not an address at all (a parse artefact). A real subject is "
+            f"reset by address, where the domain guard applies: subject_reset({email!r}).")
+    out = _reset_stores(str(uid), email, doors)
+    out["by"] = "id"
+    out["reason"] = "the stored email is not an address; no person can be named by it"
+    return out
+
+
+def _reset_stores(uid: str, address: str, doors: Doors) -> dict:
+    """The removal sequence itself — ONE rulebook, whichever path called it.
+
+    Order matters: the desk and the redis keys are addressed BY uid, so the user goes last. Every
+    store is attempted even when an earlier one refused, and each refusal lands in `remaining`
+    rather than stopping the rest: a reset that gives up halfway leaves a subject in a state no
+    caller can describe.
+    """
+    out: dict = {"address": address, "uid": uid or None, "removed": {}, "remaining": {}, "ok": False}
+
+    def attempt(name, fn):
+        try:
+            out["removed"][name] = fn()
+        except DoorRefused as e:
+            out["remaining"][name] = str(e)
+
+    if uid:
+        attempt("meetings", lambda: doors.meetings_delete_for(uid))
+        attempt("desk", lambda: doors.desk_delete(uid))
+        attempt("sessions", lambda: doors.session_keys_delete(uid))
+        attempt("friction", lambda: doors.friction_delete_for(uid))
+        # The lane's dedup memory. Without this the subject is gone and the state still cannot be
+        # re-entered: `admit()` swallows the next invite as a duplicate and the touch that should
+        # follow is simply never sent.
+        attempt("lane_rows", lambda: doors.lane_rows_delete_for(uid, address))
+    attempt("scaffolds", lambda: doors.scaffold_keys_delete(address))
+    attempt("mail", lambda: doors.mail_delete_for(address))
+    if uid:
+        attempt("user", lambda: doors.user_delete(uid))
+
+    # PROVE IT. Reading back is the whole difference between a reset and a claim of one.
+    if uid:
+        try:
+            doors.user_email(uid)
+            out["remaining"]["user_still_exists"] = uid
+        except DoorRefused:
+            pass                                    # gone, which is what we wanted
+    left = 0
+    try:
+        left = doors.scaffold_keys_delete(address)
+    except DoorRefused:
+        pass
+    if left:
+        out["remaining"]["scaffold_keys"] = left
+    out["ok"] = not out["remaining"]
+    return out
+
+
+def subject_reset(address: str, *, doors: Doors, catalog: cat.Catalogue | None = None,
+                  env: dict | None = None) -> dict:
+    """Remove one subject entirely — user, meetings, desk, sessions, scaffolds, friction, lane
+    rows, mail.
+
+    A state is re-entered in seconds and the instance is never blanked (decision 38.3). The
+    refusal is the same one `rehearse` uses and it comes first: a non-test address is not reset,
+    ever, and the tool says so rather than doing part of it. The one account this cannot reach is
+    one whose stored email is not an address at all — see `subject_reset_malformed`.
+
+    It VERIFIES EMPTINESS AFTERWARDS and reports what it could not remove. A reset that half
+    worked and said "done" is the failure this whole file is built around — the ledger's phantom
+    `_global` write, one layer down.
+    """
+    catalog = catalog or cat.load()
+    address = str(address).strip().lower()
+    guard_domain([address], catalog.domain(env))
+    return _reset_stores(doors.user_find(address) or "", address, doors)

--- a/deploy/dogfood/rehearse/pyproject.toml
+++ b/deploy/dogfood/rehearse/pyproject.toml
@@ -1,0 +1,21 @@
+[project]
+name = "vexa-rehearse"
+version = "0.12.0"
+description = "User states as data (PRD decision 38) — enter any state a person can be in, on the running dogfood stack, through the product's own doors, without a rebuild."
+requires-python = ">=3.11"
+# ONE dependency, and it is the catalogue's file format. Everything else is stdlib on purpose:
+# this package runs on the rig host, beside the stack, and a rehearsal that cannot start because a
+# wheel is missing is a rehearsal nobody runs.
+dependencies = ["PyYAML>=6,<7"]
+
+[dependency-groups]
+dev = ["pytest>=8,<10"]
+
+[tool.uv]
+package = false
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+# The package is imported as `rehearse`, from the directory ABOVE this one, so the tests exercise
+# the same import path `bin/rehearse.py` and the control MCP use.
+pythonpath = [".."]

--- a/deploy/dogfood/rehearse/run_all.py
+++ b/deploy/dogfood/rehearse/run_all.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+"""THE CATALOGUE IS THE TEST — PRD decision 38.5.
+
+Runs every state in `states.yaml`, clicks nothing, verifies the artefacts each recipe declares,
+and files every failure as friction (decision 33) so a fixing agent gets it in the shape it can
+act on. Per state it reports: pass/fail, wall time, and the link produced.
+
+    python -m rehearse.run_all --stub                    # offline, against the door stub
+    python -m rehearse.run_all --as-domain rehearse.test # against the running stack
+    python -m rehearse.run_all --only organizer-invited,reply-pending
+
+WHY CLICKING NOTHING IS THE POINT. Every state ends at a touch — a mail with one link. Whether
+that link works when a person clicks it is the founder's judgment and belongs in a walk. What a
+suite can prove is everything up to the click: the touch exists, its link is a scaffold, the
+record resolves, the desk holds what it should. A loop that also clicked would be measuring the
+agent's answer, which is a different (slower, judged) thing.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import pathlib
+import sys
+import time
+
+from . import catalogue as cat
+from .doors import Doors, LiveDoors
+from .engine import DEFAULT_MEETING, DEFAULT_WHEN, Refused, rehearse
+
+#: Where a finding goes when the intake cannot take it. Overridable, because a run on a host with
+#: a read-only /tmp still has to be able to keep its findings.
+FRICTION_FALLBACK = pathlib.Path(
+    os.environ.get("VEXA_REHEARSE_FRICTION_LOG", "/tmp/rehearse-friction.jsonl"))
+
+
+def file_friction(doors_kind: str, state: str, res, reporter) -> dict:
+    """One failing state → one friction record, in the ledger's finding shape.
+
+    `symptom · exact context · pointers · repro` — the four fields `friction_dump` groups on. The
+    repro line is the whole value: a fixing agent must be able to re-enter the state without
+    asking anybody how.
+    """
+    # A CORRECT REFUSAL IS NOT A DEFECT. `blank-admin` on a claimed instance did not fail — the
+    # stack is not blank, which is a fact about the deployment, not a rough edge. Filing it as a
+    # blocker put a non-problem at the top of the fixer's dump, and a loop whose findings include
+    # things nobody should fix teaches its readers to skim (`fr_af253789b2780003`, mis-filed).
+    refused = bool(getattr(res, "refused", False))
+    failed = [v for v in res.verify if not v["ok"]]
+    stopped = next((s for s in res.steps if not s.get("ok", True)), None)
+    symptom = (res.error or (failed[0]["detail"] if failed
+                             else "the state ran but its verify block did not pass"))
+    if refused:
+        symptom = ("PRECONDITION, not a defect — this state cannot be entered on this stack "
+                   "as it stands: " + symptom)
+    rec = {
+        "tool": "rehearse",
+        "kind": "refused" if refused else ("error" if res.error else "unfulfilled"),
+        "severity": "idea" if refused else "blocker",
+        "what_i_was_doing": f"entering the state `{state}` as {res.subject} through {doors_kind} "
+                            f"doors, so a touch could be rehearsed without a rebuild",
+        "what_went_wrong": f"{state}: {symptom}",
+        "what_would_have_helped": (
+            f"repro: python -m rehearse.run_all --only {state}"
+            + (f"  (stopped at step `{stopped['do']}` on the {stopped['door']} door)"
+               if stopped else "")
+            + f"  ·  failed checks: {', '.join(v['check'] for v in failed) or 'none'}"),
+        "error": symptom[:900],
+    }
+    # THE FILE FIRST, ALWAYS — the rig's own rule for `report_friction`, and it earned its place
+    # here on the first live run: `POST /api/friction` is not on the deployed agent-api image yet
+    # (#1412), so every record 404'd. A finding that exists only in a 404 is a finding nobody has.
+    # The file is the fallback, never the store: the intake below is still the destination.
+    try:
+        FRICTION_FALLBACK.parent.mkdir(parents=True, exist_ok=True)
+        with FRICTION_FALLBACK.open("a") as f:
+            f.write(json.dumps({"at": time.time(), "state": state, **rec}) + "\n")
+        rec["written_to"] = str(FRICTION_FALLBACK)
+    except OSError as e:
+        rec["written_to"] = f"FAILED: {e}"
+    if reporter:
+        try:
+            reporter(rec)
+            rec["filed"] = True
+        except Exception as e:                                     # noqa: BLE001
+            # A 404 here is NOT a pass and never becomes one: the record is on disk, the run is
+            # still red, and the report says the intake refused it and where the record went.
+            rec["filed"] = False
+            rec["file_error"] = f"{type(e).__name__}: {e}"
+    return rec
+
+
+def run(doors: Doors, *, catalog: cat.Catalogue | None = None, only: list | None = None,
+        domain: str | None = None, meeting: str = DEFAULT_MEETING, when: str = DEFAULT_WHEN,
+        mailbox: str = "", reporter=None, env: dict | None = None,
+        dry_run: bool = False) -> dict:
+    catalog = catalog or cat.load()
+    dom = domain or catalog.domain(env)
+    names = [n for n in catalog.states if not only or n in only]
+    rows, frictions = [], []
+    t0 = time.time()
+    for name in names:
+        subject = f"rehearse-{name}@{dom}"
+        started = time.time()
+        try:
+            res = rehearse(name, subject, meeting=meeting, when=when, doors=doors,
+                           catalog=catalog, env=env, mailbox=mailbox, dry_run=dry_run)
+        except (Refused, Exception) as e:                          # noqa: BLE001
+            rows.append({"state": name, "as": subject, "ok": False,
+                         "wall_s": round(time.time() - started, 1), "link": "",
+                         "why": f"{type(e).__name__}: {e}"})
+            continue
+        link = next(iter(res.links.values()), "")
+        rows.append({"state": name, "as": subject, "ok": res.ok,
+                     "refused": bool(getattr(res, "refused", False)),
+                     "wall_s": round(res.wall_s, 1), "link": link,
+                     "checks": [f"{v['check']}={'ok' if v['ok'] else 'FAIL'}" for v in res.verify],
+                     **({"why": res.error} if res.error else {})})
+        if not res.ok:
+            frictions.append(file_friction(type(doors).__name__, name, res, reporter))
+    return {"ran": len(rows), "passed": sum(1 for r in rows if r["ok"]),
+            # `failed` is what somebody has to fix. A refused precondition is reported separately
+            # so the count means what a reader assumes it means.
+            "failed": [r["state"] for r in rows if not r["ok"] and not r.get("refused")],
+            "refused": [r["state"] for r in rows if r.get("refused")],
+            "wall_s": round(time.time() - t0, 1), "states": rows, "friction": frictions}
+
+
+def render(report: dict) -> str:
+    w = max([len(r["state"]) for r in report["states"]] + [5])
+    lines = [f"{'state'.ljust(w)}  {'':4}  {'wall':>7}  link / why"]
+    for r in report["states"]:
+        mark = "PASS" if r["ok"] else ("SKIP" if r.get("refused") else "FAIL")
+        tail = r["link"] or r.get("why", "")
+        lines.append(f"{r['state'].ljust(w)}  {mark}  {r['wall_s']:>6.1f}s  {tail[:96]}")
+    lines.append("")
+    lines.append(f"{report['passed']}/{report['ran']} states green in {report['wall_s']}s"
+                 + (f" · failed: {', '.join(report['failed'])}" if report["failed"] else "")
+                 + (f" · refused (precondition, not a defect): "
+                    f"{', '.join(report.get('refused') or [])}" if report.get("refused") else ""))
+    if report["friction"]:
+        filed = sum(1 for f in report["friction"] if f.get("filed"))
+        unfiled = [f for f in report["friction"] if not f.get("filed")]
+        lines.append(f"{len(report['friction'])} friction record(s): {filed} filed to the intake "
+                     f"(decision 33), {len(unfiled)} written to "
+                     f"{report['friction'][0].get('written_to', FRICTION_FALLBACK)}")
+        if unfiled:
+            lines.append(f"  the intake refused them: {unfiled[0].get('file_error', '?')}")
+    return "\n".join(lines)
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(description="run every state in the catalogue")
+    ap.add_argument("--stub", action="store_true",
+                    help="run against the offline door stub — proves the recipes, touches nothing")
+    ap.add_argument("--dry-run", action="store_true",
+                    help="resolve and guard every step, execute none")
+    ap.add_argument("--only", default="", help="comma-separated state names")
+    ap.add_argument("--meeting", default=DEFAULT_MEETING)
+    ap.add_argument("--when", default=DEFAULT_WHEN)
+    ap.add_argument("--domain", default="")
+    ap.add_argument("--json", action="store_true")
+    a = ap.parse_args(argv)
+
+    if a.stub:
+        from .stub_doors import StubDoors
+        doors: Doors = StubDoors()
+        reporter = None
+    else:
+        doors = LiveDoors()
+        reporter = _live_reporter()
+    report = run(doors, only=[s for s in a.only.split(",") if s] or None,
+                 domain=a.domain or None, meeting=a.meeting, when=a.when,
+                 reporter=reporter, dry_run=a.dry_run)
+    print(json.dumps(report, indent=1) if a.json else render(report))
+    return 0 if not report["failed"] else 1
+
+
+def _live_reporter():
+    """File a friction record through decision 33's route — `POST /api/friction` on AGENT-API.
+
+    Not the flows `friction` table: agent-api owns the store (the terminal's "Report this" posts
+    there, the blank script deletes the flows table with the rest of the lane, and only agent-api's
+    record has the context and status columns the dump groups on). The reasoning is written down at
+    `core/agent/shared/friction.py`; this comment exists so the second writer does not appear here.
+
+    Never fatal. A suite that cannot file its findings still has to report its findings.
+    """
+    from .doors import AGENT_API, _http
+
+    def post(rec: dict) -> None:
+        st, body = _http("POST", f"{AGENT_API}/api/friction", None, {
+            "reporter": "rehearse", "kind": rec["kind"], "severity": rec["severity"],
+            "tried": rec["what_i_was_doing"], "happened": rec["what_went_wrong"],
+            "would_help": rec["what_would_have_helped"],
+            "context": {"tool": "rehearse", "error": rec["error"]}})
+        if not 200 <= st < 300:
+            raise RuntimeError(f"friction intake answered {st}: {str(body)[:160]}")
+    return post
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/deploy/dogfood/rehearse/states.yaml
+++ b/deploy/dogfood/rehearse/states.yaml
@@ -1,0 +1,448 @@
+# states.yaml — THE CATALOGUE. PRD decision 38.1: "user states are data".
+#
+# Every state a person can be in when a touch reaches them, written as an ordered recipe of
+# steps against the product's OWN doors. Nothing here is code and nothing here needs an image:
+# a state is entered on the running stack by executing these rows (see ../README.md § Hot).
+#
+# THE SHAPE OF A ROW
+#   do:      one verb from the closed vocabulary in catalogue.py VERBS. An unknown verb is
+#            refused at load, not at run — a recipe that half-executes and then discovers it
+#            cannot finish has already changed the stack.
+#   door:    which service actually answers. It is CHECKED against the verb's declared door at
+#            load time, so this column can never drift into decoration: if the code changes
+#            which door a verb uses, every recipe naming the old one fails the catalogue test.
+#   <args>   the verb's own arguments. `{{ }}` interpolates from the run's bindings
+#            (`subject`, `organizer`, `state`, `meeting`, `when`, `domain`, `title`, `native`)
+#            and from anything an earlier step captured with `as:`.
+#
+# THE VERIFY BLOCK is not a formality and it is not a log line. `rehearse()` runs it after the
+# steps and returns it; `run_all.py` fails a state on it and files the failure as friction
+# (decision 33). A state whose artefacts cannot be checked without a human eye does not belong
+# in this file.
+#
+# ADDRESSES. Every address in every recipe resolves under $VEXA_REHEARSE_DOMAIN (default
+# rehearse.test) and the engine refuses anything else BEFORE the first door is touched. This is
+# the whole safety story: the founder's identities, `_global`, the DNA and OeNB groups cannot be
+# named by a recipe, because the domain check runs over the interpolated arguments.
+#
+# IDEMPOTENCE is by derived identity, never by a marker file: the ICS UID and the meeting's
+# native id are functions of (state, subject, meeting), and the fact's source_event_id is a
+# function of the meeting ROW that native id resolves to. So a second run of the same state dedups
+# at the doors that already dedup — the mail poller on the ICS UID, `seed_meeting` adopting the
+# completed row it already made, `admit()` on (source_event_id, flow), `user_ensure` on the
+# address. And after `subject_reset` the row is gone with its owner, so the same recipe produces a
+# genuinely new touch instead of a silent duplicate. That is why the fact's id names the row and
+# not the calendar date: an id that never changes cannot be re-entered, and an id that changes
+# every run cannot be idempotent.
+
+version: 1
+
+# The one deployment value this file needs. The engine reads it from the environment; it is named
+# here so the catalogue states its own precondition rather than assuming one.
+domain_env: VEXA_REHEARSE_DOMAIN
+default_domain: rehearse.test
+
+# Where the meeting material comes from. `meeting=` on the call names a file in this directory.
+fixtures_env: VEXA_DNA_FIXTURES
+default_fixtures: ~/dna-fixtures
+
+states:
+
+  # ─────────────────────────────────────────────────────────────────────────────────────────────
+  blank-admin:
+    summary: >
+      A blank instance, and the first sign-in claims it. Produces the sign-in mail and its link —
+      the touch that turns an unclaimed deployment into a company's.
+    story: PRD decision 17 · rehearsal script stage 1 · alpha ledger rows 6-8
+    # THIS RECIPE NEVER BLANKS. It asserts the precondition and refuses when it does not hold,
+    # naming what is in the way. Blanking is `bin/blank-instance.sh`, it deletes every person on
+    # the stack, and it is not something a state recipe may do as a side effect of being entered.
+    preconditions:
+      - instance is blank (no admin claimed, company layer missing)
+      - the subject address has no user
+    steps:
+      - do: require_instance_blank
+        door: admin-api
+      - do: require_subject_absent
+        door: admin-api
+        address: "{{subject}}"
+      - do: request_sign_in_link
+        door: terminal
+        address: "{{subject}}"
+      - do: await_mail
+        door: mailpit
+        to: "{{subject}}"
+        subject_contains: "sign in"
+        as: sign_in_mail
+    artefacts:
+      mail: one message to {{subject}} carrying a single-use magic link
+      link: the magic link — clicking it CLAIMS THE INSTANCE for {{subject}}
+      desks: none; the claim creates the admin's desk and the admin-setup scaffold
+    verify:
+      - check: mail_present
+        of: sign_in_mail
+      - check: link_present
+        of: sign_in_mail
+        must_match: "/(auth|redeem|\\?t=)"
+        as: sign_in
+      # The state is "about to claim", not "claimed": nothing was clicked, so no user exists yet.
+      - check: no_user
+        address: "{{subject}}"
+
+  # ─────────────────────────────────────────────────────────────────────────────────────────────
+  organizer-invited:
+    summary: >
+      The subject is a user with a scaffolded desk who has just put the mailbox on a meeting.
+      An invite lands in the mail double for a DNA fixture starting at now+{{when}}; the prepare
+      touch comes back within seconds.
+    story: rehearsal script stage 2-3 · alpha ledger 11:23Z (station 2)
+    # start = now + when (default +30m) ON PURPOSE. `invite_intake` parks on `await_start` until
+    # start-2min, so nothing dispatches a real bot at a fixture URL; the prepare mail is emitted
+    # immediately by `emit_prep`. A past start would spawn a bot that cannot join.
+    steps:
+      - do: user_ensure
+        door: admin-api
+        address: "{{subject}}"
+        as: subject_user
+      - do: desk_init
+        door: agent-api
+        subject: "{{subject_user.uid}}"
+      - do: drop_invite
+        door: smtp
+        organizer: "{{subject}}"
+        title: "{{title}}"
+        start: "{{when}}"
+        attendees_from_fixture: true
+        ics_uid: "rehearse-{{state}}-{{subject_local}}-{{meeting}}"
+      - do: await_mail
+        door: mailpit
+        to: "{{subject}}"
+        subject_contains: "Prepare"
+        as: prepare_mail
+      # A REHEARSAL LEAVES NOTHING ARMED. `invite_intake` parks on `await_start` until start−2min
+      # and then dispatches a REAL bot at the invite's URL — and this state rehearses the PREPARE
+      # touch, not the bot leg. Left parked, the run arms a live dispatch at a fixture Zoom URL
+      # that fires on the clock long after the state was reported green: on 2026-09-02 meeting 115
+      # reached `joining` while the catalogue was still running.
+      - do: cancel_bot_leg
+        door: flows-api
+        flow: invite_intake
+        source_contains: "rehearse-{{state}}-{{subject_local}}-{{meeting}}"
+    artefacts:
+      mail: "RSVP (\"Accepted\") and \"Prepare: {{title}}\" to {{subject}}"
+      link: the prepare mail's only link is /?s=<scaffold id> (kind `prep`)
+      desks: "{{subject}}'s desk exists; the meeting row is scheduled, parked on await_start"
+    verify:
+      - check: mail_present
+        of: prepare_mail
+      - check: link_present
+        of: prepare_mail
+        must_match: "/\\?s="
+        as: prepare
+      - check: scaffold_resolves
+        link: prepare
+        kind: prep
+      - check: user_exists
+        address: "{{subject}}"
+
+  # ─────────────────────────────────────────────────────────────────────────────────────────────
+  attendee-stranger-minutes:
+    summary: >
+      A meeting has been held with a real DNA transcript, and the subject was in the room but has
+      never signed in. The post-meeting run writes one shared report, mails everyone, and drops a
+      pointer on every attendee's desk — the subject's desk is born from the drop.
+    story: rehearsal script stage 4b · PRD decisions 19-22, 22a
+    steps:
+      # The organizer is a SEPARATE rehearse-domain identity: the subject must be a stranger, and
+      # a stranger cannot be the person who owns the meeting row.
+      - do: user_ensure
+        door: admin-api
+        address: "{{organizer}}"
+        as: organizer_user
+      - do: desk_init
+        door: agent-api
+        subject: "{{organizer_user.uid}}"
+      - do: require_subject_absent
+        door: admin-api
+        address: "{{subject}}"
+      - do: seed_meeting
+        door: gateway
+        owner: "{{organizer_user.uid}}"
+        native: "rehearse-{{state}}-{{subject_local}}-{{meeting}}"
+        as: meeting_row
+      - do: emit_fact
+        door: flows-api
+        event_type: meeting.completed
+        source_event_id: "rehearse-{{state}}-{{subject_local}}-{{meeting_row.meeting_id}}"
+        refs:
+          uid: "{{organizer_user.uid}}"
+          organizer: "{{organizer}}"
+          meeting_id: "{{meeting_row.meeting_id}}"
+          native: "{{meeting_row.native_meeting_id}}"
+          title: "{{title}}"
+          start: "{{meeting_row.started_epoch}}"
+          participants: "{{fixture_attendees}}"
+          participant_names: "{{fixture_attendee_names}}"
+      - do: await_mail
+        door: mailpit
+        to: "{{subject}}"
+        subject_contains: "{{title}}"
+        as: attendee_mail
+        budget_s: 900
+    artefacts:
+      mail: the attendee follow-up to {{subject}}, head template + the one shared report
+      link: one button — /?s=<scaffold id> (kind `post-meeting`), carrying the meeting's share
+      desks: "{{subject}}'s desk is created by the drop and holds the report; no click required"
+    verify:
+      - check: mail_present
+        of: attendee_mail
+      - check: link_present
+        of: attendee_mail
+        must_match: "/\\?s="
+        as: minutes
+      - check: scaffold_resolves
+        link: minutes
+        kind: post-meeting
+      - check: meeting_status
+        of: meeting_row
+        is: completed
+
+  # ─────────────────────────────────────────────────────────────────────────────────────────────
+  group-member:
+    summary: >
+      A group desk exists with the subject as a member, and a #group meeting has been held. The
+      post-meeting run mounts the group desk read/write and maintains it (decision 22, group half).
+    story: rehearsal script stage 5 · PRD decision 22
+    steps:
+      - do: user_ensure
+        door: admin-api
+        address: "{{organizer}}"
+        as: organizer_user
+      - do: desk_init
+        door: agent-api
+        subject: "{{organizer_user.uid}}"
+      - do: user_ensure
+        door: admin-api
+        address: "{{subject}}"
+        as: subject_user
+      - do: desk_init
+        door: agent-api
+        subject: "{{subject_user.uid}}"
+      - do: group_new
+        door: agent-api
+        owner: "{{organizer_user.uid}}"
+        name: "rehearse {{meeting}}"
+        purpose: "The rehearsal group for the {{meeting}} DNA occurrence."
+        as: group
+      # A person JOINS by redeeming an invite. There is no add-a-member verb, deliberately
+      # (agent-api has none), so the recipe mints one and redeems it as the subject — the same
+      # two calls a human makes.
+      - do: group_join
+        door: agent-api
+        group: "{{group.workspace_id}}"
+        owner: "{{organizer_user.uid}}"
+        member: "{{subject_user.uid}}"
+        member_email: "{{subject}}"
+      - do: seed_meeting
+        door: gateway
+        owner: "{{organizer_user.uid}}"
+        native: "rehearse-{{state}}-{{subject_local}}-{{meeting}}"
+        as: meeting_row
+      - do: emit_fact
+        door: flows-api
+        event_type: meeting.completed
+        source_event_id: "rehearse-{{state}}-{{subject_local}}-{{meeting_row.meeting_id}}"
+        refs:
+          uid: "{{organizer_user.uid}}"
+          organizer: "{{organizer}}"
+          meeting_id: "{{meeting_row.meeting_id}}"
+          native: "{{meeting_row.native_meeting_id}}"
+          title: "{{title}}"
+          start: "{{meeting_row.started_epoch}}"
+          group: "{{group.workspace_id}}"
+          participants: "{{fixture_attendees}}"
+          participant_names: "{{fixture_attendee_names}}"
+      - do: await_mail
+        door: mailpit
+        to: "{{subject}}"
+        subject_contains: "{{title}}"
+        as: group_mail
+        budget_s: 900
+    artefacts:
+      mail: the follow-up to every attendee, including the member {{subject}}
+      link: /?s=<scaffold id> whose intent is the GROUP desk, mounted in the member's sessions
+      desks: the group desk holds the maintained pages; every attendee desk holds the report
+    verify:
+      - check: mail_present
+        of: group_mail
+      - check: link_present
+        of: group_mail
+        must_match: "/\\?s="
+        as: group_minutes
+      - check: group_member
+        group: "{{group.workspace_id}}"
+        address: "{{subject}}"
+        owner: "{{organizer_user.uid}}"
+      # The group desk is READ AS THE MEMBER: agent-api resolves a shared workspace by membership,
+      # so "is the group desk written?" and "can the member see it?" are one question here.
+      - check: desk_nonempty
+        subject: "{{subject_user.uid}}"
+        slug: "{{group.workspace_id}}"
+
+  # ─────────────────────────────────────────────────────────────────────────────────────────────
+  warm-desk-recurring:
+    summary: >
+      The subject's desk already holds two reports from earlier occurrences of the same series.
+      A third invite arrives, and the prepare touch is the WARM branch — it tells what is held and
+      asks the one question, instead of introducing itself to a stranger.
+    story: rehearsal script stage 6 · prep preset's warm branch
+    # The two prior reports go in through POST /api/workspace/entity — the product's own write
+    # door, the one `entity_upsert` forwards to. They are a STAND-IN for two earlier post-meeting
+    # runs, declared as such (`source: rehearse:<state>`), not a claim that those runs happened.
+    # The faithful alternative is two real completed meetings; it costs two agent turns and it is
+    # what `run_all.py --deep` does.
+    steps:
+      - do: user_ensure
+        door: admin-api
+        address: "{{subject}}"
+        as: subject_user
+      - do: desk_init
+        door: agent-api
+        subject: "{{subject_user.uid}}"
+      - do: desk_entity
+        door: agent-api
+        subject: "{{subject_user.uid}}"
+        kind: meeting
+        name: "{{title}} — first occurrence"
+        summary: "An earlier occurrence of {{title}}, on the desk before this rehearsal began."
+        facts:
+          - "The series met and the report landed on this desk."
+        source: "rehearse:{{state}}"
+      - do: desk_entity
+        door: agent-api
+        subject: "{{subject_user.uid}}"
+        kind: meeting
+        name: "{{title}} — second occurrence"
+        summary: "The occurrence before this one; the desk is warm, not new."
+        facts:
+          - "The series met again and the report landed on this desk."
+        source: "rehearse:{{state}}"
+      # `desk_state()` is the product's classifier and its vocabulary is not ours: meeting entities
+      # ALONE are a `pile` — "reports landed and nobody wired them", decision 22's economics —
+      # and it takes a NON-meeting entity for a desk to read `warm` ("somebody has worked here").
+      # The first live run failed here, correctly: two prior reports made a pile, not a warm desk.
+      # A warm desk really does carry both, so the recipe now writes both rather than arguing with
+      # the classifier.
+      - do: desk_entity
+        door: agent-api
+        subject: "{{subject_user.uid}}"
+        kind: person
+        name: "{{subject_local}}"
+        summary: "The subject's own page — what makes this desk worked-in rather than a pile."
+        facts:
+          - "Attends the {{title}} series."
+        source: "rehearse:{{state}}"
+      - do: drop_invite
+        door: smtp
+        organizer: "{{subject}}"
+        title: "{{title}}"
+        start: "{{when}}"
+        attendees_from_fixture: true
+        ics_uid: "rehearse-{{state}}-{{subject_local}}-{{meeting}}"
+      - do: await_mail
+        door: mailpit
+        to: "{{subject}}"
+        subject_contains: "Prepare"
+        as: prepare_mail
+      - do: cancel_bot_leg          # same reason as organizer-invited: disarm the bot leg
+        door: flows-api
+        flow: invite_intake
+        source_contains: "rehearse-{{state}}-{{subject_local}}-{{meeting}}"
+    artefacts:
+      mail: "\"Prepare: {{title}}\" to {{subject}}"
+      link: "/?s=<scaffold id> (kind `prep`) whose refs carry `state: warm`"
+      desks: two meeting entities on {{subject}}'s desk before the touch is composed
+    verify:
+      - check: desk_nonempty
+        subject: "{{subject_user.uid}}"
+      - check: mail_present
+        of: prepare_mail
+      - check: link_present
+        of: prepare_mail
+        must_match: "/\\?s="
+        as: prepare
+      - check: scaffold_resolves
+        link: prepare
+        kind: prep
+        desk_state: warm
+
+  # ─────────────────────────────────────────────────────────────────────────────────────────────
+  reply-pending:
+    summary: >
+      A minutes mail has been sent to the subject and they have replied to it by mail. The reply
+      is on a registered thread, so the poller admits `mail.reply` and `email_chat` is the turn
+      waiting to run.
+    story: rehearsal script stage 4 (the reply leg) · flows email_chat
+    steps:
+      - do: user_ensure
+        door: admin-api
+        address: "{{subject}}"
+        as: subject_user
+      - do: desk_init
+        door: agent-api
+        subject: "{{subject_user.uid}}"
+      - do: seed_meeting
+        door: gateway
+        owner: "{{subject_user.uid}}"
+        native: "rehearse-{{state}}-{{subject_local}}-{{meeting}}"
+        as: meeting_row
+      - do: emit_fact
+        door: flows-api
+        event_type: meeting.completed
+        source_event_id: "rehearse-{{state}}-{{subject_local}}-{{meeting_row.meeting_id}}"
+        refs:
+          uid: "{{subject_user.uid}}"
+          organizer: "{{subject}}"
+          meeting_id: "{{meeting_row.meeting_id}}"
+          native: "{{meeting_row.native_meeting_id}}"
+          title: "{{title}}"
+          start: "{{meeting_row.started_epoch}}"
+      - do: await_mail
+        door: mailpit
+        to: "{{subject}}"
+        subject_contains: "{{title}}"
+        as: minutes_mail
+        budget_s: 900
+      # The reply goes back through the SAME door a person's mail client uses: SMTP into the
+      # double, In-Reply-To set to the minutes mail's own Message-ID. `mail_thread` resolves it;
+      # nothing is injected past the poller.
+      - do: reply_to_mail
+        door: smtp
+        to_mail: minutes_mail
+        from_address: "{{subject}}"
+        body: >
+          One correction: the decision on the third item was deferred, not taken.
+          Please amend the note and tell me what is still open.
+        as: reply
+      - do: await_reaction
+        door: flows-api
+        flow: email_chat
+        since: "{{reply.sent_at}}"
+        as: email_chat_reaction
+        budget_s: 300
+    artefacts:
+      mail: "\"Minutes: {{title}}\" out, one reply in, and the agent's threaded answer after"
+      link: the minutes mail's /?s= link stays valid; the reply loop needs no link at all
+      desks: the note on {{subject}}'s desk, amended by the reply turn
+    verify:
+      - check: mail_present
+        of: minutes_mail
+      # The minutes mail carries the same scaffolded button every other touch does. The reply loop
+      # does not need it — but a minutes mail WITHOUT it is the F10 defect (a link that opens onto
+      # nothing), so the state checks it on the way past.
+      - check: link_present
+        of: minutes_mail
+        must_match: "/\\?s="
+        as: minutes
+      - check: reaction_admitted
+        of: email_chat_reaction

--- a/deploy/dogfood/rehearse/stub_doors.py
+++ b/deploy/dogfood/rehearse/stub_doors.py
@@ -1,0 +1,331 @@
+"""StubDoors — the whole stack as a dict, so every recipe is provable with nothing running.
+
+It is NOT a mock in the usual sense: it does not record calls for an assertion to inspect. It is a
+tiny model of the product's own behaviour at each door — an invite produces an RSVP and a prepare
+mail, a completed meeting produces an attendee mail, a mail carries a `/?s=` link whose scaffold
+resolves — so `run_all.py --stub` exercises the SAME code path the live run takes and fails on the
+same verify block. The offline proof is therefore about the recipes and the engine, and only the
+doors are substituted.
+
+What it deliberately does NOT model: agent turns, timing, and whether the words in a mail are any
+good. Those need the stack and, for the last one, a person.
+"""
+from __future__ import annotations
+
+import json
+import re
+import time
+
+from .doors import DoorRefused, Doors, runner_config
+
+UI = "https://app.dev.vexa.test"
+
+
+class StubDoors(Doors):
+    def __init__(self, *, blank: bool = True, live: list | None = None):
+        self.users: dict[str, str] = {}
+        self.desks: dict[str, list] = {}
+        self.groups: dict[str, dict] = {}
+        self.meetings: dict[str, dict] = {}
+        self.mail: list[dict] = []
+        self.scaffolds: dict[str, dict] = {}
+        self.facts: list[dict] = []
+        self.reactions: list[dict] = []
+        self.runners: dict[str, dict] = {}
+        self.calls: list[tuple] = []
+        self._blank = blank
+        self._live = list(live or [])
+        self._n = 0
+
+    # -- helpers ---------------------------------------------------------------------------------
+    def _id(self, prefix: str = "") -> str:
+        self._n += 1
+        return f"{prefix}{self._n:06d}"
+
+    def _scaffold(self, kind: str, who: str, refs: dict | None = None) -> str:
+        sid = self._id("sc")
+        self.scaffolds[sid] = {"id": sid, "kind": kind, "who": who, "refs": refs or {}}
+        return f"{UI}/?s={sid}"
+
+    def _send(self, to: str, subject: str, body: str) -> dict:
+        msg = {"id": self._id("m"), "subject": subject, "to": [to], "from": "vexa@storm.test",
+               "message_id": f"<{self._id('mid')}@rehearse.local>", "text": body, "html": "",
+               "body": body, "links": re.findall(r"https?://\S+", body), "at": time.time()}
+        self.mail.append(msg)
+        return msg
+
+    # -- verbs -----------------------------------------------------------------------------------
+    def require_instance_blank(self) -> dict:
+        self.calls.append(("require_instance_blank",))
+        if not self._blank:
+            # Word for word the live refusal (`LiveDoors.require_instance_blank`): a double whose
+            # error text differs from the door's teaches a caller to handle a message the stack
+            # never sends.
+            raise DoorRefused(
+                "the instance is NOT blank: an admin has claimed it and the company layer is "
+                "completed. `blank-admin` asserts this state, it never creates it — blanking "
+                "deletes every person on the stack and is `bin/blank-instance.sh`, run on purpose.")
+        return {"blank": True}
+
+    def require_subject_absent(self, address: str) -> dict:
+        self.calls.append(("require_subject_absent", address))
+        if address in self.users:
+            raise DoorRefused(f"{address} already has a user (uid {self.users[address]})")
+        return {"absent": True, "address": address}
+
+    def user_ensure(self, address: str) -> dict:
+        existed = address in self.users
+        uid = self.users.setdefault(address, self._id())
+        self.calls.append(("user_ensure", address))
+        return {"uid": uid, "email": address, "existed": existed}
+
+    def desk_init(self, subject: str) -> dict:
+        self.desks.setdefault(str(subject), ["README.md"])
+        self.calls.append(("desk_init", subject))
+        return {"subject": str(subject), "status": 201}
+
+    def desk_entity(self, subject: str, kind: str, name: str, facts=(), source: str = "",
+                    summary: str = "", slug: str = "") -> dict:
+        path = f"kg/entities/{kind}/{re.sub(r'[^a-z0-9]+', '-', name.lower()).strip('-')}.md"
+        self.desks.setdefault(str(slug or subject), []).append(path)
+        self.calls.append(("desk_entity", subject, kind, name))
+        return {"path": path, "created": True, "changed": True}
+
+    def group_new(self, owner: str, name: str, purpose: str = "") -> dict:
+        wid = re.sub(r"[^a-z0-9]+", "-", name.lower()).strip("-") + "-" + self._id()
+        self.groups[wid] = {"owner": str(owner), "name": name, "members": [
+            {"subject": str(owner), "role": "owner", "email": ""}]}
+        self.desks.setdefault(wid, ["README.md"])
+        self.calls.append(("group_new", owner, name))
+        return {"workspace_id": wid, "name": name, "owner": str(owner)}
+
+    def group_join(self, group: str, owner: str, member: str, member_email: str = "",
+                   role: str = "contributor") -> dict:
+        g = self.groups.get(group)
+        if not g:
+            raise DoorRefused(f"no such group {group}")
+        g["members"].append({"subject": str(member), "role": role, "email": member_email})
+        self.calls.append(("group_join", group, member))
+        return {"group": group, "member": str(member), "joined": True}
+
+    def request_sign_in_link(self, address: str) -> dict:
+        self._send(address, "Sign in to Vexa",
+                   f"Your sign-in link:\n{UI}/auth/redeem?t={self._id('tok')}\n")
+        self.calls.append(("request_sign_in_link", address))
+        return {"requested": address, "status": 200}
+
+    def drop_invite(self, organizer: str, title: str, start: float, attendees=(),
+                    ics_uid: str = "", group: str = "", url: str = "") -> dict:
+        """The invite, and everything `invite_intake` does with one — modelled, not faked.
+
+        ensure_user · rsvp_accept · ack_by_email · emit_prep. `await_start` parks (start is in the
+        future by construction), so no bot is dispatched and no meeting completes here.
+        """
+        uid = self.users.setdefault(organizer, self._id())
+        self.desks.setdefault(uid, ["README.md"])
+        self._send(organizer, f"Accepted: {title}", "Vexa will be there.")
+        link = self._scaffold("prep", organizer,
+                              {"title": title, "when": start, "organizer": organizer,
+                               "state": {"desk": self._desk_state(uid), "group": "absent"}})
+        self._send(organizer, f"Prepare: {title}",
+                   f"{title} — I'll be in the room. Open the chat: {link}\n")
+        mid = self._id()
+        self.meetings[mid] = {"id": mid, "native_meeting_id": ics_uid or mid, "status": "scheduled",
+                              "owner": uid, "title": title}
+        # `invite_intake` PARKS on `await_start` and then dispatches a real bot. Modelled, because
+        # the thing the recipe has to prove is that it leaves nothing armed.
+        self.reactions.append({"flow": "invite_intake", "state": "retrying", "id": self._id("r"),
+                               "created_at": time.time(),
+                               "source_event_id": f"ics-{ics_uid}::invite_intake"})
+        self.calls.append(("drop_invite", organizer, title, group))
+        return {"ics_uid": ics_uid, "to": "vexa@storm.test", "organizer": organizer,
+                "start": start, "attendees": [a for _, a in attendees]}
+
+    #: `transcript-import`'s own vocabulary, from its 422. A double that accepts what the real
+    #: route refuses certifies a broken caller — which is exactly what happened on the first live
+    #: run: three states passed here and 422'd there.
+    IMPORT_SOURCES = ("import", "seed")
+
+    def seed_meeting(self, owner: str, native: str, title: str, segments: list,
+                     started_at: float, source: str = "seed") -> dict:
+        if source not in self.IMPORT_SOURCES:
+            raise DoorRefused(
+                f"'source' must be one of {list(self.IMPORT_SOURCES)} — say where the transcript "
+                f"came from (got {source!r})")
+        for row in self.meetings.values():            # adopt, exactly as LiveDoors does
+            if row["native_meeting_id"] == native and row["status"] == "completed":
+                return {"meeting_id": row["id"], "native_meeting_id": native, "platform": "jitsi",
+                        "status": "completed", "segments_loaded": len(segments),
+                        "imported": False, "started_epoch": int(started_at),
+                        "ended_epoch": int(started_at)}
+        mid = self._id()
+        row = {"id": mid, "native_meeting_id": native, "platform": "jitsi", "status": "completed",
+               "owner": str(owner), "title": title}
+        self.meetings[mid] = row
+        self.calls.append(("seed_meeting", owner, native))
+        return {"meeting_id": mid, "native_meeting_id": native, "platform": "jitsi",
+                "status": "completed", "segments_loaded": len(segments), "imported": True,
+                "started_epoch": int(started_at),
+                "ended_epoch": int(started_at + max((s["end"] for s in segments), default=0))}
+
+    def emit_fact(self, event_type: str, source_event_id: str, refs: dict) -> dict:
+        dup = any(f["source_event_id"] == source_event_id for f in self.facts)
+        self.facts.append({"event_type": event_type, "source_event_id": source_event_id,
+                           "refs": refs})
+        self.calls.append(("emit_fact", event_type, source_event_id))
+        if event_type == "meeting.completed" and not dup:
+            self._post_meeting(refs)
+        return {"event_type": event_type, "source_event_id": source_event_id,
+                "reactions_created": 0 if dup else 1, "duplicate": dup, "at": time.time()}
+
+    def _post_meeting(self, refs: dict) -> None:
+        """`post_meeting`: one shared report, one mail per attendee, one drop per desk.
+
+        Decision 22a — the organizer's desk always receives the drop, even when the room is all
+        external. Modelled because a state's verify block asks about it.
+        """
+        title = str(refs.get("title") or "Meeting")
+        group = str(refs.get("group") or "")
+        everyone = list(dict.fromkeys([str(refs.get("organizer") or "")]
+                                      + list(refs.get("participants") or [])))
+        for who in [w for w in everyone if w]:
+            uid = self.users.get(who) or self.users.setdefault(who, self._id())
+            self.desks.setdefault(uid, []).append(f"kg/entities/meeting/{title}.md")
+            link = self._scaffold("post-meeting", who,
+                                  {"meeting": refs.get("meeting_id"), "group": group or None})
+            self._send(who, f"{title} — what it means for you",
+                       f"The report from {title}.\nOpen the chat: {link}\n")
+        if group and group in self.groups:
+            self.desks.setdefault(group, []).append(f"kg/entities/meeting/{title}.md")
+        self.reactions.append({"flow": "post_meeting", "state": "done", "id": self._id("r"),
+                               "created_at": time.time()})
+
+    def await_mail(self, to: str, subject_contains: str = "", budget_s: int = 180,
+                   since: float = 0.0) -> dict:
+        for msg in reversed(self.mail):
+            if to not in msg["to"]:
+                continue
+            if subject_contains and subject_contains.lower() not in msg["subject"].lower():
+                continue
+            if since and msg["at"] < since - 5:
+                continue          # a previous run's touch is not this run's evidence
+            return dict(msg)
+        raise DoorRefused(f"no mail to {to} containing {subject_contains!r}")
+
+    def reply_to_mail(self, message: dict, from_address: str, body: str) -> dict:
+        orig = str(message.get("message_id") or "")
+        if not orig:
+            raise DoorRefused("the mail we are replying to carries no Message-ID")
+        self.reactions.append({"flow": "email_chat", "state": "running", "id": self._id("r"),
+                              "created_at": time.time()})
+        self.calls.append(("reply_to_mail", from_address))
+        return {"in_reply_to": orig, "message_id": self._id("mid"), "from": from_address,
+                "sent_at": time.time()}
+
+    def await_reaction(self, flow: str, since: float = 0.0, budget_s: int = 300) -> dict:
+        for r in reversed(self.reactions):
+            if r["flow"] == flow:
+                return {"flow": flow, "state": r["state"], "id": r["id"], "reaction": r,
+                        "admitted": True}
+        raise DoorRefused(f"no `{flow}` reaction appeared")
+
+    def bind_runner(self, subject: str, runner: str) -> dict:
+        cfg = runner_config(runner)                     # the same refusal the live door raises
+        self.runners[str(subject)] = cfg
+        self.calls.append(("bind_runner", subject, runner))
+        return {"subject": str(subject), "runner": runner, "config": cfg}
+
+    def _desk_state(self, subject: str) -> str:
+        """`new` | `pile` | `warm`, by the product's rule (`control_plane/scaffolds.desk_state`):
+        meeting entities ALONE are a pile — reports landed and nobody wired them — and it takes a
+        non-meeting entity for somebody to have worked here. Mirrored rather than invented, because
+        the recipe asserts against it and a double with its own opinion proves nothing."""
+        files = [f for f in self.desks.get(str(subject), []) if "kg/entities/" in f]
+        if not files:
+            return "new"
+        other = [f for f in files if "/meeting/" not in f and not f.endswith("index.md")]
+        return "warm" if other else "pile"
+
+    def cancel_bot_leg(self, flow: str, source_contains: str = "") -> dict:
+        live = [r for r in self.reactions
+                if r["flow"] == flow and r["state"] in ("admitted", "running", "retrying")]
+        for r in live:
+            r["state"] = "cancelled"
+        self.calls.append(("cancel_bot_leg", flow))
+        return {"flow": flow, "cancelled": len(live), "ids": [r["id"] for r in live]}
+
+    # -- reads -----------------------------------------------------------------------------------
+    def user_find(self, address: str):
+        return self.users.get(address)
+
+    def user_email(self, uid: str) -> str:
+        for addr, u in self.users.items():
+            if u == str(uid):
+                return addr
+        raise DoorRefused(f"no user {uid} on this instance (404)")
+
+    def meeting_get(self, owner: str, meeting_id) -> dict:
+        return self.meetings[str(meeting_id)]
+
+    def desk_tree(self, subject: str, slug: str = "") -> list:
+        return list(self.desks.get(str(slug or subject), []))
+
+    def group_members(self, owner: str, group: str) -> list:
+        return list((self.groups.get(group) or {}).get("members") or [])
+
+    def scaffold_get(self, scaffold_id: str, subject: str = "") -> dict:
+        if scaffold_id not in self.scaffolds:
+            raise DoorRefused(f"scaffold {scaffold_id} does not resolve (404)")
+        return self.scaffolds[scaffold_id]
+
+    # -- guard + reset ---------------------------------------------------------------------------
+    def live_meetings(self) -> list:
+        return list(self._live)
+
+    def user_delete(self, uid: str) -> dict:
+        """Deleting a user takes their meetings with them — the FK cascade admin-api's route
+        performs. Modelled here because `rehearse(..., fresh=True)` depends on it: the fact's id
+        names the meeting row, so a row that outlived its owner would dedup the re-entry away."""
+        for addr, u in list(self.users.items()):
+            if u == str(uid):
+                del self.users[addr]
+        for mid, row in list(self.meetings.items()):
+            if row.get("owner") == str(uid):
+                del self.meetings[mid]
+        return {"deleted": True, "via": "admin-api"}
+
+    def meetings_delete_for(self, subject: str) -> int:
+        gone = [m for m, row in self.meetings.items() if row.get("owner") == str(subject)]
+        for m in gone:
+            del self.meetings[m]
+        return len(gone)
+
+    def desk_delete(self, subject: str) -> dict:
+        return {"deleted": self.desks.pop(str(subject), None) is not None}
+
+    def session_keys_delete(self, subject: str) -> int:
+        return 0
+
+    def scaffold_keys_delete(self, address: str) -> int:
+        gone = [k for k, v in self.scaffolds.items() if v["who"] == address]
+        for k in gone:
+            del self.scaffolds[k]
+        return len(gone)
+
+    def friction_delete_for(self, subject: str) -> int:
+        return 0
+
+    def lane_rows_delete_for(self, subject: str, address: str) -> dict:
+        """Drop this subject's admitted facts, so the same derived ids are admissible again —
+        the model of `admit()`'s dedup being per-subject-clearable."""
+        gone = [f for f in self.facts
+                if str(subject) in json.dumps(f.get("refs") or {})
+                or address in json.dumps(f.get("refs") or {})]
+        self.facts = [f for f in self.facts if f not in gone]
+        self.reactions = [r for r in self.reactions if r.get("subject") not in (str(subject),)]
+        return {"facts": len(gone)} if gone else {}
+
+    def mail_delete_for(self, address: str) -> int:
+        before = len(self.mail)
+        self.mail = [m for m in self.mail if address not in m["to"] and m["from"] != address]
+        return before - len(self.mail)

--- a/deploy/dogfood/rehearse/tests/README.md
+++ b/deploy/dogfood/rehearse/tests/README.md
@@ -1,0 +1,19 @@
+# tests — offline by construction
+
+No network, no docker, no home directory: the doors are substituted with `stub_doors.StubDoors`
+and the transcripts come from `fixtures/`. The whole suite runs in under a second, which is what
+makes it something you run before every change rather than instead of one.
+
+| file | what it holds to account |
+|---|---|
+| `test_catalogue.py` | the recipes validate themselves, and the `door:` column is proved not to be decoration |
+| `test_guards.py` | the two refusals that keep a rehearsal off the founder's data, wired end to end |
+| `test_engine.py` | every state runs and passes its own verify block; idempotence; derived addresses |
+| `test_reset.py` | `subject_reset` removes one subject, reads the emptiness back, and reports what it could not |
+| `test_runner.py` | `runner=` binds a harness per subject — and to nobody else |
+| `test_hot.py` | **no state needs an image** (PRD decision 38.4), asserted over the source rather than promised |
+| `test_run_all.py` | the catalogue as the test, and what it files when a state breaks |
+
+The other half of the runner chain lives in `core/agent/tests/test_runner_per_subject.py`: this
+suite proves the exact config a rehearsal writes, that one proves the exact worker env it becomes.
+Neither can prove the other, and a test that mocked across the seam would prove neither.

--- a/deploy/dogfood/rehearse/tests/conftest.py
+++ b/deploy/dogfood/rehearse/tests/conftest.py
@@ -1,0 +1,33 @@
+"""Shared fixtures. Offline by construction: nothing here reads the host's home directory.
+
+The DNA corpus lives at `~/dna-fixtures` on the rig, which is a deployment fact and not a test
+input — a suite that read it would pass on bbb and fail everywhere else, and would silently start
+measuring whatever somebody left in that directory. `tests/fixtures/` holds two small transcripts
+in exactly the corpus's shape instead.
+"""
+from __future__ import annotations
+
+import pathlib
+
+import pytest
+
+from rehearse import catalogue as cat
+
+FIXTURES = pathlib.Path(__file__).resolve().parent / "fixtures"
+
+
+@pytest.fixture(scope="session")
+def catalog() -> cat.Catalogue:
+    return cat.load()
+
+
+@pytest.fixture
+def env() -> dict:
+    """The environment a rehearsal reads: the test domain and the fixture library."""
+    return {"VEXA_REHEARSE_DOMAIN": "rehearse.test", "VEXA_DNA_FIXTURES": str(FIXTURES)}
+
+
+@pytest.fixture
+def doors():
+    from rehearse.stub_doors import StubDoors
+    return StubDoors()

--- a/deploy/dogfood/rehearse/tests/fixtures/2026-03-02.transcript.json
+++ b/deploy/dogfood/rehearse/tests/fixtures/2026-03-02.transcript.json
@@ -1,0 +1,33 @@
+{
+ "meeting": {
+  "title": "DNA TSC 2026-03-02",
+  "platform": "zoom",
+  "native_meeting_id": "96088138284",
+  "occurrence": "2026-03-02",
+  "participants": [
+   "Olga Avramenko (Sony Pictures Imageworks)",
+   "Tommy Burnette (Lucasfilm)",
+   "Sam Richards"
+  ]
+ },
+ "segments": [
+  {
+   "t": 0.0,
+   "end": 4.2,
+   "speaker": "Olga Avramenko (Sony Pictures Imageworks)",
+   "text": "Hey, everyone. Let's start with the schema change."
+  },
+  {
+   "t": 4.2,
+   "end": 11.7,
+   "speaker": "Tommy Burnette (Lucasfilm)",
+   "text": "We reviewed it on our side. The naming still worries me."
+  },
+  {
+   "t": 11.7,
+   "end": 19.0,
+   "speaker": "Sam Richards",
+   "text": "I'll write it up and bring it back next time."
+  }
+ ]
+}

--- a/deploy/dogfood/rehearse/tests/fixtures/2026-03-16.transcript.json
+++ b/deploy/dogfood/rehearse/tests/fixtures/2026-03-16.transcript.json
@@ -1,0 +1,33 @@
+{
+ "meeting": {
+  "title": "DNA TSC 2026-03-16",
+  "platform": "zoom",
+  "native_meeting_id": "96088138284",
+  "occurrence": "2026-03-16",
+  "participants": [
+   "Olga Avramenko (Sony Pictures Imageworks)",
+   "Tommy Burnette (Lucasfilm)",
+   "Sam Richards"
+  ]
+ },
+ "segments": [
+  {
+   "t": 0.0,
+   "end": 4.2,
+   "speaker": "Olga Avramenko (Sony Pictures Imageworks)",
+   "text": "Hey, everyone. Let's start with the schema change."
+  },
+  {
+   "t": 4.2,
+   "end": 11.7,
+   "speaker": "Tommy Burnette (Lucasfilm)",
+   "text": "We reviewed it on our side. The naming still worries me."
+  },
+  {
+   "t": 11.7,
+   "end": 19.0,
+   "speaker": "Sam Richards",
+   "text": "I'll write it up and bring it back next time."
+  }
+ ]
+}

--- a/deploy/dogfood/rehearse/tests/fixtures/README.md
+++ b/deploy/dogfood/rehearse/tests/fixtures/README.md
@@ -1,0 +1,14 @@
+# tests/fixtures — two transcripts in the DNA corpus's shape
+
+Small stand-ins for `~/dna-fixtures/`, in exactly the shape the real library uses: a `meeting`
+block (`title`, `platform`, `native_meeting_id`, `occurrence`, `participants` as display names
+with an org in parentheses) and `segments` keyed `t` / `end` / `speaker` / `text`.
+
+**They are here so the suite never reads the rig's home directory.** `~/dna-fixtures` is a
+deployment fact: a test that read it would pass on bbb and fail everywhere else, and would quietly
+start measuring whatever somebody last left in that directory. Three turns is enough — the tests
+assert over the recipe and the derived addresses, never over the words.
+
+The org in parentheses is deliberate: `engine.attendee_address` has to drop it
+("Olga Avramenko (Sony Pictures Imageworks)" → `olga-avramenko@rehearse.test`), and a fixture
+without one would let that regress unnoticed.

--- a/deploy/dogfood/rehearse/tests/test_catalogue.py
+++ b/deploy/dogfood/rehearse/tests/test_catalogue.py
@@ -1,0 +1,136 @@
+"""The catalogue validates itself — and the `door:` column is proved not to be decoration."""
+from __future__ import annotations
+
+import inspect
+
+import pytest
+
+from rehearse import catalogue as cat
+from rehearse.doors import Doors
+
+STATES = ("blank-admin", "organizer-invited", "attendee-stranger-minutes", "group-member",
+          "warm-desk-recurring", "reply-pending")
+
+
+def test_the_six_states_of_decision_38_are_all_here():
+    c = cat.load()
+    assert sorted(c.states) == sorted(STATES)
+
+
+def test_every_state_names_its_story_and_can_be_checked():
+    c = cat.load()
+    for name, st in c.states.items():
+        assert st.summary, name
+        assert st.story, f"{name} does not say which part of the script it is"
+        assert st.verify, f"{name} has no verify block — nobody could tell it worked"
+        assert st.steps, name
+
+
+def test_every_verb_has_a_door_method_and_every_door_method_is_a_verb():
+    """The two halves cannot drift.
+
+    A verb in the vocabulary with no method behind it is a recipe nothing can execute; a method
+    with no verb is a door nothing reaches. Both are silent until someone writes the recipe that
+    needs them, which is the wrong moment to find out.
+    """
+    methods = {n for n, _ in inspect.getmembers(Doors, inspect.isfunction)
+               if not n.startswith("_")}
+    # Doors that are NOT recipe verbs, each with the caller that needs it: the verify block's
+    # reads, the two guards, the reset's per-store deletes, and the per-subject harness binding
+    # (which is a flag on the call, never a step — a recipe describes a STATE, and which model
+    # runs the turns is not part of what state somebody is in).
+    reads = {"user_find", "meeting_get", "desk_tree", "group_members", "scaffold_get",
+             "live_meetings", "user_delete", "desk_delete", "session_keys_delete",
+             "scaffold_keys_delete", "friction_delete_for", "mail_delete_for",
+             "bind_runner", "meetings_delete_for", "lane_rows_delete_for",
+             "user_email"}
+    assert set(cat.VERBS) <= methods
+    assert methods - reads == set(cat.VERBS)
+
+
+def test_every_step_declares_the_door_that_actually_answers_it():
+    c = cat.load()
+    for name, st in c.states.items():
+        for step in st.steps:
+            assert step.door == cat.VERBS[step.do].door, f"{name} step {step.index}"
+
+
+def test_a_wrong_door_is_refused_at_load(tmp_path):
+    bad = tmp_path / "s.yaml"
+    bad.write_text(_yaml(steps=[{"do": "user_ensure", "door": "gateway",
+                                 "address": "a@t.test", "as": "u"}]))
+    with pytest.raises(cat.CatalogueError, match="declares door"):
+        cat.load(bad)
+
+
+def test_an_unknown_verb_is_refused_at_load(tmp_path):
+    bad = tmp_path / "s.yaml"
+    bad.write_text(_yaml(steps=[{"do": "teleport", "door": "gateway"}]))
+    with pytest.raises(cat.CatalogueError, match="not a verb"):
+        cat.load(bad)
+
+
+def test_an_unknown_argument_is_refused_at_load(tmp_path):
+    bad = tmp_path / "s.yaml"
+    bad.write_text(_yaml(steps=[{"do": "user_ensure", "door": "admin-api",
+                                 "address": "a@t.test", "as": "u", "hurry": True}]))
+    with pytest.raises(cat.CatalogueError, match="unknown argument"):
+        cat.load(bad)
+
+
+def test_a_verify_row_naming_a_capture_nobody_makes_is_refused(tmp_path):
+    """The vacuous-check rule: a check pointing at nothing passes for free."""
+    bad = tmp_path / "s.yaml"
+    bad.write_text(_yaml(
+        steps=[{"do": "user_ensure", "door": "admin-api", "address": "a@t.test", "as": "u"}],
+        verify=[{"check": "mail_present", "of": "never_captured"}]))
+    with pytest.raises(cat.CatalogueError, match="which no step captures"):
+        cat.load(bad)
+
+
+def test_a_state_with_no_verify_block_is_refused(tmp_path):
+    bad = tmp_path / "s.yaml"
+    bad.write_text(_yaml(
+        steps=[{"do": "user_ensure", "door": "admin-api", "address": "a@t.test", "as": "u"}],
+        verify=[]))
+    with pytest.raises(cat.CatalogueError, match="no `verify`"):
+        cat.load(bad)
+
+
+# ── interpolation ────────────────────────────────────────────────────────────────────────────────
+
+def test_a_whole_string_token_keeps_the_value_s_type():
+    """`participants: "{{fixture_attendees}}"` must reach the intake as a LIST.
+
+    A fact whose participants arrived as the string "['a@x']" admits fine, fans out to nobody, and
+    reports success. That is the failure this rule exists for.
+    """
+    out = cat.interpolate({"participants": "{{who}}", "n": "{{count}}"},
+                          {"who": ["a@t.test", "b@t.test"], "count": 3})
+    assert out == {"participants": ["a@t.test", "b@t.test"], "n": 3}
+
+
+def test_a_token_inside_a_sentence_renders_as_text():
+    assert cat.interpolate("Prepare: {{title}} now", {"title": "DNA TSC"}) == "Prepare: DNA TSC now"
+
+
+def test_an_unbound_token_raises_and_says_what_is_bound():
+    with pytest.raises(cat.CatalogueError, match="nothing is bound to"):
+        cat.interpolate("{{meeting_row.meeting_id}}", {"title": "x"})
+
+
+def test_lenient_interpolation_leaves_a_marker_that_is_not_address_shaped():
+    """The pre-flight guard reads the plan; its placeholder must not read as an address."""
+    out = cat.interpolate({"a": "{{subject}}", "b": "{{later.id}}"}, {"subject": "x@t.test"},
+                          lenient=True)
+    assert out == {"a": "x@t.test", "b": cat.UNBOUND}
+    assert "@" not in cat.UNBOUND
+
+
+def _yaml(steps, verify=None) -> str:
+    import json
+    doc = {"version": 1, "domain_env": "VEXA_REHEARSE_DOMAIN", "default_domain": "t.test",
+           "states": {"x": {"summary": "s", "story": "st", "steps": steps,
+                            "verify": verify if verify is not None
+                            else [{"check": "user_exists", "address": "a@t.test"}]}}}
+    return json.dumps(doc)      # JSON is valid YAML, and it keeps these fixtures unambiguous

--- a/deploy/dogfood/rehearse/tests/test_engine.py
+++ b/deploy/dogfood/rehearse/tests/test_engine.py
@@ -1,0 +1,155 @@
+"""Every recipe, executed end to end against the door stub, and the artefacts it promises."""
+from __future__ import annotations
+
+import pytest
+
+from rehearse.engine import attendee_address, rehearse
+from rehearse.stub_doors import StubDoors
+
+STATES = ("blank-admin", "organizer-invited", "attendee-stranger-minutes", "group-member",
+          "warm-desk-recurring", "reply-pending")
+
+
+@pytest.mark.parametrize("state", STATES)
+def test_every_state_runs_and_passes_its_own_verify_block(state, catalog, env):
+    res = rehearse(state, f"rehearse-{state}@rehearse.test", doors=StubDoors(), catalog=catalog,
+                   env=env)
+    assert res.ok, f"{state}: {res.error or [v for v in res.verify if not v['ok']]}"
+    assert res.verify and all(v["ok"] for v in res.verify)
+
+
+@pytest.mark.parametrize("state", ("organizer-invited", "attendee-stranger-minutes",
+                                   "group-member", "warm-desk-recurring", "reply-pending"))
+def test_every_touch_produces_a_link_a_person_could_click(state, catalog, env):
+    """A state that ends without a link is a state nobody can walk. `blank-admin` is excluded
+    only because its link is a magic link, not a scaffold — it is checked in its own test."""
+    res = rehearse(state, f"rehearse-{state}@rehearse.test", doors=StubDoors(), catalog=catalog,
+                   env=env)
+    assert res.links, state
+    assert any("?s=" in u for u in res.links.values()), res.links
+
+
+def test_blank_admin_produces_a_sign_in_link_and_still_no_user(catalog, env):
+    doors = StubDoors()
+    res = rehearse("blank-admin", "admin@rehearse.test", doors=doors, catalog=catalog, env=env)
+    assert res.ok
+    assert res.links["sign_in"].startswith("https://")
+    assert doors.user_find("admin@rehearse.test") is None, (
+        "the state is ABOUT TO CLAIM; nothing was clicked, so nothing may have been created")
+
+
+def test_blank_admin_refuses_on_a_claimed_instance_and_says_so(catalog, env):
+    res = rehearse("blank-admin", "admin@rehearse.test", doors=StubDoors(blank=False),
+                   catalog=catalog, env=env)
+    assert not res.ok and "NOT blank" in res.error
+
+
+def test_the_organizer_state_leaves_a_meeting_parked_not_dispatched(catalog, env):
+    doors = StubDoors()
+    rehearse("organizer-invited", "olga@rehearse.test", doors=doors, catalog=catalog, env=env)
+    assert [m["status"] for m in doors.meetings.values()] == ["scheduled"]
+
+
+def test_the_stranger_state_gives_the_subject_a_desk_without_a_click(catalog, env):
+    """Decision 20: the drop creates the desk. The stranger has still never signed in."""
+    doors = StubDoors()
+    who = "rehearse-attendee-stranger-minutes@rehearse.test"
+    res = rehearse("attendee-stranger-minutes", who, doors=doors, catalog=catalog, env=env)
+    assert res.ok
+    uid = doors.user_find(who)
+    assert uid and doors.desk_tree(uid), "the drop must land somewhere for a person with no desk"
+
+
+def test_the_group_state_puts_the_report_on_the_group_desk_and_the_member_in_it(catalog, env):
+    doors = StubDoors()
+    who = "rehearse-group-member@rehearse.test"
+    res = rehearse("group-member", who, doors=doors, catalog=catalog, env=env)
+    assert res.ok
+    (group,) = list(doors.groups)
+    assert any(m.get("email") == who for m in doors.group_members("", group))
+    assert len(doors.desk_tree("", group)) > 1
+
+
+def test_the_reply_state_reaches_the_email_chat_turn(catalog, env):
+    doors = StubDoors()
+    res = rehearse("reply-pending", "rehearse-reply-pending@rehearse.test", doors=doors,
+                   catalog=catalog, env=env)
+    assert res.ok
+    assert any(r["flow"] == "email_chat" for r in doors.reactions)
+
+
+def test_the_warm_state_puts_history_on_the_desk_before_the_touch_is_composed(catalog, env):
+    """Order is the whole state: two reports must exist BEFORE the invite drops, or the prepare
+    scaffold is composed against an empty desk and the warm branch never fires."""
+    doors = StubDoors()
+    rehearse("warm-desk-recurring", "rehearse-warm-desk-recurring@rehearse.test", doors=doors,
+             catalog=catalog, env=env)
+    kinds = [c[0] for c in doors.calls]
+    assert kinds.index("drop_invite") > max(i for i, k in enumerate(kinds) if k == "desk_entity")
+
+
+# ── idempotence ──────────────────────────────────────────────────────────────────────────────────
+
+@pytest.mark.parametrize("state", ("organizer-invited", "warm-desk-recurring"))
+def test_running_a_state_twice_is_the_same_state_not_two(state, catalog, env):
+    """Idempotence by DERIVED IDENTITY (engine docstring): same ICS uid, same source_event_id,
+    same native id, so the doors that already dedup do the deduping."""
+    doors = StubDoors()
+    who = f"rehearse-{state}@rehearse.test"
+    a = rehearse(state, who, doors=doors, catalog=catalog, env=env)
+    users_after_first = dict(doors.users)
+    b = rehearse(state, who, doors=doors, catalog=catalog, env=env)
+    assert a.ok and b.ok, b.error
+    assert doors.users == users_after_first, "a second run must not mint a second account"
+
+
+def test_re_entering_the_stranger_state_says_the_stranger_is_gone(catalog, env):
+    """The one state a second run cannot reproduce, and it SAYS so rather than pretending.
+
+    `attendee-stranger-minutes` needs somebody who has never been seen; the first run gives them a
+    desk. Re-entering it is `subject_reset` then `rehearse`, and the refusal names the way out.
+    """
+    doors = StubDoors()
+    who = "rehearse-attendee-stranger-minutes@rehearse.test"
+    assert rehearse("attendee-stranger-minutes", who, doors=doors, catalog=catalog, env=env).ok
+    again = rehearse("attendee-stranger-minutes", who, doors=doors, catalog=catalog, env=env)
+    assert not again.ok and "already has a user" in again.error
+
+
+def test_a_second_completed_fact_is_a_duplicate_not_a_second_fan_out(catalog, env):
+    doors = StubDoors()
+    who = "rehearse-reply-pending@rehearse.test"
+    rehearse("reply-pending", who, doors=doors, catalog=catalog, env=env)
+    mails_after_first = len(doors.mail)
+    out = doors.emit_fact("meeting.completed",
+                          [f["source_event_id"] for f in doors.facts][-1], {})
+    assert out["duplicate"] is True
+    assert len(doors.mail) == mails_after_first
+
+
+# ── derived values ───────────────────────────────────────────────────────────────────────────────
+
+def test_a_speaker_label_becomes_a_test_domain_address_without_their_employer():
+    assert attendee_address("Olga Avramenko (Sony Pictures Imageworks)", "rehearse.test") == \
+        "olga-avramenko@rehearse.test"
+    assert attendee_address("Sam Richards", "rehearse.test") == "sam-richards@rehearse.test"
+    assert attendee_address("", "rehearse.test") == "someone@rehearse.test"
+
+
+def test_a_failing_step_stops_the_recipe_and_names_where(catalog, env):
+    class NoMail(StubDoors):
+        def await_mail(self, to, subject_contains="", budget_s=180, since=0.0):
+            from rehearse.doors import DoorRefused
+            raise DoorRefused("no mail arrived")
+    res = rehearse("organizer-invited", "x@rehearse.test", doors=NoMail(), catalog=catalog,
+                   env=env)
+    assert not res.ok
+    assert res.steps[-1]["do"] == "(stopped)"
+    assert "no mail arrived" in res.error
+
+
+def test_a_missing_fixture_names_the_ones_that_exist(catalog, env):
+    from rehearse.engine import Refused
+    with pytest.raises(Refused, match="2026-03-02"):
+        rehearse("organizer-invited", "x@rehearse.test", meeting="1999-01-01",
+                 doors=StubDoors(), catalog=catalog, env=env)

--- a/deploy/dogfood/rehearse/tests/test_guards.py
+++ b/deploy/dogfood/rehearse/tests/test_guards.py
@@ -1,0 +1,155 @@
+"""The two refusals that come before the first door, and the time argument they depend on.
+
+These are the tests that keep a rehearsal off the founder's data. They are written against the
+guard functions directly AND against `rehearse()` end to end, because a guard that exists but is
+not wired is the same thing as no guard — and that is exactly how it would fail.
+"""
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from rehearse import catalogue as cat
+from rehearse.engine import (Refused, addresses_in, guard_domain, guard_no_live_real_meeting,
+                             parse_when, rehearse, subject_reset)
+from rehearse.stub_doors import StubDoors
+
+from .conftest import FIXTURES
+
+CAT = cat.load()
+
+
+def _env(domain="rehearse.test"):
+    return {"VEXA_REHEARSE_DOMAIN": domain, "VEXA_DNA_FIXTURES": str(FIXTURES)}
+
+
+# ── the domain guard ─────────────────────────────────────────────────────────────────────────────
+
+def test_a_subject_outside_the_test_domain_is_refused_before_any_door():
+    doors = StubDoors()
+    with pytest.raises(Refused, match="not under @rehearse.test"):
+        rehearse("organizer-invited", "dmitry@vexa.ai", doors=doors, catalog=CAT, env=_env())
+    assert doors.calls == [], "a refused run must not have touched a single door"
+
+
+def test_the_guard_reads_addresses_the_recipe_derives_not_only_the_one_typed():
+    """`attendee-stranger-minutes` derives an organizer and pulls a room out of the fixture.
+
+    If the guard only looked at `as=`, a fixture whose participants resolved outside the domain
+    would fan mail at real people while the call itself looked safe.
+    """
+    doors = StubDoors()
+    with pytest.raises(Refused) as e:
+        rehearse("attendee-stranger-minutes", "someone@rehearse.test", doors=doors, catalog=CAT,
+                 env=_env("other.test"))
+    assert "someone@rehearse.test" in str(e.value)
+    assert doors.calls == []
+
+
+def test_the_mail_double_s_own_address_is_the_one_named_exception():
+    guard_domain(["a@rehearse.test", "vexa@storm.test"], "rehearse.test", mailbox="vexa@storm.test")
+    with pytest.raises(Refused):
+        guard_domain(["vexa@storm.test"], "rehearse.test", mailbox="")
+
+
+def test_addresses_are_found_wherever_they_are_nested():
+    tree = {"refs": {"participants": ["a@x.test", {"deep": "b@y.test"}], "n": 3},
+            "note": "cc c@z.test please"}
+    assert sorted(addresses_in(tree)) == ["a@x.test", "b@y.test", "c@z.test"]
+
+
+# ── the live-meeting guard ───────────────────────────────────────────────────────────────────────
+
+def test_a_live_meeting_belonging_to_a_real_subject_stops_everything():
+    doors = StubDoors(live=[{"id": "91", "status": "active", "email": "dmitry@vexa.ai"}])
+    with pytest.raises(Refused, match="live meeting"):
+        rehearse("organizer-invited", "x@rehearse.test", doors=doors, catalog=CAT, env=_env())
+    assert not any(c[0] == "user_ensure" for c in doors.calls)
+
+
+def test_a_live_meeting_belonging_to_a_rehearsal_subject_does_not():
+    doors = StubDoors(live=[{"id": "92", "status": "active", "email": "x@rehearse.test"}])
+    guard_no_live_real_meeting(doors, "rehearse.test")
+
+
+def test_the_probe_fails_closed():
+    """An unreadable probe refuses. A guard that degrades to "probably fine" is not one."""
+    class Blind(StubDoors):
+        def live_meetings(self):
+            from rehearse.doors import DoorRefused
+            raise DoorRefused("could not read the live-meeting probe")
+    with pytest.raises(Exception) as e:
+        rehearse("organizer-invited", "x@rehearse.test", doors=Blind(), catalog=CAT, env=_env())
+    assert "live-meeting probe" in str(e.value)
+
+
+# ── when ─────────────────────────────────────────────────────────────────────────────────────────
+
+def test_relative_absolute_and_iso_times_all_parse():
+    now = 1_700_000_000.0
+    assert parse_when("+30m", now) == now + 1800
+    assert parse_when("+3h", now) == now + 10800
+    assert parse_when("-45m", now) == now - 2700
+    assert parse_when("1700000123", now) == 1700000123.0
+    assert parse_when("2026-03-02T14:00:00Z", now) > 0
+
+
+def test_a_time_we_cannot_read_raises_rather_than_defaulting():
+    with pytest.raises(Refused, match="is not a time"):
+        parse_when("soon")
+
+
+def test_the_default_start_is_in_the_future_so_no_bot_is_ever_dispatched():
+    """`await_start` parks until start-2min. A past start spawns a real bot at a fixture URL."""
+    from rehearse.engine import DEFAULT_WHEN
+    assert parse_when(DEFAULT_WHEN, 1000.0) > 1000.0 + 120
+
+
+# ── the reset's guard ────────────────────────────────────────────────────────────────────────────
+
+def test_subject_reset_refuses_a_real_address_and_deletes_nothing():
+    doors = StubDoors()
+    doors.users["dmitry@vexa.ai"] = "126"
+    with pytest.raises(Refused, match="not under @rehearse.test"):
+        subject_reset("dmitry@vexa.ai", doors=doors, catalog=CAT, env=_env())
+    assert doors.users["dmitry@vexa.ai"] == "126"
+
+
+def test_a_dry_run_resolves_the_whole_plan_and_touches_nothing():
+    doors = StubDoors()
+    res = rehearse("group-member", "x@rehearse.test", doors=doors, catalog=CAT, env=_env(),
+                   dry_run=True)
+    assert res.ok and len(res.steps) == len(CAT["group-member"].steps)
+    assert doors.calls == []
+    assert time.time() > 0
+
+
+# ── F94: the guard checks the SHAPE, not only the suffix ─────────────────────────────────────────
+
+@pytest.mark.parametrize("value", [
+    "20260902t183213z",          # the DTSTAMP that became user 131 on the instance
+    "",
+    "@rehearse.test",            # a domain with nobody in front of it
+    "someone@",
+    "someone@evil.test",
+    "rehearse.test",             # the domain as a bare word — `endswith` would have judged only
+    "a b@rehearse.test",         # a space is not part of an address
+])
+def test_a_value_that_is_not_an_address_under_the_domain_is_refused(value):
+    """`endswith("@" + domain)` passes anything ending in those characters and says nothing about
+    the rest. A safety check that would wave a timestamp through is not one."""
+    with pytest.raises(Refused):
+        guard_domain([value], "rehearse.test")
+
+
+@pytest.mark.parametrize("value", ["a@rehearse.test", "rehearse-group-member@rehearse.test",
+                                   "OLGA-AVRAMENKO@REHEARSE.TEST"])
+def test_a_real_address_under_the_domain_still_passes(value):
+    guard_domain([value], "rehearse.test")
+
+
+def test_a_subdomain_is_not_the_domain():
+    """`evil.rehearse.test` ends with the domain and is somebody else's host."""
+    with pytest.raises(Refused):
+        guard_domain(["a@evil.rehearse.test"], "rehearse.test")

--- a/deploy/dogfood/rehearse/tests/test_hot.py
+++ b/deploy/dogfood/rehearse/tests/test_hot.py
@@ -1,0 +1,106 @@
+"""NO STATE NEEDS AN IMAGE — PRD decision 38.4, asserted rather than promised.
+
+    "presets and mail templates are read hot from `_global`, flow versions load hot; the tool
+     writes data only. Code changes still swap; a state change never does."
+
+A README claiming this would go stale the first time somebody reached for `docker` to make one
+awkward state work — which is exactly how a rig acquires a build step. So the claim is a test over
+the source: every verb's door is a running service, no recipe writes a preset or a template, and
+the only subprocess calls in the whole package are the three named exceptions in `doors.py`'s
+module docstring.
+"""
+from __future__ import annotations
+
+import ast
+import pathlib
+import re
+
+from rehearse import catalogue as cat
+
+PKG = pathlib.Path(__file__).resolve().parent.parent
+
+#: Everything a recipe may talk to. Each is a service that is ALREADY RUNNING, or the mail double.
+#: Nothing here is a build step, an image tag, or a compose file.
+RUNNING_SERVICES = {"admin-api", "agent-api", "gateway", "flows-api", "terminal", "smtp",
+                    "mailpit"}
+
+#: The ONLY functions in the package allowed to shell out, and why. `doors.py`'s docstring lists
+#: the same three; this set is the enforced half. Adding a fourth means writing the reason in both
+#: places, which is the point — the cost of the exception should be visible.
+MAY_SHELL_OUT = {
+    "live_meetings",        # the fail-closed guard: no instance-wide live-meeting route exists
+    "_redis_cli", "_redis", "_redis_del",   # per-subject session/scaffold keys agent-api owns
+    "friction_delete_for", "_flow_lanes",   # per-subject friction rows no route removes
+    "lane_rows_delete_for",                 # per-subject reactions/receipts/threads, ditto
+    "_admin_key",           # reading this deployment's own admin token, when it is not in the env
+}
+
+
+def test_every_door_a_recipe_uses_is_a_service_that_is_already_running():
+    assert {v.door for v in cat.VERBS.values()} <= RUNNING_SERVICES
+
+
+def test_no_recipe_writes_a_preset_a_mail_template_or_the_company_layer():
+    """`_global` is read at click time and written by the admin, in the product. A state that
+    edited a preset would be changing the deployment to enter a state, which is a swap wearing a
+    recipe's clothes.
+
+    Asserted over the PARSED recipe, never over the file's text: a prose line in `artefacts` that
+    happens to contain the word "composed" is not a compose file, and a rule that cannot tell the
+    difference gets deleted the first time it cries wolf.
+    """
+    for name, st in cat.load().states.items():
+        for step in st.steps:
+            said = " ".join(str(v) for v in step.args.values())
+            for forbidden in ("_global", "asks/", "mail/", "docker", "compose", "image"):
+                assert forbidden not in said, f"{name} step {step.index} names {forbidden!r}"
+
+
+def test_the_package_never_builds_runs_or_swaps_an_image():
+    for py in sorted(PKG.glob("*.py")):
+        src = py.read_text()
+        for forbidden in ("docker build", "docker compose", "docker run", "up -d", "docker rm",
+                          "docker restart", "docker stop", "IMAGE_TAG"):
+            assert forbidden not in src, f"{py.name} reaches for {forbidden!r}"
+
+
+def test_only_the_three_named_exceptions_shell_out():
+    """Every other write goes through a route or SMTP. This is the invariant the whole package
+    exists to keep, so it is asserted structurally rather than by reading."""
+    tree = ast.parse((PKG / "doors.py").read_text())
+    offenders = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        src = ast.dump(node)
+        if "subprocess" in src and node.name not in MAY_SHELL_OUT:
+            offenders.add(node.name)
+    assert not offenders, (
+        f"{sorted(offenders)} shell out. A state is entered through the product's own doors; if a "
+        f"new exception is genuinely needed, name it in doors.py's docstring AND in MAY_SHELL_OUT "
+        f"so the cost stays visible.")
+
+
+def test_nothing_writes_the_database_or_the_workspace_volume():
+    src = (PKG / "doors.py").read_text()
+    assert "INSERT" not in src and "UPDATE " not in src
+    # One DELETE, and it is the per-subject friction rows the docstring names.
+    # The per-subject lane tables the reset owns — named, in FK order, and nothing else. The
+    #  `{table}` is `LANE_TABLES`, which the docstring above it lists and bounds.
+    deletes = sorted(set(re.findall(r"DELETE FROM (\{?\w+\}?)", src)))
+    assert deletes == ["friction", "{table}"], deletes
+    assert "cat > /workspaces" not in src and "/workspaces/" not in src
+
+
+def test_the_only_flows_writes_are_facts_never_definitions():
+    """`flows_submit` / `flow_lifecycle` rewrite what the whole instance reacts to. A rehearsal
+    injects FACTS and nothing else — decision 38.4's "the tool writes data only", enforced.
+
+    Matched on the ROUTE and the verb names, not on the substring "/flows": the flows-api key file
+    is `~/.storm/flows-api-key`, and a rule that reads a key path as a definition write is a rule
+    that gets deleted for crying wolf.
+    """
+    src = (PKG / "doors.py").read_text()
+    for definition_verb in ("flows_submit", "flow_lifecycle", "/flows/", "/flows\"", "/flows}"):
+        assert definition_verb not in src, definition_verb
+    assert "/events" in src, "the fact intake is the only flows door a rehearsal uses"

--- a/deploy/dogfood/rehearse/tests/test_live_lessons.py
+++ b/deploy/dogfood/rehearse/tests/test_live_lessons.py
@@ -1,0 +1,141 @@
+"""What the FIRST live run against the sim lane taught, held as tests.
+
+Three of the six states failed on the stack and passed offline, which is the whole reason a stub
+is not enough — each failure was a place where this package had guessed at a shape the product
+defines. None of them was a product defect; all three were this tool being confidently wrong.
+
+    attendee-stranger-minutes   422  'source' must be one of ['import', 'seed']
+    group-member                422  (same)
+    reply-pending               422  (same)
+    warm-desk-recurring         scaffold_resolves FAIL — desk state, read as the wrong TYPE
+
+The stub could not have caught any of them: it answered whatever it was asked. So the stub now
+enforces the product's vocabulary too — a double that accepts what the real door refuses is a
+double that certifies a broken caller.
+"""
+from __future__ import annotations
+
+import pytest
+
+from rehearse.doors import DoorRefused
+from rehearse.engine import rehearse
+from rehearse.stub_doors import StubDoors
+
+# The route's closed vocabulary, from its own 422: "'source' must be one of ['import', 'seed']".
+IMPORT_SOURCES = ("import", "seed")
+
+
+def test_the_transcript_import_declares_a_source_the_route_accepts():
+    """`source: "rehearse"` was refused 422 on three states. These words came from a fixture via a
+    double, which is what `seed` means; the route's vocabulary is right and was not widened."""
+    import inspect
+
+    from rehearse import doors
+    for door in (doors.Doors, doors.LiveDoors):
+        default = inspect.signature(door.seed_meeting).parameters["source"].default
+        assert default in IMPORT_SOURCES, (
+            f"{door.__name__}.seed_meeting defaults `source` to {default!r}; the import route "
+            f"answers 422 with the list {list(IMPORT_SOURCES)} for anything else")
+        assert default == "seed", "a fixture through a double is a seed, not an import"
+
+
+def test_the_stub_refuses_a_source_the_real_route_would_refuse(catalog, env):
+    """The stub's job is to fail where the stack fails. It answered 200 to `source: "rehearse"`
+    and certified three states that could not run."""
+    doors = StubDoors()
+    with pytest.raises(DoorRefused, match="must be one of"):
+        doors.seed_meeting("1", "native-x", "T", [{"start": 0, "end": 1}], 0.0, source="rehearse")
+
+
+def test_the_desk_state_in_a_scaffold_is_an_object_not_a_string(catalog, env):
+    """`refs.state` is `{"desk": …, "group": …}`. Read as a string the check could never pass, so
+    it reported a product defect where the state had actually worked."""
+    doors = StubDoors()
+    res = rehearse("warm-desk-recurring", "rehearse-warm-desk-recurring@rehearse.test",
+                   doors=doors, catalog=catalog, env=env)
+    assert res.ok, [v for v in res.verify if not v["ok"]]
+    sc = next(iter(doors.scaffolds.values()))
+    assert isinstance(sc["refs"]["state"], dict)
+    assert sc["refs"]["state"]["desk"] == "warm"
+
+
+def test_a_wrong_desk_state_still_fails_the_check(catalog, env):
+    """The fix must not have turned the check off: a scaffold whose desk state is not what the
+    recipe declared is still a FAIL."""
+    class Pile(StubDoors):
+        def _desk_state(self, uid):                       # every desk reads as a pile
+            return "pile"
+    res = rehearse("warm-desk-recurring", "rehearse-warm-desk-recurring@rehearse.test",
+                   doors=Pile(), catalog=catalog, env=env)
+    bad = [v for v in res.verify if v["check"] == "scaffold_resolves"]
+    assert bad and not bad[0]["ok"]
+    assert "'pile', expected 'warm'" in bad[0]["detail"]
+
+
+def test_two_meeting_reports_alone_are_a_pile_not_a_warm_desk(catalog, env):
+    """The product's classifier, in its own words: meeting entities alone are a `pile` (decision
+    22's economics — reports landed, nobody wired them); it takes a non-meeting entity to be
+    `warm`. The recipe writes both rather than arguing with the classifier."""
+    doors = StubDoors()
+    rehearse("warm-desk-recurring", "rehearse-warm-desk-recurring@rehearse.test", doors=doors,
+             catalog=catalog, env=env)
+    kinds = [c[2] for c in doors.calls if c[0] == "desk_entity"]
+    assert kinds.count("meeting") == 2 and "person" in kinds
+
+
+def test_blank_admin_refuses_on_a_claimed_instance_which_is_the_live_answer(catalog, env):
+    """The live run's `blank-admin` failure is this refusal, and it is CORRECT: the dogfood stack
+    has an admin and a committed company layer. The state asserts that precondition; it never
+    creates it, because creating it means deleting every person on the stack."""
+    res = rehearse("blank-admin", "admin@rehearse.test", doors=StubDoors(blank=False),
+                   catalog=catalog, env=env)
+    assert not res.ok
+    assert "NOT blank" in res.error and "blank-instance.sh" in res.error
+
+
+# ── run 4's lesson: a rehearsal must leave NOTHING armed ─────────────────────────────────────────
+
+def test_every_state_that_drops_an_invite_disarms_its_bot_leg(catalog):
+    """`invite_intake` parks on `await_start` until start−2min and then dispatches a REAL bot at
+    the invite's URL. These states rehearse the PREPARE TOUCH; the bot leg is not what they
+    measure, and leaving it parked arms a live dispatch at a fixture Zoom URL that fires on the
+    clock long after the state was reported green.
+
+    It happened on 2026-09-02: meeting 115 reached `joining` at 19:20Z while the catalogue was
+    still running, because the run outlived a `+30m` start.
+    """
+    for name, st in catalog.states.items():
+        verbs = [step.do for step in st.steps]
+        if "drop_invite" not in verbs:
+            continue
+        assert "cancel_bot_leg" in verbs, f"{name} drops an invite and never disarms it"
+        assert verbs.index("cancel_bot_leg") > verbs.index("drop_invite"), name
+
+
+def test_the_default_start_cannot_be_reached_by_a_run_s_own_wall_clock():
+    """A floor, not the fix. Three states with a 677-segment import and an agent turn each ran for
+    well over half an hour; `+30m` put start−2min inside that window."""
+    from rehearse.engine import DEFAULT_WHEN, parse_when
+    assert parse_when(DEFAULT_WHEN, 0.0) >= 3 * 3600
+
+
+def test_the_state_actually_cancels_the_parked_reaction(catalog, env):
+    doors = StubDoors()
+    res = rehearse("organizer-invited", "rehearse-organizer-invited@rehearse.test", doors=doors,
+                   catalog=catalog, env=env)
+    assert res.ok, res.error
+    parked = [r for r in doors.reactions
+              if r["flow"] == "invite_intake" and r["state"] != "cancelled"]
+    assert not parked, f"the run left a parked invite reaction: {parked}"
+
+
+def test_a_cancel_that_is_refused_fails_the_state_rather_than_passing_quietly(catalog, env):
+    """The one outcome that must never be silent: a reaction we could not disarm is a bot that
+    will be dispatched."""
+    class NoCancel(StubDoors):
+        def cancel_bot_leg(self, flow, source_contains=""):
+            raise DoorRefused("cancelled 0, REFUSED ['r1:500']")
+    res = rehearse("organizer-invited", "rehearse-organizer-invited@rehearse.test",
+                   doors=NoCancel(), catalog=catalog, env=env)
+    assert not res.ok
+    assert "REFUSED" in res.error

--- a/deploy/dogfood/rehearse/tests/test_refusal_kind.py
+++ b/deploy/dogfood/rehearse/tests/test_refusal_kind.py
@@ -1,0 +1,119 @@
+'''A correct refusal is not a defect, and a malformed subject is the one account the address
+guard cannot reach.
+
+Both come from the same live run. `blank-admin` refused correctly on a claimed instance and was
+filed as a `blocker` (`fr_af253789b2780003`) — a non-problem at the top of the fixer's dump. And
+user 131 (`20260902t183213z`) was minted by `ensure_user` from a mis-parsed ICS, which
+`subject_reset` cannot clean because there is no domain to judge.
+'''
+from __future__ import annotations
+
+import pytest
+
+from rehearse import catalogue as cat
+from rehearse.doors import DoorRefused
+from rehearse.engine import (Refused, is_malformed, rehearse, subject_reset,
+                             subject_reset_malformed)
+from rehearse.stub_doors import StubDoors
+from rehearse import run_all as ra
+
+
+# ── a precondition that says no ─────────────────────────────────────────────────────────────────
+
+def test_the_precondition_verbs_are_declared_not_guessed_from_their_names():
+    assert cat.VERBS['require_instance_blank'].precondition
+    assert cat.VERBS['require_subject_absent'].precondition
+    assert not cat.VERBS['user_ensure'].precondition
+    assert not cat.VERBS['await_mail'].precondition
+
+
+def test_a_refused_precondition_marks_the_result_refused_not_merely_failed(catalog, env):
+    res = rehearse('blank-admin', 'admin@rehearse.test', doors=StubDoors(blank=False),
+                   catalog=catalog, env=env)
+    assert res.ok is False and res.refused is True
+    assert res.to_dict()['refused'] is True
+
+
+def test_a_door_that_says_no_is_NOT_a_refusal(catalog, env):
+    '''The distinction has to hold both ways, or it is just a second word for failure.'''
+    class NoMail(StubDoors):
+        def await_mail(self, to, subject_contains='', budget_s=180, since=0.0):
+            raise DoorRefused('no mail arrived')
+    res = rehearse('organizer-invited', 'x@rehearse.test', doors=NoMail(), catalog=catalog,
+                   env=env)
+    assert res.ok is False and res.refused is False
+
+
+def test_run_all_files_a_refusal_as_kind_refused_and_not_a_blocker(catalog, env, tmp_path,
+                                                                   monkeypatch):
+    monkeypatch.setattr(ra, 'FRICTION_FALLBACK', tmp_path / 'f.jsonl')
+    filed = []
+    report = ra.run(StubDoors(blank=False), catalog=catalog, env=env, only=['blank-admin'],
+                    reporter=filed.append)
+    rec = filed[0]
+    assert rec['kind'] == 'refused'
+    assert rec['severity'] != 'blocker'
+    assert 'PRECONDITION, not a defect' in rec['what_went_wrong']
+
+
+def test_a_refusal_is_counted_apart_from_a_failure(catalog, env, tmp_path, monkeypatch):
+    '''`failed` is what somebody has to fix. Counting a precondition there makes the number mean
+    something other than what a reader assumes.'''
+    monkeypatch.setattr(ra, 'FRICTION_FALLBACK', tmp_path / 'f.jsonl')
+    report = ra.run(StubDoors(blank=False), catalog=catalog, env=env, only=['blank-admin'])
+    assert report['failed'] == []
+    assert report['refused'] == ['blank-admin']
+    assert 'SKIP' in ra.render(report)
+    assert 'precondition, not a defect' in ra.render(report)
+
+
+# ── the malformed subject ───────────────────────────────────────────────────────────────────────
+
+@pytest.mark.parametrize('email,malformed', [
+    ('20260902t183213z', True),          # THE ONE — user 131, an invite's DTSTAMP
+    ('', True),
+    ('someone@localhost', True),
+    ('a b@rehearse.test', True),
+    ('dmitry@vexa.ai', False),
+    ('rehearse-group-member@rehearse.test', False),
+])
+def test_malformed_means_no_person_could_be_named_by_it(email, malformed):
+    assert is_malformed(email) is malformed
+
+
+def test_a_malformed_account_is_reset_by_id():
+    doors = StubDoors()
+    doors.users['20260902t183213z'] = '131'
+    doors.desks['131'] = ['README.md']
+    out = subject_reset_malformed('131', doors=doors)
+    assert out['ok'], out['remaining']
+    assert out['by'] == 'id'
+    assert doors.user_find('20260902t183213z') is None
+
+
+@pytest.mark.parametrize('email', ['dmitry@vexa.ai', 'rehearse-x@rehearse.test'])
+def test_a_WELL_FORMED_address_is_refused_by_the_by_id_path(email):
+    '''The bound that makes this safe: a real person's address is well-formed, so this path can
+    never reach one. It is a narrower rule, not a domain exemption.'''
+    doors = StubDoors()
+    doors.users[email] = '126'
+    doors.desks['126'] = ['README.md']
+    with pytest.raises(Refused, match='well-formed address'):
+        subject_reset_malformed('126', doors=doors)
+    assert doors.user_find(email) == '126' and doors.desks['126']
+
+
+def test_subject_reset_still_refuses_the_malformed_address_by_name():
+    '''The address path is unchanged — it cannot judge a value with no domain, so it says no.'''
+    doors = StubDoors()
+    doors.users['20260902t183213z'] = '131'
+    with pytest.raises(Refused):
+        subject_reset('20260902t183213z', doors=doors)
+
+
+def test_both_paths_run_the_SAME_removal_sequence():
+    '''One rulebook: two spellings of a reset is how the second one ends up weaker.'''
+    import inspect
+    from rehearse import engine
+    for fn in (engine.subject_reset, engine.subject_reset_malformed):
+        assert '_reset_stores' in inspect.getsource(fn)

--- a/deploy/dogfood/rehearse/tests/test_reset.py
+++ b/deploy/dogfood/rehearse/tests/test_reset.py
@@ -1,0 +1,119 @@
+"""`subject_reset` — one subject gone, the instance untouched, and the emptiness READ BACK."""
+from __future__ import annotations
+
+import pytest
+
+from rehearse.doors import DoorRefused
+from rehearse.engine import Refused, rehearse, subject_reset
+from rehearse.stub_doors import StubDoors
+
+WHO = "rehearse-organizer-invited@rehearse.test"
+
+
+def _entered(catalog, env):
+    doors = StubDoors()
+    rehearse("organizer-invited", WHO, doors=doors, catalog=catalog, env=env)
+    return doors
+
+
+def test_it_removes_the_user_the_desk_the_scaffolds_and_the_mail(catalog, env):
+    doors = _entered(catalog, env)
+    uid = doors.user_find(WHO)
+    assert uid and doors.desk_tree(uid) and doors.mail
+    out = subject_reset(WHO, doors=doors, catalog=catalog, env=env)
+    assert out["ok"], out["remaining"]
+    assert doors.user_find(WHO) is None
+    assert doors.desk_tree(uid) == []
+    assert not [m for m in doors.mail if WHO in m["to"]]
+    assert not [s for s in doors.scaffolds.values() if s["who"] == WHO]
+
+
+def test_it_leaves_every_other_subject_exactly_where_it_found_them(catalog, env):
+    doors = _entered(catalog, env)
+    rehearse("group-member", "rehearse-group-member@rehearse.test", doors=doors, catalog=catalog,
+             env=env)
+    before = {a: u for a, u in doors.users.items() if a != WHO}
+    desks_before = {k: list(v) for k, v in doors.desks.items()}
+    subject_reset(WHO, doors=doors, catalog=catalog, env=env)
+    assert {a: u for a, u in doors.users.items()} == before
+    gone_uid = {k for k in desks_before if k not in doors.desks}
+    assert len(gone_uid) == 1, "exactly one desk may disappear — the subject's"
+
+
+def test_it_is_a_no_op_on_a_subject_that_was_never_there(catalog, env):
+    doors = StubDoors()
+    out = subject_reset("never-existed@rehearse.test", doors=doors, catalog=catalog, env=env)
+    assert out["ok"] and out["uid"] is None
+
+
+def test_it_refuses_a_non_test_domain_before_touching_anything(catalog, env):
+    doors = StubDoors()
+    doors.users["dmitry@vexa.ai"] = "126"
+    doors.desks["126"] = ["README.md"]
+    with pytest.raises(Refused):
+        subject_reset("dmitry@vexa.ai", doors=doors, catalog=catalog, env=env)
+    assert doors.users["dmitry@vexa.ai"] == "126" and doors.desks["126"]
+
+
+def test_a_door_that_cannot_delete_is_REPORTED_not_swallowed(catalog, env):
+    """A reset that half worked and said "done" is the ledger's phantom `_global` write, one
+    layer down. `ok` is false and `remaining` names the door."""
+    class NoUserDelete(StubDoors):
+        def user_delete(self, uid):
+            raise DoorRefused("admin-api has no DELETE /admin/users/{id} on the running image")
+    doors = NoUserDelete()
+    rehearse("organizer-invited", WHO, doors=doors, catalog=catalog, env=env)
+    out = subject_reset(WHO, doors=doors, catalog=catalog, env=env)
+    assert out["ok"] is False
+    assert "DELETE /admin/users" in out["remaining"]["user"]
+    assert out["remaining"]["user_still_exists"], "the read-back is what proves it, not the call"
+
+
+def test_the_state_can_be_re_entered_immediately_after_a_reset(catalog, env):
+    """The point of decision 38.3: a state re-entered in seconds, the instance never blanked.
+
+    `fresh=True` resets the room the recipe owns — the subject and the organizer derived from
+    them. Both are needed: the fact's id names the meeting row, and that row belongs to the
+    organizer, so resetting only the subject would leave the fact deduping the re-entry away and
+    the state would look entered while producing no touch at all.
+    """
+    doors = StubDoors()
+    who = "rehearse-attendee-stranger-minutes@rehearse.test"
+    first = rehearse("attendee-stranger-minutes", who, doors=doors, catalog=catalog, env=env)
+    assert first.ok
+    assert not rehearse("attendee-stranger-minutes", who, doors=doors, catalog=catalog,
+                        env=env).ok
+    again = rehearse("attendee-stranger-minutes", who, doors=doors, catalog=catalog, env=env,
+                     fresh=True)
+    assert again.ok, again.error
+    assert again.links and again.links != {}, "a re-entered state must produce a NEW touch"
+
+
+def test_fresh_resets_the_organizer_too_or_the_fact_would_dedup_the_touch_away(catalog, env):
+    """The lane's dedup memory is the thing that has to go, and it belongs to BOTH people.
+
+    `admit()` dedups on (source_event_id, flow) and a rehearsal's ids are derived from
+    (state, subject, meeting) — deliberately, so a plain re-run is idempotent. The cost is that a
+    re-entry needs the earlier row cleared, and the meeting the fact names belongs to the ORGANIZER
+    the recipe derives, not to the subject. Reset only the subject and the fact is swallowed as a
+    duplicate: no touch is sent, and the step waits out its budget for a mail nothing will produce.
+    That is what the sim lane logged as `admitted 0`.
+    """
+    doors = StubDoors()
+    who = "rehearse-attendee-stranger-minutes@rehearse.test"
+    first = rehearse("attendee-stranger-minutes", who, doors=doors, catalog=catalog, env=env)
+    organizer = f"organizer-{who.split('@')[0]}@rehearse.test"
+    assert first.ok and doors.user_find(organizer)
+    stale = [f["source_event_id"] for f in doors.facts]
+    assert stale
+
+    again = rehearse("attendee-stranger-minutes", who, doors=doors, catalog=catalog, env=env,
+                     fresh=True)
+    assert again.ok, again.error
+    assert again.links, "a re-entered state must produce a touch, not a deduped silence"
+    # ONE fact in the lane, not two: the earlier one went with the organizer's reset, and the
+    # re-entry admitted its own. Its id differs because it names the meeting ROW, which is new —
+    # both halves matter, and either alone would let the touch be swallowed as a duplicate.
+    fresh_ids = [f["source_event_id"] for f in doors.facts]
+    assert len(fresh_ids) == 1, f"the stale fact survived the reset: {fresh_ids}"
+    assert fresh_ids != stale

--- a/deploy/dogfood/rehearse/tests/test_run_all.py
+++ b/deploy/dogfood/rehearse/tests/test_run_all.py
@@ -1,0 +1,115 @@
+"""`run_all` — the catalogue as the test, and what it does with a state that breaks."""
+from __future__ import annotations
+
+from rehearse import run_all
+from rehearse.doors import DoorRefused
+from rehearse.stub_doors import StubDoors
+
+
+def test_the_whole_catalogue_is_green_offline(catalog, env):
+    report = run_all.run(StubDoors(), catalog=catalog, env=env)
+    assert report["failed"] == [], report["states"]
+    assert report["ran"] == len(catalog.states) == report["passed"]
+
+
+def test_it_reports_pass_fail_wall_time_and_the_link_per_state(catalog, env):
+    report = run_all.run(StubDoors(), catalog=catalog, env=env)
+    for row in report["states"]:
+        assert set(("state", "as", "ok", "wall_s", "link")) <= set(row)
+        assert row["wall_s"] >= 0
+        assert row["link"].startswith("http"), row
+
+
+def test_it_clicks_nothing(catalog, env):
+    """Whether the link WORKS when a person clicks it is a walk, and a founder's judgment. What a
+    suite can prove is everything up to the click."""
+    doors = StubDoors()
+    run_all.run(doors, catalog=catalog, env=env)
+    assert not any(c[0].startswith("redeem") or c[0].startswith("click") for c in doors.calls)
+
+
+def test_a_broken_state_fails_and_is_filed_as_friction(catalog, env):
+    class NoMail(StubDoors):
+        def await_mail(self, to, subject_contains="", budget_s=180, since=0.0):
+            raise DoorRefused("no mail to that address arrived within 180s")
+
+    filed = []
+    report = run_all.run(NoMail(), catalog=catalog, env=env, reporter=filed.append)
+    assert report["failed"], "every state ends at a mail; none of them can pass here"
+    assert len(filed) == len(report["failed"])
+    rec = filed[0]
+    assert rec["severity"] == "blocker" and rec["tool"] == "rehearse"
+    assert "no mail" in rec["what_went_wrong"]
+    # The repro line is the whole value of the record: a fixing agent must be able to re-enter the
+    # state without asking anybody how.
+    assert "python -m rehearse.run_all --only" in rec["what_would_have_helped"]
+    assert report["friction"][0]["filed"] is True
+
+
+def test_a_friction_intake_that_is_down_does_not_lose_the_finding(catalog, env):
+    def broken(_rec):
+        raise RuntimeError("friction intake answered 503")
+
+    class NoMail(StubDoors):
+        def await_mail(self, to, subject_contains="", budget_s=180, since=0.0):
+            raise DoorRefused("no mail arrived")
+    report = run_all.run(NoMail(), catalog=catalog, env=env, reporter=broken)
+    assert report["failed"]
+    assert report["friction"][0]["filed"] is False
+    assert "503" in report["friction"][0]["file_error"]
+
+
+def test_only_runs_the_states_named(catalog, env):
+    report = run_all.run(StubDoors(), catalog=catalog, env=env, only=["reply-pending"])
+    assert [r["state"] for r in report["states"]] == ["reply-pending"]
+
+
+def test_the_rendered_report_names_every_state_and_the_score(catalog, env):
+    text = run_all.render(run_all.run(StubDoors(), catalog=catalog, env=env))
+    for name in catalog.states:
+        assert name in text
+    assert f"{len(catalog.states)}/{len(catalog.states)} states green" in text
+
+
+# ── a finding must survive an intake that is not there ───────────────────────────────────────────
+
+def test_a_finding_lands_on_disk_even_when_the_intake_is_missing(catalog, env, tmp_path,
+                                                                 monkeypatch):
+    """`POST /api/friction` is not on the deployed agent-api image yet (#1412), so every record
+    404'd on the first live run. A finding that exists only in a 404 is a finding nobody has —
+    and a 404 is never allowed to read as a pass."""
+    import json as _json
+
+    from rehearse import run_all as ra
+    log = tmp_path / "friction.jsonl"
+    monkeypatch.setattr(ra, "FRICTION_FALLBACK", log)
+
+    def intake_404(_rec):
+        raise RuntimeError("friction intake answered 404: {'detail': 'Not Found'}")
+
+    class NoMail(StubDoors):
+        def await_mail(self, to, subject_contains="", budget_s=180, since=0.0):
+            raise DoorRefused("no mail arrived")
+
+    report = ra.run(NoMail(), catalog=catalog, env=env, reporter=intake_404)
+    assert report["failed"], "a refused intake must not turn a red run green"
+    assert all(f["filed"] is False for f in report["friction"])
+    rows = [_json.loads(ln) for ln in log.read_text().splitlines()]
+    assert len(rows) == len(report["friction"])
+    assert {r["state"] for r in rows} == set(report["failed"])
+    assert all("python -m rehearse.run_all --only" in r["what_would_have_helped"] for r in rows)
+
+
+def test_the_rendered_report_says_the_intake_refused_and_where_the_records_went(catalog, env,
+                                                                                tmp_path,
+                                                                                monkeypatch):
+    from rehearse import run_all as ra
+    monkeypatch.setattr(ra, "FRICTION_FALLBACK", tmp_path / "friction.jsonl")
+
+    class NoMail(StubDoors):
+        def await_mail(self, to, subject_contains="", budget_s=180, since=0.0):
+            raise DoorRefused("no mail arrived")
+
+    text = ra.render(ra.run(NoMail(), catalog=catalog, env=env,
+                            reporter=lambda _r: (_ for _ in ()).throw(RuntimeError("404"))))
+    assert "written to" in text and "the intake refused them" in text

--- a/deploy/dogfood/rehearse/tests/test_runner.py
+++ b/deploy/dogfood/rehearse/tests/test_runner.py
@@ -1,0 +1,105 @@
+"""`rehearse(..., runner=…)` — the harness is a per-subject dial (PRD decisions 37 + 38).
+
+THE CHAIN THIS FILE OWNS HALF OF. A rehearsed state on Qwen has to end with a worker whose env
+reads `VEXA_RUNNER=openai-agent` and whose model is `qwen3.8-27b`, and that runs through two
+services:
+
+    rehearse(runner=…)  →  PUT /admin/users/{id}/models   ← THIS FILE: the exact config, on the
+                                                            scratch subject and on nobody else
+    that config         →  worker env                     ← core/agent/tests/test_runner_per_subject.py
+
+Neither half can prove the other, and a test that mocked across the seam would prove nothing at
+all. So each half asserts the same literal config, and the two docstrings name each other.
+"""
+from __future__ import annotations
+
+import pytest
+
+from rehearse.doors import RUNNER_DIALS, DoorRefused, runner_config
+from rehearse.engine import Refused, rehearse
+from rehearse.stub_doors import StubDoors
+
+QWEN = {"runner": "openai-agent", "mode": "custom",
+        "base_url": "http://192.168.1.6:8001/v1", "model": "qwen3.8-27b",
+        "extra_body": '{"chat_template_kwargs":{"enable_thinking":false}}'}
+
+
+def test_the_qwen_dials_are_exactly_what_the_worker_half_expects():
+    """The literal `core/agent/tests/test_runner_per_subject.py` feeds to `overlay_model_config`."""
+    assert runner_config("openai-agent") == QWEN
+
+
+def test_an_unknown_runner_is_refused_with_the_names_that_work():
+    with pytest.raises(DoorRefused, match="not a runner this tool knows"):
+        runner_config("qwen-magic")
+    assert "openai-agent" in str(RUNNER_DIALS)
+
+
+def test_the_name_is_refused_before_a_single_door_is_touched(catalog, env):
+    doors = StubDoors()
+    with pytest.raises(DoorRefused):
+        rehearse("organizer-invited", "x@rehearse.test", doors=doors, catalog=catalog, env=env,
+                 runner="typo-agent")
+    assert doors.calls == []
+
+
+def test_every_subject_the_recipe_resolves_is_bound_and_nobody_else(catalog, env):
+    doors = StubDoors()
+    doors.users["dmitry@vexa.ai"] = "126"          # the founder, already on the instance
+    who = "rehearse-group-member@rehearse.test"
+    res = rehearse("group-member", who, doors=doors, catalog=catalog, env=env,
+                   runner="openai-agent")
+    assert res.ok, res.error
+    bound = set(doors.runners)
+    assert bound == {doors.user_find(who), doors.user_find(f"organizer-{who.split('@')[0]}@rehearse.test")}
+    assert "126" not in bound, "the founder's dispatches must be untouched"
+    assert all(cfg == QWEN for cfg in doors.runners.values())
+
+
+def test_the_binding_happens_before_anything_could_dispatch_for_that_subject(catalog, env):
+    """Binding after the steps would leave the turns the recipe itself triggers — the post-meeting
+    run, the prepare compose — on the deployment's default, which is the thing being measured."""
+    doors = StubDoors()
+    rehearse("reply-pending", "rehearse-reply-pending@rehearse.test", doors=doors, catalog=catalog,
+             env=env, runner="openai-agent")
+    kinds = [c[0] for c in doors.calls]
+    assert kinds.index("bind_runner") < kinds.index("emit_fact")
+
+
+def test_no_runner_binds_nothing(catalog, env):
+    doors = StubDoors()
+    res = rehearse("organizer-invited", "x@rehearse.test", doors=doors, catalog=catalog, env=env)
+    assert res.ok and doors.runners == {}
+
+
+def test_claude_code_clears_the_custom_dials_rather_than_leaving_them_set():
+    """Naming the deployment's own harness must UNSET the endpoint and the model, not just the
+    runner — a subject left pointing at Qwen while claiming to run the default is worse than one
+    that was never rebound. Empty strings are admin-api's clear."""
+    cfg = runner_config("claude-code")
+    assert cfg["runner"] == "claude-code"
+    assert cfg["base_url"] == "" and cfg["model"] == "" and cfg["extra_body"] == ""
+
+
+def test_the_endpoint_is_a_deployment_fact_not_a_constant(monkeypatch):
+    """A different Qwen box, or a different model, is an env var — never an edit to this package."""
+    monkeypatch.setenv("VEXA_REHEARSE_LLM_BASE_URL", "http://10.0.0.9:8001/v1")
+    monkeypatch.setenv("VEXA_REHEARSE_LLM_MODEL", "qwen3.8-72b")
+    import importlib
+
+    from rehearse import doors as doors_mod
+    importlib.reload(doors_mod)
+    try:
+        cfg = doors_mod.runner_config("openai-agent")
+        assert cfg["base_url"] == "http://10.0.0.9:8001/v1"
+        assert cfg["model"] == "qwen3.8-72b"
+    finally:
+        monkeypatch.undo()
+        importlib.reload(doors_mod)
+
+
+def test_a_runner_binding_still_refuses_a_real_address(catalog, env):
+    """The domain guard runs first and is not weakened by the new argument."""
+    with pytest.raises(Refused):
+        rehearse("organizer-invited", "dmitry@vexa.ai", doors=StubDoors(), catalog=catalog,
+                 env=env, runner="openai-agent")

--- a/deploy/dogfood/rehearse/tests/test_since.py
+++ b/deploy/dogfood/rehearse/tests/test_since.py
@@ -1,0 +1,190 @@
+"""A touch is evidence only if it is THIS run's touch — run 2's lesson, held as a test.
+
+`await_mail` had no floor, so it matched a message an earlier run had sent. On the sim lane that
+made `warm-desk-recurring` verify run 1's Prepare mail and run 1's scaffold, and report on a state
+run 2 had not produced. It looked like a product defect (`desk state 'pile', expected 'warm'`) and
+it was a reader accepting stale evidence — the same class as a hash comparison that goes stale, and
+the reason the doctrine is *positive evidence*, never inequality against a remembered value.
+"""
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from rehearse.doors import DoorRefused
+from rehearse.engine import rehearse, subject_reset
+from rehearse.stub_doors import StubDoors
+
+WHO = "rehearse-organizer-invited@rehearse.test"
+
+
+def test_a_previous_run_s_mail_is_not_this_run_s_evidence(catalog, env):
+    """The reproduction. The mail is there, addressed correctly, with the right subject — and it
+    is old, so the step must keep waiting rather than accept it."""
+    class SilentInvite(StubDoors):
+        """The invite lands but the lane sends nothing back — a parked or broken flow. The ONLY
+        candidate for `await_mail` is then the stale message, which is the whole point."""
+        def drop_invite(self, organizer, title, start, attendees=(), ics_uid="", group="",
+                        url=""):
+            return {"ics_uid": ics_uid, "to": "vexa@sim.test", "organizer": organizer,
+                    "start": start, "attendees": [a for _, a in attendees]}
+
+    doors = SilentInvite()
+    doors._send(WHO, "Prepare: DNA TSC 2026-03-02", "an earlier run's touch")
+    doors.mail[-1]["at"] = time.time() - 3600
+    res = rehearse("organizer-invited", WHO, doors=doors, catalog=catalog, env=env)
+    assert not res.ok
+    assert "no mail" in res.error
+
+
+def test_a_fresh_touch_in_the_same_run_is_accepted(catalog, env):
+    res = rehearse("organizer-invited", WHO, doors=StubDoors(), catalog=catalog, env=env)
+    assert res.ok, res.error
+
+
+def test_the_floor_is_the_run_s_own_start_not_the_process_s(catalog, env):
+    """Two runs back to back: the second must verify the second's mail, not the first's."""
+    doors = StubDoors()
+    first = rehearse("organizer-invited", WHO, doors=doors, catalog=catalog, env=env)
+    second = rehearse("organizer-invited", WHO, doors=doors, catalog=catalog, env=env)
+    assert first.ok and second.ok
+    assert first.mails[0]["id"] != second.mails[0]["id"], (
+        "the second run verified the first run's mail — the floor did not move")
+
+
+def test_subject_reset_removes_the_meetings_that_would_block_re_entry(catalog, env):
+    """Run 2's other lesson. A run that fails BETWEEN `POST /meetings` and the import leaves a
+    non-terminal row, and the next attempt is refused — correctly — with a 409. Nothing else on
+    today's stack clears it: `DELETE /admin/users/{id}` is not on the running admin-api image."""
+    doors = StubDoors()
+    rehearse("reply-pending", "rehearse-reply-pending@rehearse.test", doors=doors,
+             catalog=catalog, env=env)
+    assert doors.meetings
+    out = subject_reset("rehearse-reply-pending@rehearse.test", doors=doors, catalog=catalog,
+                        env=env)
+    assert out["removed"]["meetings"] >= 1
+    assert doors.meetings == {}
+
+
+def test_it_only_removes_that_subject_s_meetings(catalog, env):
+    doors = StubDoors()
+    rehearse("reply-pending", "rehearse-reply-pending@rehearse.test", doors=doors,
+             catalog=catalog, env=env)
+    rehearse("group-member", "rehearse-group-member@rehearse.test", doors=doors, catalog=catalog,
+             env=env)
+    before = len(doors.meetings)
+    subject_reset("rehearse-reply-pending@rehearse.test", doors=doors, catalog=catalog, env=env)
+    assert 0 < len(doors.meetings) < before
+
+
+def test_a_meeting_delete_that_refuses_is_reported_not_swallowed(catalog, env):
+    class NoDelete(StubDoors):
+        def meetings_delete_for(self, subject):
+            raise DoorRefused("the gateway refused DELETE /meetings/{id}")
+    doors = NoDelete()
+    rehearse("reply-pending", "rehearse-reply-pending@rehearse.test", doors=doors,
+             catalog=catalog, env=env)
+    out = subject_reset("rehearse-reply-pending@rehearse.test", doors=doors, catalog=catalog,
+                        env=env)
+    assert out["ok"] is False
+    assert "DELETE /meetings" in out["remaining"]["meetings"]
+
+
+# ── run 2's third lesson: a refusal is not an empty list ─────────────────────────────────────────
+
+def test_the_meetings_list_never_reads_a_refusal_as_no_meetings():
+    """`GET /meetings` caps `limit` at 100 and answers 422 above it. The list was requested with
+    `?limit=200`, and both readers did `(b or {}).get("meetings", [])` — so the 422's `{"detail":
+    …}` became "this person has no meetings".
+
+    `subject_reset` then reported `meetings: 0` with a row sitting right there, and the next run of
+    that state was refused with a 409 nobody could explain. The other reader is worse:
+    `seed_meeting` asks it whether a completed row already exists, so a swallowed refusal would
+    have minted a SECOND completed meeting and mailed the whole room twice.
+    """
+    import ast
+    import inspect
+
+    from rehearse import doors
+
+    # Read the CODE, not the prose: the fix's own docstring quotes `?limit=200` as the defect, and
+    # a grep over source text cannot tell an explanation from an instruction.
+    tree = ast.parse(inspect.getsource(doors))
+    docstrings = set()
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.Module, ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)):
+            first = (node.body or [None])[0]
+            if isinstance(first, ast.Expr) and isinstance(first.value, ast.Constant):
+                docstrings.add(id(first.value))
+    for node in ast.walk(tree):
+        if (isinstance(node, ast.Constant) and isinstance(node.value, str)
+                and id(node) not in docstrings):
+            assert "/meetings?limit=200" not in node.value, (
+                "a meetings request still asks for more than that route's cap")
+    assert doors.MEETINGS_PAGE_MAX == 100, "the route's own cap, not a number we prefer"
+
+    # Exactly one place reads that list, and it RAISES rather than defaulting to empty.
+    assert "raise DoorRefused" in inspect.getsource(doors.LiveDoors._meetings_of)
+    for reader in (doors.LiveDoors._find_meeting, doors.LiveDoors.meetings_delete_for):
+        body = inspect.getsource(reader)
+        assert "_meetings_of" in body
+        assert '.get("meetings", [])' not in body
+
+
+def test_a_meeting_that_refused_deletion_is_not_counted_as_deleted(catalog, env):
+    """`meetings_delete_for` returned a count, and a count cannot say "one of these did not go".
+    A delete that did not happen must reach `remaining`, or the next run meets a 409."""
+    import inspect
+
+    from rehearse import doors
+    src = inspect.getsource(doors.LiveDoors.meetings_delete_for)
+    assert "refused" in src and "raise DoorRefused" in src
+
+
+# ── run 4: the filter rejected the mail it then named in its own refusal ─────────────────────────
+
+@pytest.mark.parametrize('created,ok', [
+    ('2026-09-02T18:50:41.503Z', True),
+    ('2026-09-02T18:50:41.5Z', True),        # Go trims trailing zeros — .5Z beside .503Z
+    ('2026-09-02T18:50:41Z', True),
+    ('2026-09-02T18:50:41.503123456Z', True),  # RFC3339Nano, more digits than %f takes
+    ('2026-09-02T18:50:41+02:00', True),
+    ('', False),
+    ('not a timestamp', False),
+])
+def test_mailpit_stamps_parse_and_an_unreadable_one_is_None_not_zero(created, ok):
+    '''NONE IS NOT ZERO. It returned 0.0 on an unparseable stamp and the caller filtered
+    `epoch < since`, so every message read as older than the run — run 4 failed three states
+    while listing, in its own refusal, the mail it had just discarded.'''
+    from rehearse.doors import _mail_epoch
+    got = _mail_epoch({'Created': created})
+    assert (got is not None) is ok
+    if ok:
+        assert got > 1_000_000_000
+
+
+def test_a_message_we_cannot_place_in_time_is_INCLUDED_not_dropped():
+    '''A false accept is a check that needs tightening; a false reject is a touch reported as
+    never sent. The second is the one that wastes a person's afternoon.'''
+    import time as _t
+
+    from rehearse.doors import LiveDoors
+    import rehearse.doors as D
+
+    calls = []
+    def fake_http(method, url, headers=None, body=None, timeout=40):
+        calls.append(url)
+        if '/search' in url:
+            return 200, {'messages': [{'ID': 'm1', 'Subject': 'Prepare: X', 'Created': 'garbage'}]}
+        return 200, {'Subject': 'Prepare: X', 'To': [{'Address': 'a@rehearse.test'}],
+                     'From': {'Address': 'v@sim.test'}, 'MessageID': '<x@y>', 'Text': 'body',
+                     'HTML': ''}
+    old = D._http
+    D._http = fake_http
+    try:
+        d = LiveDoors.__new__(LiveDoors)
+        msg = LiveDoors.await_mail(d, 'a@rehearse.test', 'Prepare', budget_s=5, since=_t.time())
+        assert msg['subject'] == 'Prepare: X'
+    finally:
+        D._http = old

--- a/deploy/dogfood/rehearse/uv.lock
+++ b/deploy/dogfood/rehearse/uv.lock
@@ -1,0 +1,138 @@
+version = 1
+revision = 3
+requires-python = ">=3.11"
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/fa/3944b40b07da9ce895c0e6303a5ab7d53da063554f534556b134a54d6093/packaging-26.3.tar.gz", hash = "sha256:94edc256424af38762eb31306eed28beb9f0efc50a8837492c9d6fd6004aed79", size = 313412, upload-time = "2026-08-04T18:15:28.737Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/63/34/ba1c580383c9eada3711951fef0795c80b829a078d72188184bcab9dd527/packaging-26.3-py3-none-any.whl", hash = "sha256:d7193f7c8e4e93f444fde0262bf90af30e16fa0ad0ad44cb553c87339b23cd1c", size = 129956, upload-time = "2026-08-04T18:15:27.159Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.21.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/49/2e/ced460408999b33da6b31b0021b0f37d329e202d4169aeb164493778f25b/pygments-2.21.0.tar.gz", hash = "sha256:610ca751c9bc2492b38eb9a38a7fbc93edbbb2d7182edaf34e66ae493dee5c8c", size = 5005329, upload-time = "2026-08-17T08:02:48.824Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/46/17f022dd3e953bf20a04a028a21ec746d942f8d2af30fa0f124fa0e6a684/pygments-2.21.0-py3-none-any.whl", hash = "sha256:2363c69b61c4a97c838da3b130dcd6468f4848992b21a82f2a63ec34377137d9", size = 1250147, upload-time = "2026-08-17T08:02:44.912Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
+]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6d/16/a95b6757765b7b031c9374925bb718d55e0a9ba8a1b6a12d25962ea44347/pyyaml-6.0.3-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:44edc647873928551a01e7a563d7452ccdebee747728c1080d881d68af7b997e", size = 185826, upload-time = "2025-09-25T21:31:58.655Z" },
+    { url = "https://files.pythonhosted.org/packages/16/19/13de8e4377ed53079ee996e1ab0a9c33ec2faf808a4647b7b4c0d46dd239/pyyaml-6.0.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:652cb6edd41e718550aad172851962662ff2681490a8a711af6a4d288dd96824", size = 175577, upload-time = "2025-09-25T21:32:00.088Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/62/d2eb46264d4b157dae1275b573017abec435397aa59cbcdab6fc978a8af4/pyyaml-6.0.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:10892704fc220243f5305762e276552a0395f7beb4dbf9b14ec8fd43b57f126c", size = 775556, upload-time = "2025-09-25T21:32:01.31Z" },
+    { url = "https://files.pythonhosted.org/packages/10/cb/16c3f2cf3266edd25aaa00d6c4350381c8b012ed6f5276675b9eba8d9ff4/pyyaml-6.0.3-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:850774a7879607d3a6f50d36d04f00ee69e7fc816450e5f7e58d7f17f1ae5c00", size = 882114, upload-time = "2025-09-25T21:32:03.376Z" },
+    { url = "https://files.pythonhosted.org/packages/71/60/917329f640924b18ff085ab889a11c763e0b573da888e8404ff486657602/pyyaml-6.0.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b8bb0864c5a28024fac8a632c443c87c5aa6f215c0b126c449ae1a150412f31d", size = 806638, upload-time = "2025-09-25T21:32:04.553Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/6f/529b0f316a9fd167281a6c3826b5583e6192dba792dd55e3203d3f8e655a/pyyaml-6.0.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:1d37d57ad971609cf3c53ba6a7e365e40660e3be0e5175fa9f2365a379d6095a", size = 767463, upload-time = "2025-09-25T21:32:06.152Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/6a/b627b4e0c1dd03718543519ffb2f1deea4a1e6d42fbab8021936a4d22589/pyyaml-6.0.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:37503bfbfc9d2c40b344d06b2199cf0e96e97957ab1c1b546fd4f87e53e5d3e4", size = 794986, upload-time = "2025-09-25T21:32:07.367Z" },
+    { url = "https://files.pythonhosted.org/packages/45/91/47a6e1c42d9ee337c4839208f30d9f09caa9f720ec7582917b264defc875/pyyaml-6.0.3-cp311-cp311-win32.whl", hash = "sha256:8098f252adfa6c80ab48096053f512f2321f0b998f98150cea9bd23d83e1467b", size = 142543, upload-time = "2025-09-25T21:32:08.95Z" },
+    { url = "https://files.pythonhosted.org/packages/da/e3/ea007450a105ae919a72393cb06f122f288ef60bba2dc64b26e2646fa315/pyyaml-6.0.3-cp311-cp311-win_amd64.whl", hash = "sha256:9f3bfb4965eb874431221a3ff3fdcddc7e74e3b07799e0e84ca4a0f867d449bf", size = 158763, upload-time = "2025-09-25T21:32:09.96Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/33/422b98d2195232ca1826284a76852ad5a86fe23e31b009c9886b2d0fb8b2/pyyaml-6.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7f047e29dcae44602496db43be01ad42fc6f1cc0d8cd6c83d342306c32270196", size = 182063, upload-time = "2025-09-25T21:32:11.445Z" },
+    { url = "https://files.pythonhosted.org/packages/89/a0/6cf41a19a1f2f3feab0e9c0b74134aa2ce6849093d5517a0c550fe37a648/pyyaml-6.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fc09d0aa354569bc501d4e787133afc08552722d3ab34836a80547331bb5d4a0", size = 173973, upload-time = "2025-09-25T21:32:12.492Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/23/7a778b6bd0b9a8039df8b1b1d80e2e2ad78aa04171592c8a5c43a56a6af4/pyyaml-6.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9149cad251584d5fb4981be1ecde53a1ca46c891a79788c0df828d2f166bda28", size = 775116, upload-time = "2025-09-25T21:32:13.652Z" },
+    { url = "https://files.pythonhosted.org/packages/65/30/d7353c338e12baef4ecc1b09e877c1970bd3382789c159b4f89d6a70dc09/pyyaml-6.0.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5fdec68f91a0c6739b380c83b951e2c72ac0197ace422360e6d5a959d8d97b2c", size = 844011, upload-time = "2025-09-25T21:32:15.21Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/9d/b3589d3877982d4f2329302ef98a8026e7f4443c765c46cfecc8858c6b4b/pyyaml-6.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc", size = 807870, upload-time = "2025-09-25T21:32:16.431Z" },
+    { url = "https://files.pythonhosted.org/packages/05/c0/b3be26a015601b822b97d9149ff8cb5ead58c66f981e04fedf4e762f4bd4/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8dc52c23056b9ddd46818a57b78404882310fb473d63f17b07d5c40421e47f8e", size = 761089, upload-time = "2025-09-25T21:32:17.56Z" },
+    { url = "https://files.pythonhosted.org/packages/be/8e/98435a21d1d4b46590d5459a22d88128103f8da4c2d4cb8f14f2a96504e1/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:41715c910c881bc081f1e8872880d3c650acf13dfa8214bad49ed4cede7c34ea", size = 790181, upload-time = "2025-09-25T21:32:18.834Z" },
+    { url = "https://files.pythonhosted.org/packages/74/93/7baea19427dcfbe1e5a372d81473250b379f04b1bd3c4c5ff825e2327202/pyyaml-6.0.3-cp312-cp312-win32.whl", hash = "sha256:96b533f0e99f6579b3d4d4995707cf36df9100d67e0c8303a0c55b27b5f99bc5", size = 137658, upload-time = "2025-09-25T21:32:20.209Z" },
+    { url = "https://files.pythonhosted.org/packages/86/bf/899e81e4cce32febab4fb42bb97dcdf66bc135272882d1987881a4b519e9/pyyaml-6.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:5fcd34e47f6e0b794d17de1b4ff496c00986e1c83f7ab2fb8fcfe9616ff7477b", size = 154003, upload-time = "2025-09-25T21:32:21.167Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/08/67bd04656199bbb51dbed1439b7f27601dfb576fb864099c7ef0c3e55531/pyyaml-6.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:64386e5e707d03a7e172c0701abfb7e10f0fb753ee1d773128192742712a98fd", size = 140344, upload-time = "2025-09-25T21:32:22.617Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/11/0fd08f8192109f7169db964b5707a2f1e8b745d4e239b784a5a1dd80d1db/pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8", size = 181669, upload-time = "2025-09-25T21:32:23.673Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/16/95309993f1d3748cd644e02e38b75d50cbc0d9561d21f390a76242ce073f/pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1", size = 173252, upload-time = "2025-09-25T21:32:25.149Z" },
+    { url = "https://files.pythonhosted.org/packages/50/31/b20f376d3f810b9b2371e72ef5adb33879b25edb7a6d072cb7ca0c486398/pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c", size = 767081, upload-time = "2025-09-25T21:32:26.575Z" },
+    { url = "https://files.pythonhosted.org/packages/49/1e/a55ca81e949270d5d4432fbbd19dfea5321eda7c41a849d443dc92fd1ff7/pyyaml-6.0.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5", size = 841159, upload-time = "2025-09-25T21:32:27.727Z" },
+    { url = "https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6", size = 801626, upload-time = "2025-09-25T21:32:28.878Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/11/ba845c23988798f40e52ba45f34849aa8a1f2d4af4b798588010792ebad6/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6", size = 753613, upload-time = "2025-09-25T21:32:30.178Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e0/7966e1a7bfc0a45bf0a7fb6b98ea03fc9b8d84fa7f2229e9659680b69ee3/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be", size = 794115, upload-time = "2025-09-25T21:32:31.353Z" },
+    { url = "https://files.pythonhosted.org/packages/de/94/980b50a6531b3019e45ddeada0626d45fa85cbe22300844a7983285bed3b/pyyaml-6.0.3-cp313-cp313-win32.whl", hash = "sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26", size = 137427, upload-time = "2025-09-25T21:32:32.58Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c9/39d5b874e8b28845e4ec2202b5da735d0199dbe5b8fb85f91398814a9a46/pyyaml-6.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c", size = 154090, upload-time = "2025-09-25T21:32:33.659Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e8/2bdf3ca2090f68bb3d75b44da7bbc71843b19c9f2b9cb9b0f4ab7a5a4329/pyyaml-6.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb", size = 140246, upload-time = "2025-09-25T21:32:34.663Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/8c/f4bd7f6465179953d3ac9bc44ac1a8a3e6122cf8ada906b4f96c60172d43/pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac", size = 181814, upload-time = "2025-09-25T21:32:35.712Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/9c/4d95bb87eb2063d20db7b60faa3840c1b18025517ae857371c4dd55a6b3a/pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310", size = 173809, upload-time = "2025-09-25T21:32:36.789Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b5/47e807c2623074914e29dabd16cbbdd4bf5e9b2db9f8090fa64411fc5382/pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7", size = 766454, upload-time = "2025-09-25T21:32:37.966Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9e/e5e9b168be58564121efb3de6859c452fccde0ab093d8438905899a3a483/pyyaml-6.0.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b3bc83488de33889877a0f2543ade9f70c67d66d9ebb4ac959502e12de895788", size = 836355, upload-time = "2025-09-25T21:32:39.178Z" },
+    { url = "https://files.pythonhosted.org/packages/88/f9/16491d7ed2a919954993e48aa941b200f38040928474c9e85ea9e64222c3/pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5", size = 794175, upload-time = "2025-09-25T21:32:40.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/3f/5989debef34dc6397317802b527dbbafb2b4760878a53d4166579111411e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764", size = 755228, upload-time = "2025-09-25T21:32:42.084Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ce/af88a49043cd2e265be63d083fc75b27b6ed062f5f9fd6cdc223ad62f03e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35", size = 789194, upload-time = "2025-09-25T21:32:43.362Z" },
+    { url = "https://files.pythonhosted.org/packages/23/20/bb6982b26a40bb43951265ba29d4c246ef0ff59c9fdcdf0ed04e0687de4d/pyyaml-6.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:4a2e8cebe2ff6ab7d1050ecd59c25d4c8bd7e6f400f5f82b96557ac0abafd0ac", size = 156429, upload-time = "2025-09-25T21:32:57.844Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f4/a4541072bb9422c8a883ab55255f918fa378ecf083f5b85e87fc2b4eda1b/pyyaml-6.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:93dda82c9c22deb0a405ea4dc5f2d0cda384168e466364dec6255b293923b2f3", size = 143912, upload-time = "2025-09-25T21:32:59.247Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/f9/07dd09ae774e4616edf6cda684ee78f97777bdd15847253637a6f052a62f/pyyaml-6.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3", size = 189108, upload-time = "2025-09-25T21:32:44.377Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/78/8d08c9fb7ce09ad8c38ad533c1191cf27f7ae1effe5bb9400a46d9437fcf/pyyaml-6.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1ff362665ae507275af2853520967820d9124984e0f7466736aea23d8611fba", size = 183641, upload-time = "2025-09-25T21:32:45.407Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/5b/3babb19104a46945cf816d047db2788bcaf8c94527a805610b0289a01c6b/pyyaml-6.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6adc77889b628398debc7b65c073bcb99c4a0237b248cacaf3fe8a557563ef6c", size = 831901, upload-time = "2025-09-25T21:32:48.83Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/cc/dff0684d8dc44da4d22a13f35f073d558c268780ce3c6ba1b87055bb0b87/pyyaml-6.0.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a80cb027f6b349846a3bf6d73b5e95e782175e52f22108cfa17876aaeff93702", size = 861132, upload-time = "2025-09-25T21:32:50.149Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/5e/f77dc6b9036943e285ba76b49e118d9ea929885becb0a29ba8a7c75e29fe/pyyaml-6.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c", size = 839261, upload-time = "2025-09-25T21:32:51.808Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/88/a9db1376aa2a228197c58b37302f284b5617f56a5d959fd1763fb1675ce6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e1674c3ef6f541c35191caae2d429b967b99e02040f5ba928632d9a7f0f065", size = 805272, upload-time = "2025-09-25T21:32:52.941Z" },
+    { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "vexa-rehearse"
+version = "0.12.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "pyyaml" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "pyyaml", specifier = ">=6,<7" }]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pytest", specifier = ">=8,<10" }]


### PR DESCRIPTION
Test tooling: a catalogue of named user states and a door/engine harness that puts the product
into one and rehearses it, with its own suite. Nothing here ships to a user.

| | |
|---|---|
| **Area** | the user-state rehearsal harness |
| **Size** | +4844 / −0 across 27 files, against its base `review/09-mcp-rig` |
| **Line range** | the 12 commits of `minutes-mcp-viewer` touching these paths, inside [`3f5c3c030...7d838534a`](https://github.com/Vexa-ai/vexa/compare/3f5c3c030198b5e3d0d8339d66bece6136ada0d5...7d838534ac29954a28a25cc24f8745a9aa976f0f) |
| **Base** | `review/09-mcp-rig` — this PR shows only its own area; read the chain in order |
| **Open first** | deploy/dogfood/rehearse/states.yaml · deploy/dogfood/rehearse/engine.py |

Draft for code review of the `minutes-mcp-viewer` line; not for merge in this shape.

## Contribution rights
<!-- Select exactly ONE. This is a legal certification: an agent may explain the choices but
     must not select one for you. See CONTRIBUTOR_RIGHTS.md. -->

- [ ] **Independent:** I created this contribution, or otherwise have the right to submit it
  under Apache-2.0, and it is not owned or controlled by an employer, client, or other entity.
  <!-- rights:independent -->
- [ ] **Employer/client authorization required:** an employer, client, or other entity owns or
  may control this contribution. I am requesting Vexa's private corporate-authorization process.
  <!-- rights:corporate -->
- [ ] **Unsure:** I need a private rights review before merge.
  <!-- rights:uncertain -->

Every commit must also carry the contributor's own DCO `Signed-off-by` line. Selecting the
independent path means no individual CLA is required. Corporate and unsure paths do not stop
technical review, but they do block merge until resolved.

<!-- vexa-agent -->
