### PR TITLE
[DEV] rig runtime: seal every store at start, give the rig its own venv, stop it by pid

### DIFF
--- a/deploy/dogfood/rig/README.md
+++ b/deploy/dogfood/rig/README.md
@@ -44,15 +44,28 @@ each slice carrying only what the rehearsal proved worth carrying.
 API and worker as processes so edits are live on restart. Both expect the dogfood stack from
 `deploy/dogfood/` to be running.
 
+**The server runs out of its own venv, `./.venv`, built by `rig.sh up` from
+[`pyproject.toml`](pyproject.toml).** It used to run out of `$VEXA_FLOWS_SRC`'s venv — a stale,
+shared checkout's — and on 2026-09-03 that cost 2.5 minutes of downtime when a module the import
+chain reached was not installed there, and a fix that meant installing a package into a venv three
+other things also use. The flows API and worker still use the flows venv; they are that checkout's
+processes. The control server is not.
+
+**`rig.sh down` stops the server by pidfile** (`$HOME/.storm/run/control-mcp.pid`, or
+`VEXA_RIG_RUN_DIR`), never by `pkill -f`. The pattern matched stage-1's own ssh session on the same
+day, so stopping the rig killed the session doing the stopping.
+
 ### What it has to be told
 
-Four values, all optional, each defaulted to what the bbb host has always used — so an
+These, all optional, each defaulted to what the bbb host has always used — so an
 unconfigured rig starts exactly as before, and a rig anywhere else is four exports rather than an
 edit to the source. `rig.sh config` prints what the current environment resolves to.
 
 | variable | what it names | default |
 |---|---|---|
-| `VEXA_FLOWS_SRC` | the flows checkout's `core/flows`: the venv, the flows API, the worker, and the engine `fact_emit` imports | `/home/dima/dev/vexa-flows1315/core/flows` |
+| `VEXA_FLOWS_SRC` | the flows checkout's `core/flows`: the flows API, the worker, their venv, and the engine `fact_emit` imports. **Not the control server's interpreter any more** | `/home/dima/dev/wt-line/core/flows` |
+| `VEXA_RIG_VENV` | the control server's own venv, built from `pyproject.toml` on `up` | `./.venv` beside this README |
+| `VEXA_RIG_RUN_DIR` | where the pidfile `down` stops by is written | `$HOME/.storm/run` |
 | `VEXA_PUBLIC_MCP_URL` | the name the server PUBLISHES — sign-in links, the `/connect` bootstrap, and the transport's host guard at once | `https://rig.dev.vexa.ai/mcp` |
 | `VEXA_UI_URL` | the terminal `deeplink()` sends people to | `https://app.dev.vexa.ai` |
 | `VEXA_MCP_DELEGATION_SECRET` | the HMAC key `vxd_` delegation tokens are verified against; read from `$HOME/.storm/delegation-secret` and never echoed | unset → every delegated token is refused, none admitted unverified |

--- a/deploy/dogfood/rig/pyproject.toml
+++ b/deploy/dogfood/rig/pyproject.toml
@@ -1,0 +1,45 @@
+[project]
+name = "vexa-control-mcp"
+version = "0.12.0"
+description = "The storm rig's control MCP — one agent-facing surface over meetings, flows, workspaces, entities and sign-in, plus its own OAuth door and file viewer."
+requires-python = ">=3.11"
+
+# THE RIG'S OWN RUNTIME DEPENDENCIES. Until 2026-09-03 this file did not exist, so nothing anywhere
+# said what the server needs to run — and `rig.sh` started it out of
+# `~/dev/vexa-flows1315/core/flows/.venv`, a SHARED venv belonging to a stale checkout that
+# happened to be lying around. On 2026-09-03 that venv was missing a module the rig's import chain
+# reached, the server would not start, and it was down 2.5 minutes while stage-1 installed a
+# package into a venv three other things also run out of.
+#
+# Two halves to the fix and this is one of them: the rig declares what it imports, and `rig.sh`
+# builds `deploy/dogfood/rig/.venv` from this file. `tests/test_runtime_deps.py` fails if the rig
+# imports something this list does not name, so the declaration cannot quietly fall behind the code.
+#
+# NOT LISTED, deliberately:
+#   * `shared.git_redaction` / `control_plane.secret_store` — loaded BY PATH out of `core/agent`
+#     (see `rig_secrets._load_agent_module`). Both are stdlib-pure and a test holds them to it.
+#     Importing them as package members is what dragged pydantic into this process and took it
+#     down; they are source the rig reads, not a wheel it installs.
+#   * `flows`, `flows_defs` — imported in-process by `fact_emit` alone, out of the checkout
+#     `VEXA_FLOWS_SRC` names. A deployment input, not a pinned dependency: when the tree is absent
+#     the server still starts and that one tool reports itself unavailable, by name.
+dependencies = [
+    # The MCP server itself. `mcp.server.mcpserver.MCPServer` is 2.x — 1.16 does not carry it
+    # (checked, not assumed), so the floor is real and a 1.x venv fails at the first import.
+    "mcp>=2.0,<3",
+    # The ASGI server `__main__` runs. Starlette arrives with `mcp`; uvicorn does not.
+    "uvicorn>=0.30,<1",
+    # `_fdb()` — the friction table's legacy rows, read out of the flows Postgres.
+    "psycopg[binary]>=3.1,<4",
+]
+
+[dependency-groups]
+dev = ["pytest>=8,<10"]
+
+[tool.uv]
+package = false
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+# The server is a single file imported by name, the way `rig.sh` runs it.
+pythonpath = ["."]

--- a/deploy/dogfood/rig/rig.sh
+++ b/deploy/dogfood/rig/rig.sh
@@ -34,8 +34,9 @@ set -u
 # attendee follow-up, the note-date fix and the provenance lines. Previous value:
 #   FL="${VEXA_FLOWS_SRC:-/home/dima/dev/vexa-flows1315/core/flows}"
 FL="${VEXA_FLOWS_SRC:-/home/dima/dev/wt-line/core/flows}"
-# The venv still lives in the old checkout: same dependencies, and a worktree has none of
-# its own. Source and interpreter are different questions.
+# THE FLOWS VENV, for the flows processes only. It still lives in the old checkout: same
+# dependencies, and a worktree has none of its own. Source and interpreter are different questions.
+# The CONTROL SERVER no longer runs out of it — see RIG_VENV below.
 VENV_DIR="${VEXA_FLOWS_VENV:-/home/dima/dev/vexa-flows1315/core/flows}"
 PUBLIC_MCP_URL="${VEXA_PUBLIC_MCP_URL:-https://rig.dev.vexa.ai/mcp}"
 UI_URL="${VEXA_UI_URL:-https://app.dev.vexa.ai}"
