### PR TITLE
[review 6/9] operating the dogfood stack

### DIFF
--- a/deploy/dogfood/.gitignore
+++ b/deploy/dogfood/.gitignore
@@ -1,0 +1,4 @@
+# The live env carries this stack's real secrets, and .dogfood-key is a live API key.
+# Only the .example ships.
+.env.dogfood
+.dogfood-key

--- a/deploy/dogfood/Makefile
+++ b/deploy/dogfood/Makefile
@@ -1,0 +1,91 @@
+# deploy/dogfood — the long-lived MCP validation + dogfooding stack.
+#
+# The container targets (up/down/pull/logs/key) are meant to run ON THE STACK HOST (bbb), never on
+# a laptop. The probe targets (validate/validate-local/connect) are pure HTTP and run anywhere.
+#
+# This drives the STOCK deploy/compose stack with a dogfood .env — there is no overlay and no fork.
+# A dogfooding stack that differs from what users run stops being evidence about what users run.
+
+DOGFOOD_ENV ?= .env.dogfood
+COMPOSE_FILE ?= ../compose/docker-compose.yml
+PROJECT ?= vexa-dogfood
+COMPOSE = docker compose -p $(PROJECT) --env-file $(DOGFOOD_ENV) -f $(COMPOSE_FILE)
+
+# Public front door (nginx → gateway). Override for a local/tunnelled probe.
+MCP_URL ?= https://mcp.dev.vexa.ai/mcp
+LOCAL_MCP_URL ?= http://127.0.0.1:18456/mcp
+EMAIL ?= dmitry@vexa.ai
+SCOPES ?= bot,tx
+
+.PHONY: help up down pull ps logs key validate validate-local connect nginx-check env-check
+
+help:
+	@echo "  on the stack host (bbb):"
+	@echo "    make up             pull published images + bring the dogfood stack up"
+	@echo "    make down           stop it (volumes survive)"
+	@echo "    make ps / logs      inspect it"
+	@echo "    make key            mint + print an API key for EMAIL=$(EMAIL)"
+	@echo "    make nginx-check    verify the two vhosts are installed and nginx is happy"
+	@echo "  from anywhere:"
+	@echo "    make validate       drive $(MCP_URL) as a real MCP client"
+	@echo "    make validate-local same, against $(LOCAL_MCP_URL) (host-local, bypasses nginx)"
+	@echo "    make connect        print the exact 'claude mcp add' line for this endpoint"
+
+env-check:
+	@[ -f $(DOGFOOD_ENV) ] || { \
+	  echo "✗ no $(DOGFOOD_ENV) — cp env.dogfood.example $(DOGFOOD_ENV) and fill the CHANGE-ME values"; \
+	  exit 1; }
+	@if grep -q 'CHANGE-ME' $(DOGFOOD_ENV); then \
+	  echo "✗ $(DOGFOOD_ENV) still has CHANGE-ME placeholders:"; \
+	  grep -n 'CHANGE-ME' $(DOGFOOD_ENV) | sed 's/^/    /'; \
+	  echo "  this stack is internet-reachable through nginx — the compose dev defaults are not acceptable here."; \
+	  exit 1; fi
+
+## up — pull the published, release-validated images and start. Never builds from source: the
+## point of dogfooding is to live on the bytes a user would get.
+up: env-check
+	$(COMPOSE) pull
+	$(COMPOSE) up -d --no-build
+	@echo "→ stack up. gateway=127.0.0.1:18456  mcp=127.0.0.1:18410  terminal=127.0.0.1:15400"
+
+down:
+	$(COMPOSE) down
+
+pull: env-check
+	$(COMPOSE) pull
+
+ps:
+	$(COMPOSE) ps
+
+logs:
+	$(COMPOSE) logs -f --tail=100 $(SVC)
+
+## key — mint an API key against THIS stack's admin-api, reusing deploy/compose/bin/provision-token
+## (same job, already idempotent on the user). Prints ONLY the token, so it pipes.
+## Note: the USER is resolve-or-create, but each run mints a FRESH token — run it once and keep the
+## value; don't call it on a loop or you accumulate live tokens.
+key: env-check
+	@ADMIN_TOKEN="$$(grep -E '^ADMIN_TOKEN=' $(DOGFOOD_ENV) | head -1 | cut -d= -f2-)" \
+	 ADMIN_API_URL="http://127.0.0.1:$$(grep -E '^ADMIN_API_PORT=' $(DOGFOOD_ENV) | head -1 | cut -d= -f2-)" \
+	 EMAIL="$(EMAIL)" SCOPES="$(SCOPES)" ../compose/bin/provision-token
+
+validate:
+	@./bin/mcp-validate --url "$(MCP_URL)" $(if $(VEXA_API_KEY),--key "$(VEXA_API_KEY)",)
+
+validate-local:
+	@./bin/mcp-validate --url "$(LOCAL_MCP_URL)" $(if $(VEXA_API_KEY),--key "$(VEXA_API_KEY)",)
+
+## connect — the one line a human runs to attach Claude Code to this endpoint. Today it carries a
+## key in a header; when the OAuth work lands the --header disappears and this becomes a login.
+connect:
+	@echo 'claude mcp add --transport http vexa-dogfood $(MCP_URL) \'
+	@echo '  --header "Authorization: Bearer $$VEXA_API_KEY"'
+	@echo
+	@echo 'Then: /mcp inside Claude Code to confirm it connected.'
+
+nginx-check:
+	@for h in mcp.dev.vexa.ai dogfood.dev.vexa.ai; do \
+	  printf '  %-22s ' "$$h"; \
+	  curl -sS -o /dev/null -w 'HTTP %{http_code} (TLS %{ssl_verify_result})\n' "https://$$h/health" || echo unreachable; \
+	done
+	@nginx -t 2>&1 | sed 's/^/  /' || true

--- a/deploy/dogfood/README.md
+++ b/deploy/dogfood/README.md
@@ -1,0 +1,142 @@
+# deploy/dogfood — the long-lived MCP validation + dogfooding stack
+
+A Vexa stack that stays up, fronted by a real hostname over real TLS, so two things can happen that
+a `docker compose up` in a terminal cannot do:
+
+1. **Validate the MCP service as deployed.** `core/meetings/services/mcp/tests/` proves the app
+   in-process against a faked gateway. That is the right test and it does not answer the question
+   an MCP client asks: *does the transport work through the proxy chain, with a real key, against a
+   real gateway?* `bin/mcp-validate` answers that one.
+2. **Dogfood it.** Point Claude at it and use Vexa the way a customer would — which is the only way
+   the onboarding defects surface, because they are all in the part no test covers: getting a key,
+   storing it, and attaching the server.
+
+## There is no compose overlay here, deliberately
+
+This directory holds a `.env`, an nginx vhost, a probe, and a Makefile. It drives the **stock**
+`deploy/compose/docker-compose.yml` unchanged.
+
+That is the design, not laziness. A dogfooding stack that differs structurally from what users run
+stops being evidence about what users run. Everything this directory sets is a *value* — ports,
+image tag, secrets, hostnames — never a structural change. If dogfooding ever needs a change to the
+stack's shape, that change belongs in the stack, where users get it too.
+
+## Layout
+
+| File | What |
+|---|---|
+| `env.dogfood.example` | the `.env` for the stock stack — a port block offset from the compose defaults so this can sit beside a release-train stack with no collision |
+| `nginx/mcp.dev.vexa.ai.conf` | the two vhosts, on the host's existing `*.dev.vexa.ai` wildcard cert |
+| `bin/mcp-validate` | drives the endpoint as a real MCP client; stdlib-only, runs from anywhere |
+| `Makefile` | `up · down · ps · logs · key · validate · connect · nginx-check` |
+
+## Hostnames
+
+Both are **one label** under `dev.vexa.ai`, because the host's wildcard DNS record and wildcard
+certificate each cover exactly one level — a four-label name would need its own cert and record.
+
+| Host | → | What it is |
+|---|---|---|
+| `mcp.dev.vexa.ai` | gateway `127.0.0.1:18456` | the MCP endpoint (`/mcp`) and the API front door |
+| `dogfood.dev.vexa.ai` | terminal `127.0.0.1:15400` | where a human signs in and copies an API key |
+
+## Bring-up
+
+On the stack host (never a laptop — container workloads run on `bbb`):
+
+```bash
+cd deploy/dogfood
+cp env.dogfood.example .env.dogfood     # then fill every CHANGE-ME
+make up                                 # pulls published images, starts the stock stack
+make key EMAIL=you@example.com          # mint an API key — prints only the token
+sudo cp nginx/mcp.dev.vexa.ai.conf /etc/nginx/sites-available/mcp.dev.vexa.ai
+sudo ln -s /etc/nginx/sites-available/mcp.dev.vexa.ai /etc/nginx/sites-enabled/mcp.dev.vexa.ai.conf
+sudo nginx -t && sudo systemctl reload nginx
+```
+
+`make up` refuses to run while `CHANGE-ME` remains in the env file. This stack is internet-reachable
+through nginx, and the compose dev defaults (`ADMIN_TOKEN=dev-admin-token`, `DB_PASSWORD=postgres`)
+are not acceptable on something with a public hostname. `make up` also never builds: it pulls the
+published, release-validated tag, because a dogfood stack running a local source build proves
+nothing about the release.
+
+## Handing the instance back to first run
+
+A first-run rehearsal needs an instance that has never been claimed, and a long-lived dogfood stack
+is the opposite of that: the admin is whoever signed in first — usually a test identity — and the
+setup wizard is marked complete. Neither fact can be undone from any product surface.
+
+```bash
+deploy/dogfood/bin/reset-instance [--admin-email minutes-test@vexa.ai] [--keep-global]
+```
+
+Three values, named, and nothing else: the admin role is released so the next sign-in claims it, the
+first-run wizard state is cleared, and the company-layer gate goes back up. **It deletes nothing** —
+workspaces, chats, meetings, transcripts and `_global/asks/` all survive. That narrow blast radius is
+the point: the account it has to reset sits next to the founder's, and the alternative that existed
+before this script was hand surgery on a jsonb column by whoever remembered the query.
+
+After it runs, until the admin's setup chat calls `mark_global_ready`:
+
+- a non-admin sign-in is refused with one sentence, and no user row is created for them;
+- the flows engine **parks** every fact instead of sending — nothing claimed, nothing failed, no
+  attempt burned, arrival order kept;
+- `flows_submit` and `flow_lifecycle` refuse by name.
+
+`--keep-global` leaves the company layer accepted, for rehearsing the claim without re-typing the
+company.
+
+## Validating
+
+```bash
+VEXA_API_KEY=vxa_… make validate          # the public endpoint, through nginx
+VEXA_API_KEY=vxa_… make validate-local    # host-local, bypassing nginx — isolates proxy faults
+```
+
+The probe reports two families, and the split is the point:
+
+**CONFORMANCE — is this an MCP server?** `initialize` · `tools/list` against the exact 9 tools the
+service declares · `prompts/list` against the 4 prompts · a pure `parse_meeting_link` call (no
+gateway hop, so it isolates the transport) · a real `list_meetings` call (the full
+MCP → gateway → meeting-api path with your key) · and a fail-closed check that a bogus key is
+*rejected* rather than passed through as an anonymous call. Drift in the tool set fails either
+direction: a missing tool is a regression, an undeclared extra one is a README that stopped being
+true. These govern the exit code.
+
+**NATIVE-READY — is this a connector, or does a human still paste a key?** RFC 9728
+protected-resource metadata · the `WWW-Authenticate` challenge on 401 · authorization-server
+metadata. These are the mechanical difference between "add a custom MCP server and paste a header"
+and what Gmail does — click connect, log in in a browser, never see a credential. They are
+**expected to fail today**; the probe prints them as a measured distance rather than hiding them,
+and `--require-native` makes them binding once that work is expected to hold.
+
+## What is verified as of 2026-08-29
+
+Against `https://mcp.dev.vexa.ai/mcp`, images `v0.12.23`, through nginx and TLS:
+
+- All 6 conformance checks pass. Server identifies as `Vexa MCP Service (v0.12) v1.28.1`,
+  protocol `2025-06-18`, sessioned.
+- The `GET /mcp` SSE leg survives the proxy: headers arrive immediately, `content-type:
+  text/event-stream`, the stream then holds open silently with no gateway-manufactured 503. This
+  is the `Vexa-ai/vexa#795` failure mode not happening, and it is why the vhost keeps
+  `proxy_buffering off` (inherited from `proxy_vexa.conf`) and additionally disables `gzip` — a
+  compression filter re-buffers an event stream even when proxy buffering is off.
+- All 3 native-ready checks report GAP. The endpoint is key-paste only.
+
+## Attaching Claude
+
+```bash
+claude mcp add --transport http vexa-dogfood https://mcp.dev.vexa.ai/mcp \
+  --header "Authorization: Bearer $VEXA_API_KEY"
+```
+
+Two known sharp edges in that line, both of which the native-ready work removes rather than
+documents around:
+
+- `claude mcp add` has been observed writing **resolved** values back into `.mcp.json` instead of
+  preserving `${VAR}` syntax, which turns a shared project config into a committed credential.
+  Keep this server in user scope, not a checked-in `.mcp.json`.
+- Claude Code strips environment variables whose names contain `KEY`, `TOKEN`, `SECRET` and
+  similar from spawned server processes. That sanitizer is about child-process env, not about
+  header expansion, but it is close enough to the blast radius that a name like `VEXA_API_KEY`
+  deserves an actual check on your machine rather than an assumption.

--- a/deploy/dogfood/bin/README.md
+++ b/deploy/dogfood/bin/README.md
@@ -1,0 +1,30 @@
+# deploy/dogfood/bin — the probe
+
+`mcp-validate` drives a RUNNING Vexa MCP endpoint as a real MCP client.
+
+The MCP service's own tests (`core/meetings/services/mcp/tests/`) prove the app in-process against
+a faked gateway. That is the right test, and it cannot answer the question an MCP client asks:
+*does the transport work through the proxy chain, with a real key, against a real gateway?* This
+answers that one.
+
+Stdlib only — no install step; runs from a laptop or from the stack host.
+
+```bash
+./mcp-validate --url https://mcp.dev.vexa.ai/mcp --key "$VEXA_API_KEY"
+./mcp-validate --url http://127.0.0.1:18456/mcp --json
+```
+
+Two families of check, and the split is the point:
+
+**CONFORMANCE — is this an MCP server?** `initialize` · the exact declared tool set · the prompt
+catalog · a pure tool call (isolating the transport from the gateway) · a real gateway call · and
+a fail-closed check that a bogus key is *rejected* rather than forwarded as an anonymous call.
+Drift in the tool set fails either direction: a missing tool is a regression, an undeclared extra
+one is a README that stopped being true. **These govern the exit code.**
+
+**NATIVE-READY — is this a connector, or does a human still paste a key?** RFC 9728
+protected-resource metadata · the `WWW-Authenticate` challenge on 401 · authorization-server
+metadata. These are the mechanical difference between "add a custom MCP server and paste a header"
+and what a first-class connector does. They are **expected to fail** until the OAuth work lands;
+the run prints them as a measured distance rather than hiding them. `--require-native` makes them
+binding once that work is expected to hold.