@@ -46,8 +47,74 @@ RIG_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CTL="$RIG_DIR/vexa_control_mcp.py"
 
 V=$VENV_DIR/.venv/bin
+
+# ── THE RIG'S OWN VENV, AND ITS OWN PIDFILES ─────────────────────────────────────────────────
+# 2026-09-03, live, 2.5 minutes down: the control server was started with $V — the venv of
+# `~/dev/vexa-flows1315`, a stale checkout that three other things also run out of. A module the
+# rig's import chain reached was not installed there, so the server would not start, and the fix
+# had to be an install into a venv nobody owns. The rig had no dependency declaration and no
+# interpreter of its own; it borrowed whichever was nearest.
+#
+# It has both now. `deploy/dogfood/rig/pyproject.toml` says what it needs and this builds a venv
+# from exactly that, next to the source, so the flows venv can be rebuilt, moved or deleted
+# without taking the rig with it.
+RIG_VENV="${VEXA_RIG_VENV:-$RIG_DIR/.venv}"
+RV="$RIG_VENV/bin"
+UV="${UV:-uv}"
+
+ensure_venv() {
+  [ -x "$RV/python" ] && return 0
+  command -v "$UV" >/dev/null 2>&1 || {
+    echo "rig: no venv at $RIG_VENV and no uv to build one — install uv, or set VEXA_RIG_VENV" >&2
+    return 1
+  }
+  echo "rig: building $RIG_VENV from $RIG_DIR/pyproject.toml…"
+  "$UV" venv "$RIG_VENV" >/dev/null 2>&1 || return 1
+  # Runtime only. The dev group is pytest, which the rig does not need to serve.
+  "$UV" pip install --python "$RV/python" -r "$RIG_DIR/pyproject.toml" >/dev/null || {
+    echo "rig: could not install the rig's dependencies into $RIG_VENV" >&2
+    return 1
+  }
+}
+
+# STOP BY PID, NEVER BY PATTERN. `pkill -f vexa_control_mcp` matches any command line containing
+# that string, and on 2026-09-03 that included stage-1's own ssh session: stopping the rig killed
+# the session doing the stopping. `-f` is a substring search over other people's arguments, not
+# process identity.
+RUN_DIR="${VEXA_RIG_RUN_DIR:-$HOME/.storm/run}"
+CTL_PIDFILE="$RUN_DIR/control-mcp.pid"
+
+# What a recorded pid's command line must look like before we signal it. The pidfile is the
+# identity; this is only the guard against a pid that has been recycled since it was written —
+# between a crash and a `down`, that number can belong to anybody.
+CTL_PAT="vexa_control_mcp"
+
+stop_by_pidfile() {  # stop_by_pidfile <file> [pattern]
+  local f="${1:-}" pat="${2:-$CTL_PAT}" pid cmd
+  [ -n "$f" ] && [ -r "$f" ] || return 0
+  pid="$(head -1 "$f" 2>/dev/null | tr -dc '0-9')"
+  rm -f "$f"
+  [ -n "$pid" ] || return 0
+  kill -0 "$pid" 2>/dev/null || return 0          # already gone; the file was stale
+  cmd="$(ps -o command= -p "$pid" 2>/dev/null || true)"
+  case "$cmd" in
+    *"$pat"*) : ;;
+    *) echo "rig: pid $pid is no longer the rig ($cmd) — not signalling it"; return 0 ;;
+  esac
+  kill "$pid" 2>/dev/null
+  for _ in 1 2 3 4 5 6 7 8 9 10; do
+    kill -0 "$pid" 2>/dev/null || return 0
+    sleep 0.2
+  done
+  kill -9 "$pid" 2>/dev/null
+  return 0
+}
+
+# Sourced as a library (the tests drive these functions directly) — define and stop here.
+if [ -n "${RIG_SH_LIB:-}" ]; then return 0 2>/dev/null || exit 0; fi
+
 LOG=/tmp/storm-logs
-mkdir -p "$LOG"
+mkdir -p "$LOG" "$RUN_DIR"
 
 up_port() { ss -ltn 2>/dev/null | grep -q ":$1 "; }
 
@@ -71,12 +138,17 @@ lane_pids() {  # lane_pids <pattern>
 lane_up() { [ -n "$(lane_pids "$1")" ]; }
 
 start_ctl() {
+  ensure_venv || { echo "rig: refusing to start the control server without its own venv" >&2; return 1; }
+  stop_by_pidfile "$CTL_PIDFILE"
   tmux kill-session -t stormctl 2>/dev/null
+  # `echo $! > pidfile` INSIDE the session, so the pid recorded is the python process itself and
+  # not tmux's. The `wait` keeps the pane alive and the exit status honest.
   tmux new-session -d -s stormctl -c /tmp \
     "VEXA_FLOWS_SRC=\"$FL\" VEXA_PUBLIC_MCP_URL=\"$PUBLIC_MCP_URL\" VEXA_UI_URL=\"$UI_URL\" \
      VEXA_MCP_DELEGATION_SECRET=\"\$(cat \"\$HOME/.storm/delegation-secret\" 2>/dev/null)\" \
      INTERNAL_API_SECRET=\"\$(cat \"\$HOME/.storm/internal-secret\" 2>/dev/null)\" \
-     $V/python -u \"$CTL\" 2>&1 | tee $LOG/control-mcp.log"
+     $RV/python -u \"$CTL\" > >(tee $LOG/control-mcp.log) 2>&1 & \
+     echo \$! > \"$CTL_PIDFILE\"; wait"
 }
 start_api() {
   tmux kill-session -t stormapi 2>/dev/null
@@ -103,13 +175,15 @@ status() {
   printf "  %-18s %s\n" "control-mcp :18310" "$(up_port 18310 && echo UP || echo DOWN)"
   printf "  %-18s %s\n" "flows-worker"    "$(lane_up 'flows_worker' && echo "UP ($(lane_pids 'flows_worker' | tr '\n' ' '))" || echo DOWN)"
   printf "  %-18s %s\n" "lane checkout"   "$FL @ $(git -C "$FL" rev-parse --short HEAD 2>/dev/null || echo '?')"
+  printf "  %-18s %s\n" "rig venv"        "$([ -x "$RV/python" ] && echo "$RIG_VENV" || echo "ABSENT (rig.sh up builds it)")"
   printf "  %-18s %s\n" "dogfood gateway" "$(curl -s -m 4 localhost:18456/health >/dev/null && echo UP || echo DOWN)"
   echo "  tmux: $(tmux ls 2>/dev/null | grep -c storm) storm sessions"
 }
 
 case "${1:-status}" in
   status) echo "storm rig:"; status ;;
-  config) echo "flows src:  $FL"; echo "server:     $CTL"; echo "publishes:  $PUBLIC_MCP_URL"; echo "terminal:   $UI_URL" ;;
+  config) echo "flows src:  $FL"; echo "server:     $CTL"; echo "rig venv:   $RIG_VENV"
+          echo "pidfile:    $CTL_PIDFILE"; echo "publishes:  $PUBLIC_MCP_URL"; echo "terminal:   $UI_URL" ;;
   up)
     start_mailpit
     lane_up 'flows_integrations.flows_api' || start_api