--- a/deploy/dogfood/bin/blank-instance.sh
+++ b/deploy/dogfood/bin/blank-instance.sh
@@ -1,0 +1,268 @@
+#!/usr/bin/env bash
+# blank-instance — return the dogfood stack to a BLANK Vexa: no admin, no users, no desks, no
+# meetings, no chats, nothing queued, an empty inbox. The state a customer's box is in the moment
+# before its administrator signs in for the first time.
+#
+# Founder, 2026-09-02: "clean state required for the blank Vexa here to setup global."
+#
+# THIS IS NOT `reset-instance`. That one releases the admin role and the wizard flags and deletes
+# NOTHING, for rehearsing a claim on a stack you want to keep. This one DELETES: every user, every
+# desk, every meeting, every chat. Reach for it only when the thing being rehearsed is what a blank
+# instance does, and never on a stack whose contents anyone still wants.
+#
+#   deploy/dogfood/bin/blank-instance.sh --yes [--keep-mail]
+#
+# WHAT IT DELETES, exactly:
+#   1. every row of `platform_settings`            -> no admin wizard state, no company-layer gate
+#   2. every `users` row and its api_tokens        -> no admin; the next sign-in claims the instance
+#   3. every meeting, session and transcription    -> SQL: no route owns bulk deletion
+#   4. every desk in the workspace volume          -> everything except `_global`
+#   5. `_global` reduced to `asks/` + `mail/`      -> the preset library and the mail templates
+#                                                     SURVIVE; a company layer written into it does not
+#   6. redis, BY PREFIX ONLY (see below)           -> no chat threads, no pending scaffolds
+#   7. both flows lanes: reactions, receipts,      -> nothing queued, nothing half-run, and no dedup
+#      signals, mail cursors and thread memory        memory that would swallow a replayed fact
+#   8. mailpit                                     -> an empty inbox (skip with --keep-mail)
+#
+# WHAT IT NEVER TOUCHES: images, API keys, the SOPS secrets, `~/dna-fixtures`, run directories,
+# `_global/.git` history, and any container. It deletes data, never infrastructure — so a wipe always
+# leaves a working stack, just an empty one. In redis it never issues FLUSHALL or FLUSHDB: the same
+# instance carries the live transcript streams and the bot/meeting machinery, and a blank is about a
+# PERSON'S data, not about the deployment's plumbing (see step 6).
+#
+# It REFUSES while a meeting is live. A wipe mid-meeting destroys the only copy of something nobody
+# can re-record, and "no meeting is live" is cheap to check and impossible to remember.
+set -euo pipefail
+
+STACK="${VEXA_DOGFOOD_STACK:-vexa-dogfood}"
+YES=0
+KEEP_MAIL=0
+MAILPIT="${VEXA_MAILPIT_URL:-http://127.0.0.1:8025}"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --yes) YES=1; shift ;;
+    --keep-mail) KEEP_MAIL=1; shift ;;
+    -h|--help) sed -n '2,32p' "$0"; exit 0 ;;
+    *) echo "unknown argument: $1" >&2; exit 2 ;;
+  esac
+done
+
+PG="${STACK}-postgres-1"
+AGENT="${STACK}-agent-api-1"
+psql_vexa() { docker exec "$PG" psql -U postgres -d vexa -tAc "$1"; }
+
+say()   { printf '  %s\n' "$*"; }
+head2() { printf '\n== %s\n' "$*"; }
+
+# ── the refusal, before anything is counted ─────────────────────────────────────────────────────
+LIVE=$(psql_vexa "SELECT count(*) FROM meetings WHERE status IN ('active','joining','requested','awaiting_admission','needs_help','stopping');" | tr -d ' ')
+if [ "${LIVE:-0}" != "0" ]; then
+  echo "REFUSING: $LIVE meeting(s) are live. A wipe mid-meeting destroys the only copy of something" >&2
+  echo "nobody can re-record. Wait for them to finish." >&2
+  exit 1
+fi
+
+# ── say what will go, then require the word ─────────────────────────────────────────────────────
+USERS=$(psql_vexa "SELECT count(*) FROM users;" | tr -d ' ')
+MEETINGS=$(psql_vexa "SELECT count(*) FROM meetings;" | tr -d ' ')
+TOKENS=$(psql_vexa "SELECT count(*) FROM api_tokens;" | tr -d ' ')
+SETTINGS=$(psql_vexa "SELECT count(*) FROM platform_settings;" | tr -d ' ')
+DESKS=$(docker exec "$AGENT" sh -lc "ls -A /workspaces | grep -vx '_global' | wc -l" | tr -d ' ')
+REDIS_KEYS=$(docker exec "${STACK}-redis-1" sh -lc '
+  C=$(command -v valkey-cli || command -v redis-cli) || exit 0
+  n=0
+  for p in "agent:sessions:*" "agent:session:*" "agent:scaffold:*" "agent:scaffolds:by:*"; do
+    n=$((n + $($C --scan --pattern "$p" --count 500 | wc -l)))
+  done
+  echo $n' 2>/dev/null | tr -d ' \r' || echo "?")
+MAILS=$(curl -sS "$MAILPIT/api/v1/messages?limit=1" 2>/dev/null | python3 -c 'import json,sys;print(json.load(sys.stdin).get("messages_count",0))' 2>/dev/null || echo "?")
+
+echo "blank-instance — stack ${STACK}"
+say "users .................. $USERS  (all deleted)"
+say "api tokens ............. $TOKENS  (all deleted)"
+say "meetings ............... $MEETINGS  (all deleted, with sessions + transcriptions)"
+say "platform settings ...... $SETTINGS  (all deleted — no admin wizard state, no gate)"
+say "desks in the volume .... $DESKS  (all deleted; _global survives)"
+say "mailpit messages ....... $MAILS  $([ "$KEEP_MAIL" = 1 ] && echo '(KEPT: --keep-mail)' || echo '(all deleted)')"
+say "_global ................ reduced to asks/ + mail/ (+ .git history, kept)"
+say "redis (BY PREFIX) ...... $REDIS_KEYS  chat-thread index + scaffold records; nothing else"
+say "flows (both lanes) ..... reactions, receipts, signals, cursors, thread memory"
+
+if [ "$YES" != "1" ]; then
+  echo
+  echo "Nothing was deleted. Re-run with --yes to do it." >&2
+  exit 3
+fi
+
+echo
+echo "wiping at $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+# ── 0 · the per-turn workers. They are not stack services, and a parked one un-blanks the wipe. ──
+head2 "agent workers"
+# ⚠ A worker container outlives the turn that spawned it (warm-window TTL), holds its subject's desk
+# BOUND READ-WRITE, and will happily re-create /workspaces/<uid> on its next write — for a uid this
+# script has just deleted. Observed 2026-09-02: `vexa-worker-124-chat-…` was still Up after a blank,
+# owned by a user that no longer existed. A wipe that leaves a live writer attached to the thing it
+# wiped is not a wipe; it is a race it has not lost yet. These are per-turn containers the runtime
+# re-creates on demand, so removing them costs nothing.
+W=$(docker ps -aq --filter "name=vexa-worker-" | wc -l | tr -d ' ')
+if [ "$W" != "0" ]; then
+  docker ps -a --filter "name=vexa-worker-" --format '    {{.Names}}  {{.Status}}'
+  docker rm -f $(docker ps -aq --filter "name=vexa-worker-") >/dev/null 2>&1 || true
+fi
+say "removed $W worker container(s); $(docker ps -aq --filter 'name=vexa-worker-' | wc -l | tr -d ' ') left"
+
+# ── 1-3 · identity + product data. No route owns bulk deletion, so this is SQL, in FK order. ────
+head2 "postgres (vexa)"
+psql_vexa "DELETE FROM transcriptions;"     | sed 's/^/  transcriptions:     /'
+psql_vexa "DELETE FROM meeting_sessions;"   | sed 's/^/  meeting_sessions:   /'
+psql_vexa "DELETE FROM meetings;"           | sed 's/^/  meetings:           /'
+psql_vexa "DELETE FROM api_tokens;"         | sed 's/^/  api_tokens:         /'
+psql_vexa "DELETE FROM users;"              | sed 's/^/  users:              /'
+psql_vexa "DELETE FROM platform_settings;"  | sed 's/^/  platform_settings:  /'
+
+# ── 4-5 · the workspace volume. `_global` survives, minus any company layer written into it. ────
+head2 "workspace volume"
+docker exec "$AGENT" sh -lc '
+  cd /workspaces || exit 1
+  for d in $(ls -A . | grep -vx "_global"); do rm -rf -- "$d"; done
+  cd _global || exit 0
+  for f in $(ls -A . | grep -vxE "asks|mail|\.git"); do rm -rf -- "$f"; done
+  if [ -d .git ]; then
+    git add -A
+    git -c user.email=platform@vexa.local -c user.name=vexa-platform \
+        commit -q -m "blank instance: the company layer is removed; presets and mail templates stay" || true
+  fi
+  echo "  /workspaces now: $(cd /workspaces && ls -A | tr "\n" " ")"
+  echo "  _global now:     $(cd /workspaces/_global && ls -A | tr "\n" " ")"
+'
+
+# ── 6 · redis, BY PREFIX. Never FLUSHALL. ───────────────────────────────────────────────────────
+head2 "redis"
+# ⚠ THE BLANK USED TO STOP AT POSTGRES AND THE VOLUME, AND REDIS IS THE THIRD STORE.
+# Found 2026-09-02 while building the scaffold (biz#449): agent-api keeps two durable things here —
+# the per-subject CHAT-THREAD INDEX (`_Sessions`) and the SCAFFOLD RECORDS (`ScaffoldStore`) — and a
+# blank left every one of them behind. 335 session keys survived the two blanks of that morning. A
+# scaffold outliving a blank is worse than untidy: it is a live capability, minted for an address,
+# still redeemable on an instance that has been handed to somebody else.
+#
+# ONLY THESE PREFIXES, and they are listed rather than globbed on `agent:*` on purpose — a prefix
+# list is reviewable, `agent:*` silently adopts whatever the next feature names. Everything here is
+# ONE PERSON'S data:
+#
+#   agent:sessions:<subject>            the subject's chat-thread id set        (api.py `_Sessions`)
+#   agent:session:<subject>:<session>   one thread's title + timestamps         (api.py `_Sessions`)
+#   agent:scaffold:<id>                 one arrival record                      (scaffolds.py)
+#   agent:scaffolds:by:<address>        that recipient's pending-scaffold index (scaffolds.py)
+#
+# AND NOTHING ELSE. `FLUSHALL`/`FLUSHDB` would also take `tc:meeting:*` (the live transcript
+# streams the copilot tails and the db-writer drains), the `unit:*` per-dispatch streams, and the
+# bot machinery — deployment plumbing, and in the transcript case the only copy of something nobody
+# can re-record. The refusal at the top of this script exists for exactly that reason; a flush here
+# would walk straight around it.
+#
+# NOT cleared, deliberately, and said out loud rather than left to be discovered: `unit:*` (the
+# per-dispatch chat streams) and `tc:meeting:*` (transcript streams) are orphaned by this wipe and
+# accumulate. They are GARBAGE, not a hazard — `dispatch_id` is derived from (subject, session) and
+# postgres never reuses a deleted user's id, so a fresh person cannot land on an old stream. Cleaning
+# them is a retention question, not a blanking one, and it is filed rather than smuggled in here.
+REDIS="${STACK}-redis-1"
+REDIS_PREFIXES="agent:sessions:* agent:session:* agent:scaffold:* agent:scaffolds:by:*"
+# valkey since #653; `redis-cli` is kept as the fallback so this works against either engine.
+RCLI=$(docker exec "$REDIS" sh -lc 'command -v valkey-cli || command -v redis-cli' 2>/dev/null | tr -d '\r')
+if [ -z "$RCLI" ]; then
+  echo "REFUSING: no valkey-cli/redis-cli in $REDIS — the chat-thread index and any pending" >&2
+  echo "scaffold would survive the blank, and a scaffold is a live capability." >&2
+  exit 1
+fi
+for pat in $REDIS_PREFIXES; do
+  # SCAN, never KEYS: KEYS blocks the server for the whole sweep, and this one also serves the live
+  # transcript streams. The delete is batched through xargs so a large sweep is not one call per key.
+  n=$(docker exec "$REDIS" sh -lc "$RCLI --scan --pattern '$pat' --count 500 | wc -l" | tr -d ' \r')
+  if [ "${n:-0}" != "0" ]; then
+    docker exec "$REDIS" sh -lc \
+      "$RCLI --scan --pattern '$pat' --count 500 | xargs -r -n 200 $RCLI DEL >/dev/null"
+  fi
+  printf '    %-26s %s\n' "$pat" "$n deleted"
+done
+# … and PROVE it, for the same reason the flows lane below proves itself: a step that cannot do its
+# job and says so quietly is indistinguishable from one that worked.
+for pat in $REDIS_PREFIXES; do
+  left=$(docker exec "$REDIS" sh -lc "$RCLI --scan --pattern '$pat' --count 500 | wc -l" | tr -d ' \r')
+  [ "${left:-0}" = "0" ] || { echo "REFUSING to report success: redis still holds $left key(s) matching $pat" >&2; exit 1; }
+done
+say "verified: no chat-thread index and no scaffold records remain"
+
+# ── 7 · every flows lane. Through the POSTGRES CONTAINER, in dependency order, loudly. ─────
+head2 "flows"
+# ⚠ WHY THIS RUNS `docker exec` AND NOT `psql`. The first version of this script called `psql` on
+# the HOST, where there is no psql binary. Every delete failed, every failure was caught and printed
+# as the word "skip", and the wipe reported success while leaving 115 reactions in `flows` and 123
+# in `flows_sim` — parked reactions referencing users that no longer existed, which would have fired
+# the moment the gate lifted. Same class as every other defect this night: a step that cannot do its
+# job and says so in a word nobody reads is indistinguishable from one that worked. It now FAILS
+# LOUDLY and refuses to report success it has not verified.
+#
+# Lanes are DISCOVERED, not listed. Reading ~/.storm/dburl finds the lane somebody remembered; a
+# `flows%` scan of the stack own postgres finds every lane that exists, including the ones nobody
+# did. The sim lane was exactly that case.
+FLOW_DBS=$(docker exec "$PG" psql -U postgres -tAc \
+  "SELECT datname FROM pg_database WHERE datname LIKE 'flows%' ORDER BY 1;" | tr -d ' \r')
+[ -n "$FLOW_DBS" ] || { echo "REFUSING: no flows lane database found in $PG" >&2; exit 1; }
+
+# DEPENDENCY ORDER, and it is not alphabetical: effect_receipt and signal reference reaction, so
+# reaction is deleted LAST or the foreign key refuses it.
+FLOW_TABLES="effect_receipt signal reaction mail_cursor mail_seen mail_thread mail_outbox_sent friction"
+for db in $FLOW_DBS; do
+  say "lane $db"
+  for t in $FLOW_TABLES; do
+    if ! out=$(docker exec "$PG" psql -U postgres -d "$db" -tAc "DELETE FROM $t;" 2>&1); then
+      # A table this lane does not have is not a failure — lanes differ (`friction` exists in one
+      # and not the other) — but it must be SAID, not swallowed. Anything else is fatal: a lane
+      # left with rows fires parked work at users that no longer exist.
+      case "$out" in
+        *"does not exist"*) printf '    %-18s %s\n' "$t" "absent in this lane — skipped"; continue ;;
+        *) echo "  FAILED on $db.$t: $out" >&2
+           echo "  A flows lane left with rows fires parked work at users that no longer exist." >&2
+           exit 1 ;;
+      esac
+    fi
+    printf '    %-18s %s\n' "$t" "$out"
+  done
+done
+
+# … and PROVE it. The whole defect above was that the failure was invisible, so the fix is not
+# only to fail loudly but to refuse to CLAIM success without reading the counts back.
+for db in $FLOW_DBS; do
+  left=$(docker exec "$PG" psql -U postgres -d "$db" -tAc \
+    "SELECT (SELECT count(*) FROM reaction)+(SELECT count(*) FROM signal)+(SELECT count(*) FROM effect_receipt);" | tr -d ' \r')
+  [ "$left" = "0" ] || { echo "REFUSING to report success: $db still holds $left row(s)" >&2; exit 1; }
+  say "lane $db verified empty"
+done
+
+# ── 8 · the inbox ───────────────────────────────────────────────────────────────────────────────
+head2 "mailpit"
+if [ "$KEEP_MAIL" = 1 ]; then
+  say "kept (--keep-mail)"
+else
+  curl -sS -X DELETE "$MAILPIT/api/v1/messages" >/dev/null && say "emptied"
+fi
+
+# ── what a blank instance looks like ────────────────────────────────────────────────────────────
+head2 "state now"
+say "users:             $(psql_vexa 'SELECT count(*) FROM users;' | tr -d ' ')"
+say "platform settings: $(psql_vexa 'SELECT count(*) FROM platform_settings;' | tr -d ' ')"
+say "meetings:          $(psql_vexa 'SELECT count(*) FROM meetings;' | tr -d ' ')"
+say "mailpit:           $(curl -sS "$MAILPIT/api/v1/messages?limit=1" 2>/dev/null | python3 -c 'import json,sys;print(json.load(sys.stdin).get("messages_count",0))' 2>/dev/null || echo '?')"
+echo
+cat <<'NEXT'
+  A blank Vexa. The next sign-in claims the instance, meets the wizard, and writes the company
+  layer; until it does, no other person can sign in, the flows engine parks every fact instead of
+  sending, and the operator verbs refuse.
+
+  Kept on purpose: _global/asks/ (the preset library), _global/mail/ (the mail templates) and
+  _global/.git (the history). Those are the deployment's own furniture, not anybody's data. In redis
+  the same rule, from the other side: the chat-thread index and every scaffold are gone, and the
+  transcript streams and per-dispatch streams are untouched — plumbing, never a person.
+NEXT

--- a/deploy/dogfood/bin/drop-invite.py
+++ b/deploy/dogfood/bin/drop-invite.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""Station 2 — drop a DNA TSC invite into the mail double as the founder (organizer).
+SMTP to mailpit (127.0.0.1:1025), To: the mailbox the poller answers as. Nothing leaves the box."""
+import argparse, smtplib, time, uuid, calendar
+from email.message import EmailMessage
+from email.utils import formatdate, make_msgid
+
+ap = argparse.ArgumentParser()
+ap.add_argument("--to", default="vexa@storm.test")
+ap.add_argument("--organizer", default="admin@vexa.ai")
+ap.add_argument("--organizer-name", default="Dmitry Grankin")
+ap.add_argument("--title", default="ASWF DNA TSC")
+ap.add_argument("--minutes-ahead", type=int, default=20)
+ap.add_argument("--zoom", default="https://us02web.zoom.us/j/84123456789?pwd=aBcD1234efGH")
+ap.add_argument("--attendee", action="append", default=[], help="Name <addr>")
+ap.add_argument("--group", default="")   # e.g. dna-tsc → '#group:dna-tsc' in DESCRIPTION
+ap.add_argument("--smtp", default="127.0.0.1:1025")
+a = ap.parse_args()
+
+start = int(time.time()) + a.minutes_ahead * 60
+fmt = lambda t: time.strftime("%Y%m%dT%H%M%SZ", time.gmtime(t))
+uid = f"dna-tsc-{fmt(start)}@zoom.us"
+att_lines = []
+for s in a.attendee:
+    name, addr = s.rsplit("<", 1); addr = addr.rstrip(">").strip(); name = name.strip()
+    att_lines.append(f"ATTENDEE;CUTYPE=INDIVIDUAL;ROLE=REQ-PARTICIPANT;PARTSTAT=NEEDS-ACTION;CN={name}:mailto:{addr}")
+att_lines.append(f"ATTENDEE;CN=Vexa;PARTSTAT=NEEDS-ACTION:mailto:{a.to}")
+desc = f"Join Zoom Meeting{' #group:' + a.group if a.group else ''}\\n{a.zoom}"
+ics = "\r\n".join([
+    "BEGIN:VCALENDAR", "PRODID:-//Zoom//Zoom Calendar//EN", "VERSION:2.0", "METHOD:REQUEST",
+    "BEGIN:VEVENT", f"DTSTART:{fmt(start)}", f"DTEND:{fmt(start + 3600)}", f"UID:{uid}",
+    f"DTSTAMP:{fmt(time.time())}",
+    f"ORGANIZER;CN={a.organizer_name}:mailto:{a.organizer}", *att_lines,
+    f"SUMMARY:{a.title}", f"DESCRIPTION:{desc}", f"LOCATION:{a.zoom}",
+    "END:VEVENT", "END:VCALENDAR", ""])
+
+m = EmailMessage()
+m["From"] = f"{a.organizer_name} <{a.organizer}>"
+m["To"] = a.to
+m["Subject"] = f"Invitation: {a.title} @ {time.strftime('%a %b %-d, %Y %H:%M', time.gmtime(start))} (UTC)"
+m["Date"] = formatdate(usegmt=True)
+m["Message-ID"] = make_msgid(domain="vexa.ai")
+m.set_content(f"You have been invited to {a.title}.\n{a.zoom}\n")
+m.add_attachment(ics.encode(), maintype="text", subtype="calendar", filename="invite.ics",
+                 params={"method": "REQUEST", "charset": "utf-8"})
+host, port = a.smtp.split(":")
+with smtplib.SMTP(host, int(port)) as s:
+    s.send_message(m)
+print(f"dropped uid={uid} start={fmt(start)} to={a.to} organizer={a.organizer} attendees={len(a.attendee)} msgid={m['Message-ID']}")

--- a/deploy/dogfood/bin/mcp-validate
+++ b/deploy/dogfood/bin/mcp-validate
@@ -1,0 +1,425 @@
+#!/usr/bin/env python3
+"""mcp-validate — drive a RUNNING Vexa MCP endpoint as a real MCP client and report what it is.
+
+This is not a unit test. ``core/meetings/services/mcp/tests/`` already proves the app in-process
+against a faked gateway. This proves the DEPLOYED surface: the transport as an MCP client actually
+speaks it, through whatever proxy chain fronts it, with a real API key against a real gateway.
+
+Two families of check, and the second is the point:
+
+  CONFORMANCE  — does the endpoint behave as an MCP server?
+                 initialize · tools/list · prompts/list · a real tools/call round trip ·
+                 auth passthrough (good key works, bad key 401s).
+
+  NATIVE-READY — is it a *connector*, or does a human still have to paste a key?
+                 RFC 9728 protected-resource metadata · the 401 WWW-Authenticate challenge ·
+                 authorization-server metadata. These are what make Claude offer a browser
+                 login instead of asking for a header, i.e. what "native like Gmail" means
+                 mechanically. They are EXPECTED TO FAIL until the OAuth work lands; the run
+                 prints them as a measured distance, not as noise.
+
+Stdlib only — no install step, runs from the laptop or from bbb.
+
+    ./mcp-validate --url https://mcp.dev.vexa.ai/mcp --key "$VEXA_API_KEY"
+    ./mcp-validate --url http://127.0.0.1:18456/mcp --key "$VEXA_API_KEY" --json
+
+Exit code is 0 when every CONFORMANCE check passes; NATIVE-READY failures never fail the run
+(use --require-native to make them binding once the OAuth work is expected to hold).
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass, field
+from typing import Any
+
+PROTOCOL_VERSION = "2025-06-18"
+
+# The surface core/meetings/services/mcp/README.md declares. Drift here is a finding either way:
+# a missing tool is a regression, an extra one is a doc that stopped being true.
+EXPECTED_TOOLS = {
+    "parse_meeting_link",
+    "request_meeting_bot",
+    "get_bot_status",
+    "update_bot_config",
+    "stop_bot",
+    "list_meetings",
+    "get_meeting_transcript",
+    "list_recordings",
+    "get_recording",
+}
+EXPECTED_PROMPTS = {
+    "vexa.meeting_prep",
+    "vexa.during_meeting",
+    "vexa.post_meeting",
+    "vexa.teams_link_help",
+}
+
+
+@dataclass
+class Check:
+    name: str
+    family: str  # "conformance" | "native-ready"
+    ok: bool
+    detail: str = ""
+
+
+@dataclass
+class Session:
+    url: str
+    key: str | None
+    timeout: float
+    session_id: str | None = None
+    checks: list[Check] = field(default_factory=list)
+
+    def record(self, name: str, family: str, ok: bool, detail: str = "") -> bool:
+        self.checks.append(Check(name, family, ok, detail))
+        return ok
+
+
+def _sse_to_payload(body: str) -> Any:
+    """Pull the first JSON-RPC message out of a text/event-stream response body."""
+    for raw in body.splitlines():
+        if raw.startswith("data:"):
+            chunk = raw[5:].strip()
+            if chunk:
+                try:
+                    return json.loads(chunk)
+                except json.JSONDecodeError:
+                    continue
+    raise ValueError("no JSON payload in event-stream body")
+
+
+def rpc(
+    sess: Session,
+    method: str,
+    params: dict[str, Any] | None = None,
+    *,
+    key: str | None = "__default__",
+    notify: bool = False,
+    request_id: int = 1,
+) -> tuple[int, dict[str, str], Any]:
+    """One JSON-RPC call over streamable HTTP. Returns (status, headers, decoded-or-raw-body)."""
+    payload: dict[str, Any] = {"jsonrpc": "2.0", "method": method}
+    if params is not None:
+        payload["params"] = params
+    if not notify:
+        payload["id"] = request_id
+
+    headers = {
+        "Content-Type": "application/json",
+        "Accept": "application/json, text/event-stream",
+    }
+    token = sess.key if key == "__default__" else key
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    if sess.session_id:
+        headers["mcp-session-id"] = sess.session_id
+        headers["MCP-Protocol-Version"] = PROTOCOL_VERSION
+
+    req = urllib.request.Request(
+        sess.url, data=json.dumps(payload).encode(), headers=headers, method="POST"
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=sess.timeout) as resp:
+            status, hdrs, body = resp.status, dict(resp.headers), resp.read().decode(errors="replace")
+    except urllib.error.HTTPError as e:  # 4xx/5xx still carry a body worth reading
+        status, hdrs, body = e.code, dict(e.headers or {}), e.read().decode(errors="replace")
+    except urllib.error.URLError as e:
+        return 0, {}, f"transport error: {e.reason}"
+
+    hdrs = {k.lower(): v for k, v in hdrs.items()}
+    if not sess.session_id and hdrs.get("mcp-session-id"):
+        sess.session_id = hdrs["mcp-session-id"]
+
+    ctype = hdrs.get("content-type", "")
+    decoded: Any = body
+    try:
+        decoded = _sse_to_payload(body) if "text/event-stream" in ctype else json.loads(body)
+    except (ValueError, json.JSONDecodeError):
+        pass
+    return status, hdrs, decoded
+
+
+def get(url: str, timeout: float, key: str | None = None) -> tuple[int, dict[str, str], str]:
+    headers = {"Accept": "application/json"}
+    if key:
+        headers["Authorization"] = f"Bearer {key}"
+    req = urllib.request.Request(url, headers=headers, method="GET")
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            return resp.status, {k.lower(): v for k, v in resp.headers.items()}, resp.read().decode(errors="replace")
+    except urllib.error.HTTPError as e:
+        return e.code, {k.lower(): v for k, v in (e.headers or {}).items()}, e.read().decode(errors="replace")
+    except urllib.error.URLError as e:
+        return 0, {}, f"transport error: {e.reason}"
+
+
+# ── conformance ──────────────────────────────────────────────────────────────────────────────
+
+def check_initialize(sess: Session) -> bool:
+    status, _, body = rpc(
+        sess,
+        "initialize",
+        {
+            "protocolVersion": PROTOCOL_VERSION,
+            "capabilities": {},
+            "clientInfo": {"name": "vexa-mcp-validate", "version": "1"},
+        },
+    )
+    result = body.get("result") if isinstance(body, dict) else None
+    if status != 200 or not result:
+        return sess.record("initialize", "conformance", False, f"HTTP {status}: {str(body)[:200]}")
+    server = result.get("serverInfo", {}) or {}
+    negotiated = result.get("protocolVersion", "?")
+    rpc(sess, "notifications/initialized", {}, notify=True)
+    return sess.record(
+        "initialize",
+        "conformance",
+        True,
+        f"server={server.get('name', '?')} v{server.get('version', '?')} protocol={negotiated}"
+        + (f" session={sess.session_id[:8]}…" if sess.session_id else " session=stateless"),
+    )
+
+
+def check_tools(sess: Session) -> bool:
+    status, _, body = rpc(sess, "tools/list", {}, request_id=2)
+    result = body.get("result") if isinstance(body, dict) else None
+    if status != 200 or not result:
+        return sess.record("tools/list", "conformance", False, f"HTTP {status}: {str(body)[:200]}")
+    got = {t.get("name") for t in result.get("tools", [])}
+    missing, extra = EXPECTED_TOOLS - got, got - EXPECTED_TOOLS
+    if missing or extra:
+        bits = []
+        if missing:
+            bits.append(f"missing {sorted(missing)}")
+        if extra:
+            bits.append(f"undeclared {sorted(extra)}")
+        return sess.record("tools/list", "conformance", False, f"{len(got)} tools; " + "; ".join(bits))
+    return sess.record("tools/list", "conformance", True, f"all {len(EXPECTED_TOOLS)} declared tools present")
+
+
+def check_prompts(sess: Session) -> bool:
+    status, _, body = rpc(sess, "prompts/list", {}, request_id=3)
+    result = body.get("result") if isinstance(body, dict) else None
+    if status != 200 or not result:
+        return sess.record("prompts/list", "conformance", False, f"HTTP {status}: {str(body)[:200]}")
+    got = {p.get("name") for p in result.get("prompts", [])}
+    missing = EXPECTED_PROMPTS - got
+    if missing:
+        return sess.record("prompts/list", "conformance", False, f"missing {sorted(missing)}")
+    return sess.record("prompts/list", "conformance", True, f"all {len(EXPECTED_PROMPTS)} prompts present")
+
+
+def _tool_payload(body: Any) -> Any:
+    """Unwrap a tools/call result into the tool's own JSON, whatever content shape carried it."""
+    result = body.get("result") if isinstance(body, dict) else None
+    if not isinstance(result, dict):
+        return None
+    if isinstance(result.get("structuredContent"), dict):
+        return result["structuredContent"]
+    for item in result.get("content", []) or []:
+        if item.get("type") == "text":
+            try:
+                return json.loads(item.get("text", ""))
+            except (ValueError, json.JSONDecodeError):
+                return item.get("text")
+    return result
+
+
+def check_pure_tool_call(sess: Session) -> bool:
+    """parse_meeting_link — the one tool with no gateway hop. Proves the transport round trip alone."""
+    status, _, body = rpc(
+        sess,
+        "tools/call",
+        {"name": "parse_meeting_link", "arguments": {"meeting_url": "https://meet.google.com/abc-defg-hij"}},
+        request_id=4,
+    )
+    payload = _tool_payload(body)
+    if status != 200 or not isinstance(payload, dict):
+        return sess.record("tools/call parse_meeting_link", "conformance", False, f"HTTP {status}: {str(body)[:200]}")
+    if payload.get("platform") != "google_meet" or payload.get("native_meeting_id") != "abc-defg-hij":
+        return sess.record("tools/call parse_meeting_link", "conformance", False, f"unexpected parse: {payload}")
+    return sess.record("tools/call parse_meeting_link", "conformance", True, "google_meet / abc-defg-hij")
+
+
+def check_gateway_tool_call(sess: Session) -> bool:
+    """list_meetings — the full path: MCP → gateway → meeting-api, with the caller's real key."""
+    if not sess.key:
+        return sess.record("tools/call list_meetings", "conformance", False, "no --key supplied")
+    status, _, body = rpc(sess, "tools/call", {"name": "list_meetings", "arguments": {"limit": 1}}, request_id=5)
+    payload = _tool_payload(body)
+    if status != 200:
+        return sess.record("tools/call list_meetings", "conformance", False, f"HTTP {status}: {str(body)[:200]}")
+    if isinstance(body, dict) and body.get("result", {}).get("isError"):
+        return sess.record("tools/call list_meetings", "conformance", False, f"tool error: {str(payload)[:200]}")
+    shape = type(payload).__name__
+    n = len(payload.get("meetings", [])) if isinstance(payload, dict) else "?"
+    return sess.record("tools/call list_meetings", "conformance", True, f"gateway reached; {shape}, {n} meeting(s)")
+
+
+def check_auth_rejected(sess: Session) -> bool:
+    """A bogus key must NOT reach the gateway as an anonymous call. Fail-closed is the whole seam."""
+    status, _, body = rpc(
+        sess,
+        "tools/call",
+        {"name": "list_meetings", "arguments": {"limit": 1}},
+        key="obviously-not-a-real-vexa-key",
+        request_id=6,
+    )
+    payload = _tool_payload(body)
+    is_error = bool(isinstance(body, dict) and body.get("result", {}).get("isError"))
+    blob = json.dumps(payload) if not isinstance(payload, str) else payload
+    rejected = status in (401, 403) or is_error or "401" in (blob or "") or "403" in (blob or "")
+    return sess.record(
+        "auth fail-closed",
+        "conformance",
+        rejected,
+        "bad key rejected" if rejected else f"BAD KEY WAS ACCEPTED — HTTP {status}: {str(payload)[:200]}",
+    )
+
+
+# ── native-readiness (the OAuth connector surface) ────────────────────────────────────────────
+
+def check_www_authenticate(sess: Session) -> bool:
+    """MCP spec: an unauthorized request MUST be answered with a WWW-Authenticate carrying
+    resource_metadata. That header is the thread Claude pulls to offer a browser login."""
+    status, hdrs, _ = rpc(sess, "tools/call", {"name": "list_meetings", "arguments": {}}, key=None, request_id=7)
+    challenge = hdrs.get("www-authenticate", "")
+    if "resource_metadata" in challenge:
+        return sess.record("401 WWW-Authenticate", "native-ready", True, challenge[:160])
+    return sess.record(
+        "401 WWW-Authenticate",
+        "native-ready",
+        False,
+        f"HTTP {status}, no resource_metadata challenge"
+        + (f" (got: {challenge[:80]})" if challenge else " (no WWW-Authenticate header)"),
+    )
+
+
+def check_protected_resource_metadata(sess: Session) -> bool:
+    """RFC 9728. MCP servers MUST serve this; clients MUST use it for AS discovery."""
+    parts = urllib.parse.urlsplit(sess.url)
+    origin = f"{parts.scheme}://{parts.netloc}"
+    # Path-aware form first (RFC 9728 §3.1), then the origin-level fallback.
+    candidates = [
+        f"{origin}/.well-known/oauth-protected-resource{parts.path}",
+        f"{origin}/.well-known/oauth-protected-resource",
+    ]
+    for url in candidates:
+        status, _, body = get(url, sess.timeout)
+        if status == 200:
+            try:
+                doc = json.loads(body)
+            except json.JSONDecodeError:
+                continue
+            servers = doc.get("authorization_servers") or []
+            return sess.record(
+                "RFC 9728 protected-resource metadata",
+                "native-ready",
+                bool(servers),
+                f"{url} → resource={doc.get('resource', '?')} as={servers}",
+            )
+    return sess.record(
+        "RFC 9728 protected-resource metadata",
+        "native-ready",
+        False,
+        "not served at either well-known path",
+    )
+
+
+def check_as_metadata(sess: Session) -> bool:
+    """RFC 8414 / OIDC discovery on the same origin — the fallback a client tries when it has a
+    resource but no explicit AS. Presence here is what turns `claude mcp add` into a login."""
+    parts = urllib.parse.urlsplit(sess.url)
+    origin = f"{parts.scheme}://{parts.netloc}"
+    for path in ("/.well-known/oauth-authorization-server", "/.well-known/openid-configuration"):
+        status, _, body = get(f"{origin}{path}", sess.timeout)
+        if status == 200:
+            try:
+                doc = json.loads(body)
+            except json.JSONDecodeError:
+                continue
+            return sess.record(
+                "authorization-server metadata",
+                "native-ready",
+                bool(doc.get("authorization_endpoint") and doc.get("token_endpoint")),
+                f"{path} → issuer={doc.get('issuer', '?')}",
+            )
+    return sess.record("authorization-server metadata", "native-ready", False, "no AS metadata on this origin")
+
+
+# ── driver ───────────────────────────────────────────────────────────────────────────────────
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--url", required=True, help="MCP endpoint, e.g. https://mcp.dev.vexa.ai/mcp")
+    ap.add_argument("--key", default=None, help="Vexa API key (falls back to $VEXA_API_KEY)")
+    ap.add_argument("--timeout", type=float, default=30.0)
+    ap.add_argument("--json", action="store_true", help="emit machine-readable results")
+    ap.add_argument(
+        "--require-native",
+        action="store_true",
+        help="make the OAuth connector checks binding on the exit code (they are informational by default)",
+    )
+    args = ap.parse_args()
+
+    import os
+
+    key = args.key or os.environ.get("VEXA_API_KEY") or None
+    sess = Session(url=args.url, key=key, timeout=args.timeout)
+
+    if check_initialize(sess):
+        check_tools(sess)
+        check_prompts(sess)
+        check_pure_tool_call(sess)
+        check_gateway_tool_call(sess)
+        check_auth_rejected(sess)
+    check_www_authenticate(sess)
+    check_protected_resource_metadata(sess)
+    check_as_metadata(sess)
+
+    conformance = [c for c in sess.checks if c.family == "conformance"]
+    native = [c for c in sess.checks if c.family == "native-ready"]
+    conf_ok = all(c.ok for c in conformance) and len(conformance) == 6
+    native_ok = all(c.ok for c in native)
+
+    if args.json:
+        print(json.dumps(
+            {
+                "url": args.url,
+                "conformance_ok": conf_ok,
+                "native_ready": native_ok,
+                "checks": [vars(c) for c in sess.checks],
+            },
+            indent=2,
+        ))
+    else:
+        print(f"\n  MCP endpoint: {args.url}\n")
+        print("  CONFORMANCE — is this an MCP server?")
+        for c in conformance:
+            print(f"    {'PASS' if c.ok else 'FAIL'}  {c.name:<34} {c.detail}")
+        if not conformance:
+            print("    FAIL  initialize never completed; nothing else could run")
+        print("\n  NATIVE-READY — is this a connector, or does a human paste a key?")
+        for c in native:
+            print(f"    {'PASS' if c.ok else 'GAP '}  {c.name:<34} {c.detail}")
+        verdict = "MCP-conformant" if conf_ok else "NOT CONFORMANT"
+        native_verdict = (
+            "OAuth connector surface present"
+            if native_ok
+            else "key-paste only — no OAuth connector surface yet"
+        )
+        print(f"\n  → {verdict}; {native_verdict}\n")
+
+    if not conf_ok:
+        return 1
+    return 1 if (args.require_native and not native_ok) else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/deploy/dogfood/bin/reset-instance
+++ b/deploy/dogfood/bin/reset-instance
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# reset-instance — hand a dogfood stack back to FIRST RUN, without deleting anybody's work.
+#
+# A first-run rehearsal needs an instance that has never been claimed. This one has: the admin is
+# whatever identity happened to sign in first, which on a dogfood stack is usually a test account
+# (`minutes-test@vexa.ai`), and the setup wizard is marked complete. Neither fact can be undone from
+# any product surface, and the alternative to this script was hand surgery on a jsonb column by
+# whoever remembered the query.
+#
+# WHAT IT TOUCHES — three values, and nothing else:
+#   1. `users.data.is_admin` on the named user   → released, so the next sign-in claims the role
+#   2. `platform_settings.setup`                 → cleared, so the wizard runs again
+#   3. `platform_settings.global_setup`          → set to missing, so the company-layer gate goes up
+#
+# WHAT IT NEVER TOUCHES: workspaces, chats, meetings, transcripts, users, tokens, `_global/asks/`.
+# It is a role-and-flags reset, not a wipe. The founder's own account and everything in it survives
+# verbatim — that is the whole reason it is a script with a named blast radius rather than a
+# `docker volume rm`.
+#
+#   deploy/dogfood/bin/reset-instance [--admin-email minutes-test@vexa.ai] [--keep-global]
+#
+# --keep-global leaves the company layer accepted (only the wizard and the admin role reset), for
+# the case where you want to rehearse the claim but not re-type the company.
+set -euo pipefail
+
+ADMIN_EMAIL="minutes-test@vexa.ai"
+KEEP_GLOBAL=0
+STACK="${VEXA_DOGFOOD_STACK:-vexa-dogfood}"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --admin-email) ADMIN_EMAIL="$2"; shift 2 ;;
+    --keep-global) KEEP_GLOBAL=1; shift ;;
+    -h|--help) sed -n '2,25p' "$0"; exit 0 ;;
+    *) echo "unknown argument: $1" >&2; exit 2 ;;
+  esac
+done
+
+API="${STACK}-admin-api-1"
+env_of() { docker inspect "$API" --format '{{range .Config.Env}}{{println .}}{{end}}' | grep "^$1=" | cut -d= -f2- ; }
+
+SECRET="$(env_of INTERNAL_API_SECRET)"
+KEY="$(env_of ADMIN_API_TOKEN)"
+BASE="${VEXA_ADMIN_API_URL:-http://127.0.0.1:18457}"
+
+if [ -z "$SECRET" ] || [ -z "$KEY" ]; then
+  echo "could not read admin-api credentials from container $API — is the stack up?" >&2
+  exit 1
+fi
+
+say() { printf '  %s\n' "$*"; }
+
+echo "reset-instance — stack ${STACK}, admin-api ${BASE}"
+
+# 1 · the admin role. Resolve the user first so a typo in the address fails loudly instead of
+#     silently resetting nothing and leaving the rehearsal to discover it at the login screen.
+UID_JSON="$(curl -fsS -H "X-Admin-API-Key: ${KEY}" "${BASE}/admin/users/email/${ADMIN_EMAIL}" || true)"
+USER_ID="$(printf '%s' "$UID_JSON" | python3 -c 'import json,sys
+try: print(json.load(sys.stdin).get("id",""))
+except Exception: print("")' )"
+if [ -z "$USER_ID" ]; then
+  echo "no user with email ${ADMIN_EMAIL} — nothing to release" >&2
+  exit 1
+fi
+say "releasing the admin role from ${ADMIN_EMAIL} (user ${USER_ID})"
+curl -fsS -X POST -H "X-Internal-Secret: ${SECRET}" -H 'Content-Type: application/json' \
+  -d "{\"user_id\": \"${USER_ID}\"}" "${BASE}/internal/release-admin"
+echo
+
+# 2 · the first-run wizard. Empty strings CLEAR a field (the settings writers' documented rule),
+#     so the wizard's own probe reads "not completed" and it runs from step 1.
+say "clearing the first-run wizard state"
+curl -fsS -X PUT -H "X-Internal-Secret: ${SECRET}" -H 'Content-Type: application/json' \
+  -d '{"models": "", "transcription": "", "completed": "", "global": ""}' \
+  "${BASE}/internal/settings/setup"
+echo
+
+# 3 · the company-layer gate.
+if [ "$KEEP_GLOBAL" = "0" ]; then
+  say "putting the company-layer gate back up"
+  curl -fsS -X PUT -H "X-Internal-Secret: ${SECRET}" -H 'Content-Type: application/json' \
+    -d '{"state": "missing", "company": "", "completed_at": ""}' \
+    "${BASE}/internal/settings/global_setup"
+  echo
+else
+  say "--keep-global: leaving the company layer accepted"
+fi
+
+echo
+say "state now:"
+curl -fsS -H "X-Internal-Secret: ${SECRET}" "${BASE}/internal/instance"
+echo
+echo
+cat <<'NEXT'
+  The next sign-in at the terminal claims the admin role, meets the setup wizard
+  (model -> transcription -> company layer), and lands in the company-setup chat.
+  Until that chat calls mark_global_ready:
+    - a non-admin sign-in is refused with one sentence,
+    - the flows engine parks every fact instead of sending,
+    - flows_submit / flow_lifecycle refuse by name.
+  Nothing was deleted: workspaces, chats, meetings and _global/asks/ are untouched.
+NEXT