@@ -120,8 +194,14 @@ case "${1:-status}" in
     start_mailpit; start_api; start_worker; start_ctl
     sleep 10; echo "storm rig restarted:"; status ;;
   down)
+    # The control server by PIDFILE; the flows processes by LANE (their PYTHONPATH names the
+    # checkout, which is the identity `lane_pids` was already written for). Neither is a pattern
+    # match against every command line on the host.
+    stop_by_pidfile "$CTL_PIDFILE"
     for s in stormctl stormapi stormworker stormflows; do tmux kill-session -t $s 2>/dev/null; done
-    pkill -f vexa_control_mcp; pkill -f flows_worker; pkill -f "uvicorn flows"
+    for pid in $(lane_pids 'flows_worker') $(lane_pids 'flows_integrations.flows_api'); do
+      kill "$pid" 2>/dev/null
+    done
     docker rm -f storm-mailpit >/dev/null 2>&1
     echo "storm rig down (dogfood stack untouched)" ;;
   *) echo "usage: rig.sh status|config|up|restart|down"; exit 1 ;;

--- a/deploy/dogfood/rig/rig_secrets.py
+++ b/deploy/dogfood/rig/rig_secrets.py
@@ -15,9 +15,17 @@ What this module is:
 * **The store is locked.** ``update()`` holds an exclusive ``flock`` across read-modify-write, so
   two concurrent sign-ins cannot lose a token, and the write underneath it is atomic, so a crash
   mid-write cannot empty the store and log everybody out.
-* **Legacy plaintext is migrated, then removed.** A ``~/.storm/<name>.json`` written by an older
-  rig is read once, sealed, verified by reading it back, and only then unlinked. A migration that
-  deletes before it verifies is a data-loss bug wearing a security fix.
+* **Legacy plaintext is migrated, then removed — EAGERLY, at process start.** A
+  ``~/.storm/<name>.json`` written by an older rig is read, sealed, verified by reading it back,
+  and only then unlinked. A migration that deletes before it verifies is a data-loss bug wearing a
+  security fix.
+
+  It used to happen on first READ of each store, which is correct per store and wrong for a
+  deployment: after the restart that shipped this module, only ``mcp-tokens`` had been read, so
+  only ``mcp-tokens`` was sealed and ``user-api-keys.json`` — every user's gateway API key — sat in
+  plaintext until some later call happened to want it. The migration had run. Nothing said it had
+  not finished, and nothing could, because no list of the stores existed anywhere. ``STORES`` is
+  that list, ``migrate_all()`` walks it at import, and both are gated by a test.
 * **One redactor, imported not copied.** ``redact``/``looks_like_token`` come from
   ``shared/git_redaction.py`` — the same detector agent-api uses — because the rig's hand-rolled
   six-prefix copy had already drifted past ``glpat-`` and bare userinfo URLs (R-D14).
@@ -38,6 +46,22 @@ HOME = pathlib.Path.home()
 #: Where the rig keeps its state. One variable so a test never touches a live store.
 STATE_DIR = pathlib.Path(os.environ.get("VEXA_RIG_STATE_DIR") or (HOME / ".storm"))
 
+#: EVERY store this module owns. The registry is half the fix for the lazy migration: without it
+#: there was no list to walk at start, and no way for anyone to ask whether the migration had
+#: finished. A new store that is not named here migrates late and silently, which is exactly the
+#: defect — so `tests/test_migration.py` fails if a caller uses a store name this tuple does not
+#: hold, and every reader below goes through `read`, which is what makes that check total.
+STORES = (
+    "mcp-tokens",        # vxa_mcp_ bearer -> {uid, email}
+    "user-api-keys",     # uid -> the gateway API key minted for them
+    "oauth/logins",      # setup code -> a short-lived login record
+    "oauth/email-codes",  # address -> the live 6-digit sign-in code
+    "oauth/regimes",     # uid -> {mode}: cloud or local
+    "oauth/clients",     # dynamic client registration (RFC 7591)
+    "oauth/codes",       # authorization codes, single use
+    "oauth/tokens",      # OAuth bearer tokens with their audience and expiry
+)
+
 
 def agent_src() -> str:
     """The importable ``core/agent`` tree — ``VEXA_AGENT_SRC``, else the nearest one above us.
@@ -56,22 +80,49 @@ def agent_src() -> str:
     return str(here.parents[3] / "core" / "agent") if len(here.parents) > 3 else ""
 
 
-def _import_agent(module: str):
-    src = agent_src()
-    if src and src not in sys.path:
-        sys.path.insert(0, src)
-    try:
-        return __import__(module, fromlist=["*"])
-    except ImportError as exc:  # pragma: no cover — a deployment input, named in the message
+def _load_agent_module(relpath: str, name: str):
+    """Load ONE file out of ``core/agent`` — by path, deliberately not as a package member.
+
+    2026-09-03, live: the rig was down 2.5 minutes on a missing ``pydantic_settings``. It was
+    never a dependency of anything the rig uses. ``shared/git_redaction.py`` imports ``re`` and
+    nothing else; ``control_plane/secret_store.py`` says of itself *"stdlib only. No new dependency
+    lands in the control-plane image for this"*. What pulled pydantic in was ``import
+    shared.git_redaction`` running ``shared/__init__.py``, which re-exports ``Settings`` from
+    ``shared.config``. The rig was paying for the whole agent control plane to get two regex
+    functions and an envelope format — and paying at BOOT, where the bill is an outage.
+
+    So the two files are loaded directly, under private names, executing no package ``__init__``.
+    The safety of that rests on their staying stdlib-pure, which is a contract with another lane
+    rather than an assumption: ``tests/test_runtime_deps.py`` fails at the gate, naming the module,
+    if either grows a third-party import — instead of the rig failing at its next restart, which
+    is how this was found the first time.
+    """
+    import importlib.util
+
+    src = pathlib.Path(agent_src()) / relpath
+    spec = importlib.util.spec_from_file_location(name, src)
+    if spec is None or spec.loader is None:
         raise RuntimeError(
-            f"the rig cannot import {module} from {src or '<unset>'}: {exc}. "
-            "Point VEXA_AGENT_SRC at the checkout's core/agent directory. This is not optional — "
-            "it carries the credential encryption and the redactor."
+            f"the rig cannot load {relpath} from {agent_src() or '<unset>'}. Point VEXA_AGENT_SRC "
+            "at the checkout's core/agent directory. This is not optional — it carries the "
+            "credential encryption and the redactor."
+        )
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    try:
+        spec.loader.exec_module(mod)
+    except Exception as exc:  # noqa: BLE001 — a deployment input, named in the message
+        sys.modules.pop(name, None)
+        raise RuntimeError(
+            f"the rig cannot load {src}: {type(exc).__name__}: {exc}. If this is a missing "
+            "third-party module, that file is no longer stdlib-pure and the rig must declare it "
+            "in deploy/dogfood/rig/pyproject.toml — see tests/test_runtime_deps.py."
         ) from exc
+    return mod
 
 
-_git_redaction = _import_agent("shared.git_redaction")
-_secret_store = _import_agent("control_plane.secret_store")
+_git_redaction = _load_agent_module("shared/git_redaction.py", "_rig_git_redaction")
+_secret_store = _load_agent_module("control_plane/secret_store.py", "_rig_secret_store")
 
 redact = _git_redaction.redact
 looks_like_token = _git_redaction.looks_like_token
@@ -184,6 +235,57 @@ def write(name: str, data: dict) -> dict:
     return update(name, lambda _cur: data)
 
 
+def migrate_all() -> dict:
+    """Seal EVERY legacy plaintext store now, and say what was found. Never raises.
+
+    Returns ``{"sealed": [...], "already": [...], "not_ours": [...], "failed": {...}}``.
+
+    ``not_ours`` is deliberate. `witness-data.json` was sitting in the live state directory beside
+    the stores and this module has no business sealing or deleting it — but staying silent about it
+    would repeat the original mistake one level up, where "the migration ran" was true and "the
+    plaintext is gone" was not. An operator reading this line sees what is still in the clear.
+    """
+    report = {"sealed": [], "already": [], "not_ours": [], "failed": {}}
+    for name in STORES:
+        try:
+            had_plaintext = _legacy_path(name).is_file()
+            read(name)                      # seals + verifies + unlinks when a legacy file is there
+            if not had_plaintext:
+                report["already"].append(name)
+            elif _legacy_path(name).is_file():
+                report["failed"][name] = "sealed copy did not read back; plaintext kept"
+            else:
+                report["sealed"].append(name)
+        except Exception as exc:            # noqa: BLE001 — a bad store must not stop the others
+            report["failed"][name] = f"{type(exc).__name__}: {exc}"
+    owned = {f"{n}.json" for n in STORES}
+    try:
+        for p in sorted(STATE_DIR.rglob("*.json")):
+            if p.is_file() and str(p.relative_to(STATE_DIR)) not in owned:
+                report["not_ours"].append(str(p.relative_to(STATE_DIR)))
+    except OSError:
+        pass
+    return report
+
+
+def _migrate_at_import() -> None:
+    """Run the migration when this module loads — which is process start for every entry point.
+
+    At import rather than from a `main()` because there are three entry points into this file's
+    consumers (the server, `vexa_oauth`, and the tests) and a migration you have to remember to
+    call is one that gets called from two of them. It is bounded work — eight small files — and it
+    cannot raise: an unstartable rig is a worse outcome than a late migration.
+    """
+    try:
+        report = migrate_all()
+    except Exception as exc:                # noqa: BLE001
+        print(f"[rig_secrets] migration skipped: {type(exc).__name__}: {exc}", flush=True)
+        return
+    if report["sealed"] or report["failed"] or report["not_ours"]:
+        print(f"[rig_secrets] sealed={report['sealed']} failed={report['failed']} "
+              f"plaintext-not-ours={report['not_ours']}", flush=True)
+
+
 def signing_key(name: str, env: str = "") -> bytes:
     """A stable server-side signing key, from ``env`` when the operator sets one, else generated
     once into the sealed store. Used for the short-lived view tokens that replaced the durable
@@ -201,3 +303,7 @@ def signing_key(name: str, env: str = "") -> bytes:
 
         held = update(f"keys/{name}", _mint).get("k", "")
     return str(held).encode("utf-8")
+
+
+
+_migrate_at_import()

--- a/deploy/dogfood/rig/tests/README.md
+++ b/deploy/dogfood/rig/tests/README.md
@@ -10,8 +10,12 @@ to a green suite (review row R-D20).
 ## Run them
 
 ```bash
-cd deploy/dogfood/rig && python3 -m pytest tests -q
+cd deploy/dogfood/rig && python3 -m pytest tests -q      # stdlib only, no venv needed
 ```
+
+The suite deliberately needs nothing installed. The server's own runtime dependencies are declared
+in `../pyproject.toml` and `rig.sh` builds `../.venv` from it — but a test run that required that
+venv would be a test run nobody does from a laptop.
 
 Offline and stdlib-only. `conftest.py` does two things so no test has to:
 
@@ -49,6 +53,18 @@ Gate 4c lives with the service that owns the scoping
 ([`core/flows/tests/test_reactions_scope.py`](../../../../core/flows/tests/test_reactions_scope.py))
 and gate 13 with the route it guards
 ([`clients/terminal/src/app/api/__tests__/minutesSeed.test.ts`](../../../../clients/terminal/src/app/api/__tests__/minutesSeed.test.ts)).
+
+## The runtime gates (added 2026-09-03, from three live findings on deploy)
+
+| gate | finding | holds |
+|---|---|---|
+| `test_migration.py` | the seal migration was LAZY | every known store is sealed at process start; the registry is total, so a new store cannot dodge it; plaintext this module does not own is reported rather than ignored |
+| `test_runtime_deps.py` | the rig had no venv and no dependency declaration | importing `rig_secrets` drags in no control-plane tree; the two borrowed `core/agent` files stay stdlib-pure; every third-party import is declared |
+| `test_rig_sh.py` | `rig.sh down` killed a bystander | `stop_by_pidfile` stops the rig and leaves a process whose command line merely *contains* the path alone; a recycled pid is not signalled |
+
+`test_rig_sh.py` drives `rig.sh`'s functions in bash (`RIG_SH_LIB=1 source rig.sh` defines them and
+returns before the dispatch). The `pkill` defect was behavioural — the string was in plain sight and
+looked fine — so reading the file would not have caught it.
 
 **Assert on the tool, not on the file.** The verbs are being split by owning domain; a test that
 greps this file dies the day it moves, and a test that calls the handler follows it.