--- a/deploy/dogfood/bin/sim-lane-up.sh
+++ b/deploy/dogfood/bin/sim-lane-up.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Bring the SIM lane (db flows_sim, api :18201, mailbox vexa@sim.test) up on the LINE source.
+# Twin of ~/.storm/flows-up.sh; the only differences are the four lane-scoped values marked below.
+# Restore the old lane with:  bash ~/.storm/sim-flows-up.sh
+set -u
+FL="${VEXA_FLOWS_SRC:-$(cd "$(dirname "$0")/../../../core/flows" && pwd)}"          # <- the line, not wt-adoption-sim
+VENV="/home/dima/dev/vexa-flows1315/core/flows/.venv/bin/python"    # the venv, as both lanes use
+LOG=/tmp/sim-logs
+mkdir -p "$LOG"
+
+export PYTHONPATH="$FL/src"
+BASE=$(sed 's#/flows$##' "$HOME/.storm/dburl")
+export VEXA_FLOWS_DB_URL="$BASE/flows_sim"                          # <- lane db
+export VEXA_FLOWS_GATEWAY_URL="http://localhost:18456"
+export VEXA_FLOWS_AGENT_API_URL="http://localhost:18500"
+export VEXA_FLOWS_ADMIN_API_URL="http://localhost:18457"
+export VEXA_FLOWS_API_KEY="$(cat "$HOME/.storm/sim-flows-api-key")" # <- lane operator key
+export VEXA_FLOWS_ADMIN_KEY="$(docker inspect vexa-dogfood-admin-api-1 \
+  --format '{{range .Config.Env}}{{println .}}{{end}}' | grep '^ADMIN_API_TOKEN=' | cut -d= -f2)"
+export VEXA_INTERNAL_SECRET="$(cat "$HOME/.storm/internal-secret" 2>/dev/null)"
+if [ -z "${VEXA_INTERNAL_SECRET:-}" ]; then
+  echo 'sim-lane: REFUSING to start — no internal-tier secret; every meeting room would silently read zero desks.' >&2
+  exit 1
+fi
+export VEXA_UI_URL="https://app.dev.vexa.ai"
+export VEXA_MAIL_ADDR="vexa@sim.test"                                # <- lane mailbox
+export VEXA_MAIL_SMTP_HOST=127.0.0.1
+export VEXA_MAIL_SMTP_PORT=1025
+export VEXA_MAIL_SMTP_MODE=plain
+export VEXA_MAIL_INBOX=mailpit
+export VEXA_MAILPIT_URL=http://127.0.0.1:8025
+export VEXA_MAILPIT_LOOKBACK_S=300
+# The attendee fan-out's allow-list. The sim org's own domains, PLUS the rehearsal domain — without
+# it every follow-up to an @rehearse.test attendee is filtered and the flow reports success having
+# mailed nobody (the F3 defect, exactly).
+export VEXA_FLOWS_ATTENDEE_DOMAINS="rehearse.test,rehearsal.test,imageworks.example,bank.example"
+
+# LANE-SCOPED KILLS ONLY. '-m flows_worker' is the FOUNDER lane's argv and must never appear here;
+# the sim worker keeps its renamed argv0 for the same reason, so the founder lane's own pkill
+# cannot reach it. (flows-up.sh learned this the hard way and wrote it down.)
+pkill -f 'flows_integrations.flows_api:app --host 127.0.0.1 --port 18201' 2>/dev/null
+pkill -f 'sim_flows_worker' 2>/dev/null
+sleep 1
+
+cd "$FL" || exit 1
+nohup "$VENV" -m uvicorn flows_integrations.flows_api:app --host 127.0.0.1 --port 18201 \
+  > "$LOG/api.log" 2>&1 &
+echo "sim flows-api pid=$!"
+nohup "$VENV" -c "import sys; sys.argv[0]='sim_flows_worker'; import runpy; runpy.run_module('flows_worker', run_name='__main__')" \
+  > "$LOG/worker.log" 2>&1 &
+echo "sim flows-worker pid=$!"
+
+sleep 6
+echo '--- flows-api:'; curl -s -m 5 -o /dev/null -w '  GET :18201/flows -> %{http_code}\n' localhost:18201/flows
+echo '--- worker log:'; tail -8 "$LOG/worker.log"
+echo '--- api log:';    tail -4 "$LOG/api.log"