--- a/deploy/dogfood/rig/tests/test_migration.py
+++ b/deploy/dogfood/rig/tests/test_migration.py
@@ -1,0 +1,130 @@
+"""Finding 1 (live, 2026-09-03) — the seal migration was LAZY, so a restart sealed almost nothing.
+
+`rig_secrets.read()` migrates a legacy plaintext store on FIRST READ. That is correct per store and
+wrong for the deployment: after the restart that shipped the sealed store, only `mcp-tokens` had
+been read, so only `mcp-tokens` was sealed. `user-api-keys.json` — every user's gateway API key —
+sat in plaintext until something happened to ask for it, which is a window measured in whatever the
+traffic happens to be. The migration ran; the operator had no way to know it had not finished.
+
+So the migration is EAGER: every known store at process start, and a registry that a new store
+cannot dodge.
+"""
+from __future__ import annotations
+
+import json
+import pathlib
+import tempfile
+
+import rig_secrets
+
+
+LEGACY = {
+    "mcp-tokens": {"vxa_mcp_AAA": {"uid": "1", "email": "a@b.c"}},
+    "user-api-keys": {"1": "gwkey_LIVEVALUE"},
+    "oauth/logins": {"code1": {"uid": "1", "email": "a@b.c", "exp": 9999999999}},
+    "oauth/email-codes": {"a@b.c": {"code": "123456", "exp": 9999999999, "tries": 0}},
+    "oauth/regimes": {"1": {"mode": "cloud"}},
+    "oauth/clients": {"cid": {"client_name": "someone"}},
+    "oauth/codes": {"c": {"cid": "cid"}},
+    "oauth/tokens": {"tok_LIVEBEARER": {"uid": "1", "exp": 9999999999}},
+}
+
+
+def _legacy_dir() -> pathlib.Path:
+    """A directory of plaintext stores exactly as an older rig left them: 0664, nothing sealed."""
+    d = pathlib.Path(tempfile.mkdtemp(prefix="rig-legacy-"))
+    for name, data in LEGACY.items():
+        p = d / f"{name}.json"
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(json.dumps(data, indent=1))
+        p.chmod(0o664)
+    return d
+
+
+def test_every_known_store_is_registered():
+    """The registry is the fix. A lazy migration is only half the defect — the other half is that
+    nothing anywhere listed the stores, so nobody could ask "did it finish?"."""
+    assert set(rig_secrets.STORES) >= set(LEGACY), \
+        f"a store is missing from the registry: {set(LEGACY) - set(rig_secrets.STORES)}"
+
+
+def test_process_start_leaves_no_plaintext_store_behind():
+    """GATE (finding 1). Start against a directory of legacy stores; none may remain."""
+    d = _legacy_dir()
+    original, rig_secrets.STATE_DIR = rig_secrets.STATE_DIR, d
+    try:
+        report = rig_secrets.migrate_all()
+
+        left = sorted(str(p.relative_to(d)) for p in d.rglob("*.json") if p.is_file())
+        assert left == [], f"plaintext stores survived process start: {left}"
+        assert sorted(report["sealed"]) == sorted(LEGACY), report
+
+        # …and the values came through, sealed, readable, owner-only.
+        for name, data in LEGACY.items():
+            assert rig_secrets.read(name) == data, name
+            enc = d / ".secrets" / f"{name}.enc"
+            assert enc.is_file() and oct(enc.stat().st_mode & 0o777) == "0o600"
+            assert b"gwkey_LIVEVALUE" not in enc.read_bytes()
+            assert b"tok_LIVEBEARER" not in enc.read_bytes()
+    finally:
+        rig_secrets.STATE_DIR = original
+
+
+def test_migration_is_idempotent_and_survives_a_second_start():
+    d = _legacy_dir()
+    original, rig_secrets.STATE_DIR = rig_secrets.STATE_DIR, d
+    try:
+        rig_secrets.migrate_all()
+        again = rig_secrets.migrate_all()
+        assert again["sealed"] == [], "a second start re-sealed something already sealed"
+        assert rig_secrets.read("user-api-keys") == LEGACY["user-api-keys"]
+    finally:
+        rig_secrets.STATE_DIR = original
+
+
+def test_a_plaintext_file_this_module_does_not_own_is_reported_not_ignored():
+    """`witness-data.json` was in the live finding and is NOT a store this module owns. Silence
+    about it would repeat the original mistake one level up: the operator reads "migration done"
+    and cannot tell that something plaintext is still sitting there."""
+    d = _legacy_dir()
+    (d / "witness-data.json").write_text('{"seen": 1}')
+    original, rig_secrets.STATE_DIR = rig_secrets.STATE_DIR, d
+    try:
+        report = rig_secrets.migrate_all()
+        assert "witness-data.json" in report["not_ours"], report
+        assert (d / "witness-data.json").is_file(), "it is not ours to delete"
+    finally:
+        rig_secrets.STATE_DIR = original
+
+
+def test_no_store_name_in_the_rig_escapes_the_registry():
+    """The registry is only a fix while it is TOTAL. Read the store-name constants out of the two
+    rig modules and require each one's value to be registered — otherwise the next store added
+    migrates late and silently, which is the defect this file exists to close.
+
+    (`signing_key` mints `keys/<name>` on demand; those are born sealed by `update` and never have
+    a plaintext ancestor, so they are not migration candidates and are not registered.)
+    """
+    import ast
+
+    rig_dir = pathlib.Path(__file__).resolve().parents[1]
+    declared = {
+        "vexa_control_mcp.py": ("TOKENS_STORE", "EMAIL_CODES_STORE", "LOGINS_STORE",
+                                "REGIMES_STORE", "USER_KEYS_STORE"),
+        "vexa_oauth.py": ("CLIENTS", "CODES", "TOKENS"),
+    }
+    seen = set()
+    for fname, names in declared.items():
+        tree = ast.parse((rig_dir / fname).read_text())
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Assign):
+                continue
+            for t in node.targets:
+                if isinstance(t, ast.Name) and t.id in names:
+                    assert isinstance(node.value, ast.Constant), f"{fname}:{t.id} is not a name"
+                    seen.add(node.value.value)
+                    assert node.value.value in rig_secrets.STORES, (
+                        f"{fname}:{t.id} = {node.value.value!r} is not in rig_secrets.STORES — "
+                        "an unregistered store migrates late and silently")
+    assert seen == set(rig_secrets.STORES), \
+        f"registry and callers disagree: only-in-registry={set(rig_secrets.STORES) - seen}"