--- a/deploy/dogfood/bin/sim-mailbox-up.sh
+++ b/deploy/dogfood/bin/sim-mailbox-up.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# The SIM lane's inbound poller, on the LINE source. Reads mailpit for mail to vexa@sim.test and
+# admits invite.received / mail.reply into flows_sim. Twin of ~/.storm/sim-mailbox-up.sh; the only
+# change is the source tree (wt-adoption-sim -> wt-line).
+set -u
+FL_SRC="${VEXA_FLOWS_SRC:-$(cd "$(dirname "$0")/../../../core/flows" && pwd)}/src"
+VENV="/home/dima/dev/vexa-flows1315/core/flows/.venv/bin/python"
+export PYTHONPATH="$FL_SRC"
+BASE=$(sed 's#/flows$##' "$HOME/.storm/dburl")
+export VEXA_FLOWS_DB_URL="$BASE/flows_sim"
+export VEXA_MAIL_ADDR="vexa@sim.test"
+export VEXA_MAIL_INBOX=mailpit
+export VEXA_MAILPIT_URL=http://127.0.0.1:8025
+export VEXA_MAIL_SMTP_HOST=127.0.0.1
+export VEXA_MAIL_SMTP_PORT=1025
+export VEXA_MAIL_SMTP_MODE=plain
+export VEXA_FLOWS_GATEWAY_URL="http://localhost:18456"
+export VEXA_FLOWS_AGENT_API_URL="http://localhost:18500"
+export VEXA_FLOWS_ADMIN_API_URL="http://localhost:18457"
+export VEXA_FLOWS_ADMIN_KEY="$(docker inspect vexa-dogfood-admin-api-1 \
+  --format '{{range .Config.Env}}{{println .}}{{end}}' | grep '^ADMIN_API_TOKEN=' | cut -d= -f2)"
+export VEXA_INTERNAL_SECRET="$(cat "$HOME/.storm/internal-secret")"
+export VEXA_UI_URL="https://app.dev.vexa.ai"
+export VEXA_FLOWS_ATTENDEE_DOMAINS="rehearse.test,rehearsal.test,imageworks.example,bank.example"
+mkdir -p /tmp/sim-logs
+cd "$FL_SRC" || exit 1
+exec "$VENV" -u -m flows_integrations.mailbox 2>&1 | tee -a /tmp/sim-logs/mailbox.log