--- a/deploy/dogfood/rig/tests/test_rig_sh.py
+++ b/deploy/dogfood/rig/tests/test_rig_sh.py
@@ -1,0 +1,101 @@
+"""Finding 3 (live, 2026-09-03) — `rig.sh down` killed a bystander.
+
+`down` ran `pkill -f vexa_control_mcp`, which matches any process whose COMMAND LINE contains that
+string. Stage-1 was connected over ssh with the path in its own command line, so stopping the rig
+also killed the session that was stopping it. `-f` matching is not process identity; it is a
+substring search over other people's arguments.
+
+Finding 2's other half is here too: the rig has never had a venv, so `rig.sh` ran it out of a
+stale, shared checkout's one.
+
+These tests drive the script's own functions in bash rather than reading it, because the defect
+was behavioural: the string was right there in plain sight and looked fine.
+"""
+from __future__ import annotations
+
+import os
+import pathlib
+import subprocess
+import tempfile
+import time
+
+RIG_SH = pathlib.Path(__file__).resolve().parents[1] / "rig.sh"
+
+
+def _bash(script: str, **env) -> subprocess.CompletedProcess:
+    """Source rig.sh as a LIBRARY (no dispatch) and run `script` against its functions."""
+    return subprocess.run(
+        ["bash", "-c", f'set -u; RIG_SH_LIB=1 source "{RIG_SH}"\n{script}'],
+        capture_output=True, text=True,
+        env={**os.environ, "HOME": env.pop("HOME", os.environ["HOME"]), **env})
+
+
+def test_the_stop_path_does_not_pattern_match_command_lines():
+    # EXECUTABLE lines only. The comment above the fix quotes the old command deliberately —
+    # a reader who does not know what was there cannot tell why the pidfile is worth the code.
+    code = [ln for ln in RIG_SH.read_text().splitlines()
+            if ln.strip() and not ln.lstrip().startswith("#")]
+    offending = [ln for ln in code if "pkill" in ln]
+    assert offending == [], (
+        "`pkill -f` matched stage-1's own ssh command line and killed it. A pidfile names one "
+        f"process; a substring names whoever happens to be typing. Still here: {offending}")
+
+
+def test_stop_kills_the_rig_and_leaves_a_bystander_alone():
+    """THE LIVE BUG, reproduced: a bystander whose command line contains `vexa_control_mcp.py`.
+
+    Here it is a `sleep` given that argument — which is exactly the shape stage-1's ssh session had.
+    """
+    state = pathlib.Path(tempfile.mkdtemp(prefix="rig-sh-"))
+    out = _bash(f'''
+        RUN_DIR="{state}"
+        # the rig itself — command line exactly the shape rig.sh starts, pid recorded
+        bash -c 'exec -a "python -u /home/dima/.storm/vexa_control_mcp.py" sleep 30' & RIG_PID=$!
+        echo $RIG_PID > "$RUN_DIR/control-mcp.pid"
+        # the bystander: stage-1's ssh session, whose command line ALSO carries the path.
+        # Nothing about the two strings tells them apart — only the pid does.
+        bash -c 'exec -a "ssh bbb tail -f vexa_control_mcp.py" sleep 30' & BYSTANDER=$!
+        sleep 0.3
+        stop_by_pidfile "$RUN_DIR/control-mcp.pid" >/dev/null 2>&1
+        sleep 0.5
+        kill -0 $RIG_PID 2>/dev/null && echo "RIG_ALIVE" || echo "RIG_DEAD"
+        kill -0 $BYSTANDER 2>/dev/null && echo "BYSTANDER_ALIVE" || echo "BYSTANDER_DEAD"
+        kill $BYSTANDER 2>/dev/null
+        [ -e "$RUN_DIR/control-mcp.pid" ] && echo "PIDFILE_KEPT" || echo "PIDFILE_CLEARED"
+    ''')
+    assert "RIG_DEAD" in out.stdout, out
+    assert "BYSTANDER_ALIVE" in out.stdout, (
+        "the bystander died — this is the live incident, reproduced", out.stdout, out.stderr)
+    assert "PIDFILE_CLEARED" in out.stdout, out.stdout
+
+
+def test_stop_is_safe_when_the_pid_has_been_reused_or_is_gone():
+    """A stale pidfile must not kill whatever now holds that number. The recorded pid is checked
+    against the command line before the signal — belt for the pidfile's braces."""
+    state = pathlib.Path(tempfile.mkdtemp(prefix="rig-sh-"))
+    out = _bash(f'''
+        RUN_DIR="{state}"
+        bash -c 'exec -a "some other program entirely" sleep 30' & OTHER=$!
+        echo $OTHER > "$RUN_DIR/control-mcp.pid"
+        sleep 0.3
+        stop_by_pidfile "$RUN_DIR/control-mcp.pid" >/dev/null 2>&1
+        sleep 0.3
+        kill -0 $OTHER 2>/dev/null && echo "OTHER_ALIVE" || echo "OTHER_DEAD"
+        kill $OTHER 2>/dev/null
+        echo "---"
+        echo 999999 > "$RUN_DIR/control-mcp.pid"
+        stop_by_pidfile "$RUN_DIR/control-mcp.pid" >/dev/null 2>&1; echo "exit=$?"
+    ''')
+    assert "OTHER_ALIVE" in out.stdout, ("a reused pid was killed", out.stdout, out.stderr)
+    assert "exit=0" in out.stdout, ("a stale pidfile must not fail the stop", out.stdout)
+
+
+def test_the_rig_runs_out_of_its_own_venv():
+    body = RIG_SH.read_text()
+    assert "$RIG_DIR/.venv" in body, \
+        "rig.sh still borrows another checkout's venv (finding 2)"
+    assert "pyproject.toml" in body, "the venv is not built from the rig's own declaration"
+    # The interpreter the server is launched with must come from the rig's venv, not from $FL's.
+    launch = [ln for ln in body.splitlines() if "$CTL" in ln and "python" in ln]
+    assert launch, "cannot find the line that launches the server"
+    assert all("VENV" not in ln or "RIG" in ln for ln in launch), launch

--- a/deploy/dogfood/rig/tests/test_runtime_deps.py
+++ b/deploy/dogfood/rig/tests/test_runtime_deps.py
@@ -1,0 +1,120 @@
+"""Finding 2 (live, 2026-09-03) — the rig was down 2.5 minutes for a dependency it does not use.
+
+What happened: `rig.sh` runs the server out of `~/dev/vexa-flows1315/core/flows/.venv`, a SHARED
+venv belonging to a stale checkout, because the rig has never had one of its own. This module's
+`import shared.git_redaction` then failed on a missing `pydantic_settings`, the server would not
+start, and stage-1 had to install a package into that shared venv to bring it back.
+
+The dependency was never real. `shared/git_redaction.py` imports `re` and nothing else — it is
+stdlib-pure by design, and so is `control_plane/secret_store.py` ("stdlib only. No new dependency
+lands in the control-plane image for this"). What dragged pydantic in was the PACKAGE: importing
+`shared.git_redaction` executes `shared/__init__.py`, which re-exports `Settings` from
+`shared.config`, which is pydantic-settings. The rig paid for the entire agent control plane to get
+two regex functions.
+
+So the rig loads those two files DIRECTLY, by path, and these tests hold the three things that
+makes true: the import is light, the two modules stay stdlib-pure, and the behaviour is identical
+to importing them as modules.
+"""
+from __future__ import annotations
+
+import ast
+import pathlib
+import subprocess
+import sys
+
+import rig_secrets
+
+RIG_DIR = pathlib.Path(__file__).resolve().parents[1]
+BORROWED = ("shared/git_redaction.py", "control_plane/secret_store.py")
+
+
+def test_importing_rig_secrets_does_not_drag_in_the_control_plane():
+    """GATE (finding 2). A subprocess, because the parent may already hold pydantic for other
+    reasons — the question is what a FRESH interpreter has to have installed to import this."""
+    probe = (
+        "import sys, json;"
+        f"sys.path.insert(0, {str(RIG_DIR)!r});"
+        "import rig_secrets;"
+        "print(json.dumps(sorted(m for m in sys.modules "
+        "if m.split('.')[0] in {'pydantic', 'pydantic_settings', 'shared', 'control_plane'})))"
+    )
+    out = subprocess.run([sys.executable, "-c", probe], capture_output=True, text=True,
+                         env={**_env(), "VEXA_RIG_STATE_DIR": str(rig_secrets.STATE_DIR)})
+    assert out.returncode == 0, out.stderr[-2000:]
+    dragged = out.stdout.strip().splitlines()[-1]
+    assert dragged == "[]", (
+        f"importing rig_secrets pulled in {dragged} — the rig is paying for the agent control "
+        "plane's dependency tree to get two stdlib-pure files, which is what took it down")
+
+
+def test_the_two_borrowed_modules_are_stdlib_pure():
+    """The rig's contract with `core/agent`: these two files carry no third-party import.
+
+    Loading them by path is only safe while that holds. If one of them grows a dependency, this
+    fails HERE — at the gate, naming the module — rather than at the rig's next restart, which is
+    where it failed the first time."""
+    std = set(sys.stdlib_module_names)
+    for rel in BORROWED:
+        src = pathlib.Path(rig_secrets.agent_src()) / rel
+        assert src.is_file(), f"{rel} moved — rig_secrets loads it by path"
+        outside = set()
+        for node in ast.walk(ast.parse(src.read_text())):
+            if isinstance(node, ast.Import):
+                outside |= {a.name.split(".")[0] for a in node.names}
+            elif isinstance(node, ast.ImportFrom) and node.level == 0 and node.module:
+                outside.add(node.module.split(".")[0])
+        assert not (outside - std), f"{rel} now imports {sorted(outside - std)}"
+
+
+def test_the_borrowed_code_behaves_exactly_as_the_module_would():
+    """Loading by path must not be a fork. Same functions, same answers."""
+    assert rig_secrets.redact("ghp_" + "A" * 36) != "ghp_" + "A" * 36
+    assert rig_secrets.looks_like_token("glpat-" + "A" * 20)
+    assert rig_secrets.TOKEN_PREFIXES and "ghp_" in rig_secrets.TOKEN_PREFIXES
+    sealed = rig_secrets._secret_store.seal("hello", b"k" * 32)
+    assert rig_secrets._secret_store.unseal(sealed, b"k" * 32) == "hello"
+    assert rig_secrets._secret_store.unseal(sealed, b"x" * 32) is None
+
+
+def test_every_third_party_import_in_the_rig_is_declared():
+    """GATE (finding 2, the other half). The rig had no `pyproject.toml`, so nothing anywhere said
+    what it needs to run — which is why it was started against whatever venv was lying around."""
+    import tomllib
+
+    pyproject = RIG_DIR / "pyproject.toml"
+    assert pyproject.is_file(), "the rig still has no dependency declaration"
+    meta = tomllib.loads(pyproject.read_text())
+    declared = {_dist(d) for d in meta["project"]["dependencies"]}
+
+    std = set(sys.stdlib_module_names)
+    local = {"vexa_control_mcp", "vexa_oauth", "rig_secrets", "mcpcli", "rehearse",
+             "shared", "control_plane",          # loaded by path, never installed
+             "flows", "flows_defs"}              # VEXA_FLOWS_SRC, a deployment input
+    used = set()
+    for f in ("vexa_control_mcp.py", "vexa_oauth.py", "rig_secrets.py", "mcpcli.py"):
+        for node in ast.walk(ast.parse((RIG_DIR / f).read_text())):
+            if isinstance(node, ast.Import):
+                used |= {a.name.split(".")[0] for a in node.names}
+            elif isinstance(node, ast.ImportFrom) and node.level == 0 and node.module:
+                used.add(node.module.split(".")[0])
+    missing = {m for m in used if m not in std and m not in local} - {_mod(d) for d in declared}
+    assert not missing, f"imported by the rig and declared nowhere: {sorted(missing)}"
+
+
+_DIST_TO_MODULE = {"mcp": "mcp", "uvicorn": "uvicorn", "psycopg": "psycopg"}
+
+
+def _dist(spec: str) -> str:
+    for sep in (">=", "<=", "==", "~=", ">", "<", "[", ";"):
+        spec = spec.split(sep)[0]
+    return spec.strip()
+
+
+def _mod(dist: str) -> str:
+    return _DIST_TO_MODULE.get(dist, dist.replace("-", "_"))
+
+
+def _env():
+    import os
+    return {k: v for k, v in os.environ.items()}