--- a/deploy/dogfood/env.dogfood.example
+++ b/deploy/dogfood/env.dogfood.example
@@ -1,0 +1,123 @@
+# deploy/dogfood — the long-lived MCP validation + dogfooding stack.
+#
+# This is a .env for the STOCK deploy/compose stack, not a fork of it. There is deliberately no
+# compose overlay here: a dogfooding stack that differs from what users run stops being evidence
+# about what users run. Everything below is a value, not a structural change.
+#
+# Install:  cp env.dogfood.example ../compose/.env.dogfood   (then edit the secrets)
+# Bring up: make -C deploy/dogfood up
+#
+# The port block is offset from the default compose block (180xx/130xx/5458/900x) so this stack
+# can sit alongside a release-train stack on the same host without a single collision.
+
+COMPOSE_PROJECT_NAME=vexa-dogfood
+
+# ── ports (dogfood block — every one offset from the deploy/compose defaults) ─────────────────
+API_GATEWAY_HOST_PORT=18456
+ADMIN_API_PORT=18457
+MEETING_API_PORT=18480
+RUNTIME_API_PORT=18490
+AGENT_API_PORT=18500
+MCP_HOST_PORT=18410
+TERMINAL_PORT=15400
+POSTGRES_HOST_PORT=5468
+MINIO_HOST_PORT=9400
+MINIO_CONSOLE_HOST_PORT=9401
+
+# ── images ────────────────────────────────────────────────────────────────────────────────────
+# Published, release-validated bytes only. A dogfood stack running a local source build proves
+# nothing about the release — pin the released tag you actually want to be living on, and bump it
+# deliberately. (`v012` is NOT a tag that exists; the published tags are `v0.12.NN`.)
+IMAGE_TAG=v0.12.23
+BROWSER_IMAGE=vexaai/vexa-bot:${IMAGE_TAG}
+# runtime spawns bot containers through the mounted docker.sock — this must be the HOST's docker
+# gid or every spawn fails on permission. On bbb: 998. Check with `getent group docker | cut -d: -f3`.
+DOCKER_GID=998
+LOG_LEVEL=info
+
+# ── datastores (stack-local; this stack owns its own universe) ─────────────────────────────────
+DB_NAME=vexa
+DB_USER=postgres
+DB_PASSWORD=CHANGE-ME
+STORAGE_BACKEND=minio
+MINIO_ROOT_USER=vexa-access-key
+MINIO_ROOT_PASSWORD=CHANGE-ME
+MINIO_ACCESS_KEY=vexa-access-key
+MINIO_SECRET_KEY=CHANGE-ME
+MINIO_BUCKET=vexa
+MINIO_ENDPOINT=minio:9000
+MINIO_SECURE=false
+
+# ── secrets ───────────────────────────────────────────────────────────────────────────────────
+# Long-lived and internet-reachable through nginx, so these are NOT the compose dev defaults.
+# Generate: openssl rand -hex 32
+ADMIN_TOKEN=CHANGE-ME
+INTERNAL_API_SECRET=CHANGE-ME
+VEXA_DISPATCH_SIGNING_KEY=CHANGE-ME
+NEXTAUTH_SECRET=CHANGE-ME
+
+# ── transcription ─────────────────────────────────────────────────────────────────────────────
+# bbb already runs transcription workers behind transcription-lb. Point at the same endpoint the
+# host's other stacks use rather than standing up GPU workers this stack does not need.
+TRANSCRIPTION_SERVICE_URL=
+TRANSCRIPTION_SERVICE_TOKEN=
+TRANSCRIPTION_MODEL=
+
+# ── public identity ───────────────────────────────────────────────────────────────────────────
+# The hostnames nginx fronts. Both are ONE label under dev.vexa.ai, deliberately: the existing
+# wildcard cert (*.dev.vexa.ai) and the wildcard DNS record cover exactly one level, so a
+# four-label name like terminal.mcp.dev.vexa.ai would need its own cert and its own record.
+#   mcp.dev.vexa.ai      → gateway  (the MCP endpoint + the API front door)
+#   dogfood.dev.vexa.ai  → terminal (where a human signs in and copies their API key)
+# CORS_ORIGINS must carry the terminal origin or browser login breaks.
+NEXTAUTH_URL=https://dogfood.dev.vexa.ai
+CORS_ORIGINS=https://mcp.dev.vexa.ai,https://dogfood.dev.vexa.ai
+
+# Google/Microsoft sign-in for the terminal. Each self-gates: set BOTH id and secret to show the
+# button. Redirect URI to register: ${NEXTAUTH_URL}/api/auth/callback/google
+GOOGLE_CLIENT_ID=
+GOOGLE_CLIENT_SECRET=
+MICROSOFT_CLIENT_ID=
+MICROSOFT_CLIENT_SECRET=
+MICROSOFT_TENANT_ID=common
+
+# Hidden admin panel — comma-separated email allowlist. Empty = off for everyone.
+VEXA_ADMIN_EMAILS=
+
+DEFAULT_BOT_NAME=Vexa
+RATE_LIMIT_RPM=
+RATE_LIMIT_ADMIN_RPM=
+RATE_LIMIT_WS_RPM=
+GA_MEASUREMENT_ID=
+VEXA_JITSI_HOSTS=
+
+# ── the rehearsal rig (deploy/dogfood/rig) ────────────────────────────────────────────────────
+# NOT a compose service: `rig.sh` supervises the control MCP, the flows API and the flows worker as
+# host PROCESSES, so these four are read by rig.sh and exported into the server it starts — not by
+# any container in the block above. They live here anyway because this file is the one .env a
+# dogfood host is told to fill in, and the rig used to carry all four as literals inside its own
+# source, where no deployment could reach them.
+#
+# Every one is optional: rig.sh defaults each to what the bbb host has always used, so an
+# unconfigured rig starts exactly as before. Set them when the rig runs anywhere else.
+
+# The flows checkout's core/flows directory. The rig's venv, the flows API and the flows worker all
+# run out of it, and the control server's fact_emit imports the engine from its src/. When it is
+# absent the server still starts and fact_emit alone reports itself unavailable, by name.
+VEXA_FLOWS_SRC=/home/dima/dev/vexa-flows1315/core/flows
+
+# The public name the control server PUBLISHES. It drives the sign-in links it hands out, the
+# /connect bootstrap and the transport's host guard at once — a server that publishes one name
+# while admitting another refuses its own users.
+VEXA_PUBLIC_MCP_URL=https://rig.dev.vexa.ai/mcp
+
+# The terminal that deeplink() sends people to (?ask= / ?view= / ?meeting=). Unset, the server
+# falls back to a localhost port nothing serves and every minted link is dead on arrival while
+# still looking perfectly well-formed.
+VEXA_UI_URL=https://app.dev.vexa.ai
+
+# The HMAC key agent-api mints `vxd_` delegation tokens with and the control server verifies them
+# against. rig.sh reads it from $HOME/.storm/delegation-secret and never echoes it; put the VALUE
+# in that file, not here. Unset, the server refuses every delegated token rather than admitting
+# them unverified — "not configured" means nobody gets in, never everybody.
+VEXA_MCP_DELEGATION_SECRET=