### PR DESCRIPTION
Three findings from deploying [#1430](https://github.com/Vexa-ai/vexa/pull/1430), all observed live
on the rig host on 2026-09-03. Owning issue:
[`DmitriyG228/biz#452`](https://github.com/DmitriyG228/biz/issues/452).

**COMMITMENTS IN THIS DRAFT — none.** No live store touched, nothing deployed, no external
recipient. Every test here is offline; no containers.

Each finding is reproduced by a failing test first, then fixed.

## 1 · The seal migration was lazy, so a restart sealed almost nothing

**Symptom.** `rig_secrets.read()` migrated a legacy plaintext store on *first read of that store*.
Correct per store, wrong for a deployment: after the restart that shipped the sealed store, only
`mcp-tokens` had been read, so only `mcp-tokens` was sealed. `user-api-keys.json` — **every user's
gateway API key** — sat in plaintext until some later call happened to want it. The migration ran.
Nothing said it had not finished, and nothing *could*, because no list of the stores existed
anywhere.

**Change.**

* `rig_secrets.py:54-71` — `STORES`, the registry that did not exist. Eight names, each commented
  with what it holds.
* `rig_secrets.py:238-268` — `migrate_all()`: seal → verify readback → unlink, per store, never
  raising, returning `{sealed, already, not_ours, failed}`.
* `rig_secrets.py:271-289`, called at `:309` — runs at **import**, which is process start for every
  entry point. At import rather than from a `main()` because there are three ways into this
  module's consumers and a migration you have to remember to call gets called from two of them.
* `not_ours` is deliberate: `witness-data.json` was sitting in the live state directory and is not
  this module's to seal or delete — but silence about it would repeat the original mistake one level
  up, where *"the migration ran"* was true and *"the plaintext is gone"* was not. It is printed.

**Proof** — `tests/test_migration.py`, red first:

* start against a directory of eight legacy `0664` stores → **no `*.json` survives**, every value
  readable, every `.enc` `0600`;
* the registry is **total**: an AST check reads the store-name constants out of `vexa_control_mcp.py`
  and `vexa_oauth.py` and fails if any names a store `STORES` does not hold — otherwise the next
  store added migrates late and silently, which is this defect;
* idempotent on a second start; `witness-data.json` is reported and left alone.

## 2 · No venv, no dependency declaration — and the dependency was never real

**Symptom.** `rig.sh` ran the server out of `~/dev/vexa-flows1315/core/flows/.venv`, a **shared,
stale checkout's** venv, because the rig had never had one. `pydantic_settings` was missing there,
the server would not start, and it was down 2.5 minutes while stage-1 installed a package into a
venv three other things also run out of.

**The root cause is worth stating precisely, because it changes the fix.** The rig does not use
pydantic-settings. `shared/git_redaction.py` imports `re` and nothing else;
`control_plane/secret_store.py` says of itself *"stdlib only. No new dependency lands in the
control-plane image for this"*. What dragged it in was the **package**: `import
shared.git_redaction` executes `shared/__init__.py`, which re-exports `Settings` from
`shared.config`. The rig was paying for the entire agent control plane to get two regex functions
and an envelope format — and paying at boot, where the bill is an outage.

Checked, not assumed: **`mcp` depends on `pydantic` but not on `pydantic-settings`.** So declaring
the rig's dependencies alone would *not* have prevented this outage. Both halves are needed.

**Change.**

* `rig_secrets.py:83-121` — `_load_agent_module()` loads those two files **by path**, under private
  module names, executing no package `__init__`. `:124-125` are the two call sites.
* `deploy/dogfood/rig/pyproject.toml` — **new.** Runtime: `mcp>=2.0,<3` (2.x is where
  `mcp.server.mcpserver.MCPServer` lives — 1.16 does not carry it, checked against the index),
  `uvicorn>=0.30,<1` (starlette arrives with `mcp`; uvicorn does not), `psycopg[binary]>=3.1,<4`
  (`_fdb()`). `dev = pytest`. What is deliberately *not* declared, and why, is written into the file:
  the two by-path modules, and `flows`/`flows_defs`, which are `VEXA_FLOWS_SRC` — a deployment input
  whose absence already degrades one tool by name rather than failing the server.
* `rig.sh:61-79` — `RIG_VENV` (`./.venv`, or `VEXA_RIG_VENV`) and `ensure_venv()`, which builds it
  from `pyproject.toml` with `uv`. `rig.sh:150` launches the server with `$RV/python`, not `$V`.
  `start_ctl` refuses to start without it rather than silently borrowing one.
* The flows API and worker still use the flows venv — they are that checkout's processes. The
  control server is not.

**Proof** — `tests/test_runtime_deps.py`, red first (it printed the whole pydantic tree):

* a **fresh subprocess** importing `rig_secrets` pulls in no `pydantic`, `pydantic_settings`,
  `shared` or `control_plane`;
* the two borrowed files are **stdlib-pure**, asserted by AST — so if either grows a dependency it
  fails *here*, naming the module, instead of at the rig's next restart, which is how this was found
  the first time;
* by-path loading is not a fork — `redact`, `looks_like_token`, `seal`/`unseal` all behave;
* every third-party import in the rig is declared in `pyproject.toml`.

And end to end, by hand: `ensure_venv` built `./.venv`, and the server imports from it — 64 tools —
with **`pydantic-settings` not installed**. The exact live failure is now impossible.

## 3 · `rig.sh down` killed the session that was running it

**Symptom.** `pkill -f vexa_control_mcp` matches any process whose *command line contains that
string*. Stage-1 was connected over ssh with the path in its own command line, so stopping the rig
killed the session doing the stopping. `-f` is a substring search over other people's arguments, not
process identity.

**Change.**

* `rig.sh:84-112` — `RUN_DIR` / `CTL_PIDFILE` and `stop_by_pidfile()`: read the pid, TERM, wait,
  KILL, remove the file; never fail a stop. Before signalling it checks the pid's command line
  (`ps -o command=`) — the pidfile is the identity, that check is the guard against a pid recycled
  between a crash and a `down`.
* `rig.sh:142-152` — `start_ctl` records the pid **inside** the tmux session, so what is recorded is
  the python process and not tmux's.
* `rig.sh:200-204` — `down` stops the server by pidfile and the flows processes by **lane**
  (`lane_pids`, which reads each process's own `PYTHONPATH` — the identity that function already
  existed for). **No `pkill` survives in any executable line.**
* `rig.sh:114` — `RIG_SH_LIB=1 source rig.sh` defines the functions and returns before the dispatch,
  so the tests can drive them.

**Proof** — `tests/test_rig_sh.py`, red first, and it reproduces the incident rather than reading the
file: two processes are started whose command lines **both** contain `vexa_control_mcp.py` — one the
rig, one shaped like stage-1's ssh session — and only the rig's pid is recorded. After
`stop_by_pidfile`: rig dead, **bystander alive**. A second test puts an unrelated process's pid in a
stale pidfile and requires it to survive. The defect was behavioural — the string was in plain sight
and looked fine — so a grep-shaped test would not have caught it.

## Gates

```
deploy/dogfood/rig                     37 passed   (was 24; +13 across the three findings)
core/agent + core/flows + rehearse   2108 passed, 2 skipped
pre-push static gates                 14/14 green   (pushed without --no-verify)
```

Nothing needed a container, so nothing ran on bbb.

## For an operator

* `rig.sh up` now builds `deploy/dogfood/rig/.venv` on first run (needs `uv`, or set
  `VEXA_RIG_VENV` at an existing one). `.venv/` is already gitignored.
* First start after this seals every remaining store and prints one line naming what it sealed, what
  failed, and any plaintext in the state directory that is **not** the rig's — expect
  `user-api-keys.json` and the oauth stores in that first `sealed=` list, and `witness-data.json` in
  `plaintext-not-ours`. Those keys were world-readable before #1430; sealing preserves the values and
  does not un-expose them, so the rotation step in #1430's description still stands.
* New knobs: `VEXA_RIG_VENV`, `VEXA_RIG_RUN_DIR` (pidfile location, default `$HOME/.storm/run`).