--- a/deploy/dogfood/nginx/README.md
+++ b/deploy/dogfood/nginx/README.md
@@ -1,0 +1,34 @@
+# deploy/dogfood/nginx — the vhosts
+
+`mcp.dev.vexa.ai.conf` serves the dogfood stack on two hostnames, both **one label** under
+`dev.vexa.ai` because the host's wildcard DNS record and wildcard certificate each cover exactly
+one level — a four-label name would need its own cert and its own record.
+
+| host | → | what it is |
+|---|---|---|
+| `mcp.dev.vexa.ai` | gateway `127.0.0.1:18456` | the MCP endpoint (`/mcp`) and the API front door |
+| `dogfood.dev.vexa.ai` | terminal `127.0.0.1:15400` | where a human signs in and copies an API key |
+
+An explicit `server_name` takes precedence over the `*.dev.vexa.ai` wildcard block, which
+otherwise routes everything to the K8s ingress.
+
+## Why the MCP vhost is not a stock proxy block
+
+The transport's two legs are not the same animal, and conflating them is a documented failure
+(`Vexa-ai/vexa#795`): `POST /mcp` is a short request/response, but `GET /mcp` is the server→client
+SSE stream — headers, then silence until the server pushes. A proxy that buffers that leg waits on
+the next body read of a healthy stream, hits its read timeout, and answers with a
+gateway-manufactured 503 the MCP service never saw.
+
+The shared `proxy_vexa.conf` already carries what that needs (`proxy_buffering off`,
+`proxy_read_timeout 86400`). This vhost adds the two things it does not: `gzip off` — a compression
+filter re-buffers an event stream even when proxy buffering is off — and
+`proxy_request_buffering off`.
+
+Install:
+
+```bash
+sudo cp mcp.dev.vexa.ai.conf /etc/nginx/sites-available/mcp.dev.vexa.ai
+sudo ln -s /etc/nginx/sites-available/mcp.dev.vexa.ai /etc/nginx/sites-enabled/mcp.dev.vexa.ai.conf
+sudo nginx -t && sudo systemctl reload nginx
+```

--- a/deploy/dogfood/nginx/mcp.dev.vexa.ai.conf
+++ b/deploy/dogfood/nginx/mcp.dev.vexa.ai.conf
@@ -1,0 +1,62 @@
+# Vexa MCP dogfood stack :: two hostnames on the existing *.dev.vexa.ai wildcard.
+#
+#   mcp.dev.vexa.ai      → gateway  127.0.0.1:18456   the MCP endpoint (/mcp) + the API front door
+#   dogfood.dev.vexa.ai  → terminal 127.0.0.1:15400   sign in, copy an API key
+#
+# An explicit server_name takes precedence over the *.dev.vexa.ai wildcard block in
+# dev.vexa.ai.conf, which otherwise routes everything to the K8s ingress on 8443.
+#
+# DNS + TLS need no work: *.dev.vexa.ai already CNAMEs to this host and the
+# dev.vexa.ai-0001 cert is a wildcard covering exactly one label.
+#
+# Install (sudo):
+#   cp mcp.dev.vexa.ai.conf /etc/nginx/sites-available/mcp.dev.vexa.ai
+#   ln -s /etc/nginx/sites-available/mcp.dev.vexa.ai /etc/nginx/sites-enabled/mcp.dev.vexa.ai.conf
+#   nginx -t && systemctl reload nginx
+
+server {
+    listen 443 ssl http2;
+    server_name mcp.dev.vexa.ai;
+
+    ssl_certificate     /etc/letsencrypt/live/dev.vexa.ai-0001/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/dev.vexa.ai-0001/privkey.pem;
+
+    # The MCP transport's two legs are not the same animal, and conflating them is the documented
+    # failure (Vexa-ai/vexa#795): POST /mcp is a short request/response, but GET /mcp is the
+    # server→client SSE stream — headers, then silence until the server pushes. A proxy that
+    # buffers that leg waits on the next body read of a healthy stream, hits its read timeout,
+    # and manufactures a 503 the MCP service never saw.
+    #
+    # proxy_vexa.conf already carries what that requires — `proxy_buffering off` and
+    # `proxy_read_timeout 86400` — so the shared include is correct here rather than in spite of
+    # itself. The two lines below are the ones it does NOT cover.
+    location / {
+        proxy_pass http://127.0.0.1:18456;
+        include    /etc/nginx/proxy_vexa.conf;
+
+        # Never let nginx's own gzip filter sit in front of an event stream: it buffers to fill a
+        # compression window, which reintroduces exactly the stall the setting above removes.
+        gzip off;
+        # No response chunk may wait on a nginx-side buffer boundary either.
+        proxy_request_buffering off;
+    }
+}
+
+server {
+    listen 443 ssl http2;
+    server_name dogfood.dev.vexa.ai;
+
+    ssl_certificate     /etc/letsencrypt/live/dev.vexa.ai-0001/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/dev.vexa.ai-0001/privkey.pem;
+
+    location / {
+        proxy_pass http://127.0.0.1:15400;
+        include    /etc/nginx/proxy_vexa.conf;
+    }
+}
+
+server {
+    listen 80;
+    server_name mcp.dev.vexa.ai dogfood.dev.vexa.ai;
+    return 301 https://$host$request_uri;
+}


### PR DESCRIPTION
Operating the long-lived validation stack: the instance scripts (blank, reset, sim lanes, invite
drop), the MCP validation entrypoint, the nginx front, the Makefile and the example env.

| | |
|---|---|
| **Area** | operating the dogfood stack |
| **Size** | +1413 / −0 across 13 files, against its base `review/10-rehearse` |
| **Line range** | the 11 commits of `minutes-mcp-viewer` touching these paths, inside [`3f5c3c030...7d838534a`](https://github.com/Vexa-ai/vexa/compare/3f5c3c030198b5e3d0d8339d66bece6136ada0d5...7d838534ac29954a28a25cc24f8745a9aa976f0f) |
| **Base** | `review/10-rehearse` — this PR shows only its own area; read the chain in order |
| **Open first** | deploy/dogfood/README.md · deploy/dogfood/Makefile |

Draft for code review of the `minutes-mcp-viewer` line; not for merge in this shape.

## Contribution rights
<!-- Select exactly ONE. This is a legal certification: an agent may explain the choices but
     must not select one for you. See CONTRIBUTOR_RIGHTS.md. -->

- [ ] **Independent:** I created this contribution, or otherwise have the right to submit it
  under Apache-2.0, and it is not owned or controlled by an employer, client, or other entity.
  <!-- rights:independent -->
- [ ] **Employer/client authorization required:** an employer, client, or other entity owns or
  may control this contribution. I am requesting Vexa's private corporate-authorization process.
  <!-- rights:corporate -->
- [ ] **Unsure:** I need a private rights review before merge.
  <!-- rights:uncertain -->

Every commit must also carry the contributor's own DCO `Signed-off-by` line. Selecting the
independent path means no individual CLA is required. Corporate and unsure paths do not stop
technical review, but they do block merge until resolved.

<!-- vexa-agent -->
