### PR TITLE
An operator can see which parts of the MCP front door are actually configured

### DIFF
--- a/core/meetings/services/mcp/src/vexa_mcp/app.py
+++ b/core/meetings/services/mcp/src/vexa_mcp/app.py
@@ -590,6 +590,12 @@ def create_app(
                       this deployment carries, and how their manifests are fetched. `VEXA_MCP_ASSEMBLY_OFF`
                       skips assembly entirely, which is what the fourteen-tool surface tests want.
     """
+    # REFUSE TO BOOT MISCONFIGURED (ADR-0026), the same first move every other adopted service
+    # makes. This service shipped with eleven env keys, no declaration and no preflight — the one
+    # service whose whole job is to be the product's front door was the one nothing checked.
+    from .config_preflight import preflight
+    preflight()
+
     base_url = (gateway_url or os.getenv("GATEWAY_URL") or _DEFAULT_GATEWAY_URL).rstrip("/")
 
     _vexa_env = os.getenv("VEXA_ENV", "development")
@@ -642,7 +648,18 @@ def create_app(
     # --- liveness probe (compose healthcheck) — no auth, no downstream call.
     @app.get("/health", include_in_schema=False)
     async def health():
-        return {"status": "ok", "service": "mcp"}
+        """Liveness, plus the CONFIGURED/NOT_CONFIGURED state of each named capability (ADR-0026).
+
+        A green health check on a service whose ticket sink is unset, or whose assembly reached no
+        domain, is a green light on a product that quietly does less than the operator thinks. The
+        tri-state is computed from the declaration, so it cannot drift from what the keys mean."""
+        body = {"status": "ok", "service": "mcp"}
+        try:
+            from .config_preflight import capability_states
+            body["capabilities"] = capability_states()
+        except Exception:  # noqa: BLE001 — health must answer even if the declaration is unreadable
+            pass
+        return body
 
     # --- validation errors an agent can act on.
     # The stock message is "Input validation error: 'meeting_id' is a required property": it names

--- a/core/meetings/services/mcp/src/vexa_mcp/config.v1.json
+++ b/core/meetings/services/mcp/src/vexa_mcp/config.v1.json
@@ -1,0 +1,165 @@
+{
+  "contract": "config.v1",
+  "service": "mcp",
+  "keys": [
+    {
+      "key": "GATEWAY_URL",
+      "class": "defaulted",
+      "default": "http://gateway:8000",
+      "description": "The PUBLIC API this service forwards every built-in tool to, with the caller's own key. It never reaches past the gateway.",
+      "targets": [
+        "compose"
+      ]
+    },
+    {
+      "key": "PORT",
+      "class": "defaulted",
+      "default": "8010",
+      "description": "The port the MCP transport listens on; the gateway's MCP_URL points here.",
+      "targets": [
+        "compose"
+      ]
+    },
+    {
+      "key": "HOST",
+      "class": "defaulted",
+      "default": "0.0.0.0",
+      "description": "Bind address. Container-internal only \u2014 the gateway is the edge.",
+      "targets": []
+    },
+    {
+      "key": "VEXA_ENV",
+      "class": "defaulted",
+      "default": "development",
+      "description": "`production` closes /docs, /redoc and /openapi.json on the PUBLIC app. Note the ASSEMBLER still reads each DOMAIN's OpenAPI over the internal network to derive tool schemas \u2014 that is a different app's docs, on a different edge.",
+      "targets": [
+        "compose"
+      ]
+    },
+    {
+      "key": "LOG_LEVEL",
+      "class": "defaulted",
+      "default": "info",
+      "description": "Log verbosity.",
+      "targets": [
+        "compose"
+      ]
+    },
+    {
+      "key": "VEXA_JITSI_HOSTS",
+      "class": "defaulted",
+      "default": "(empty)",
+      "description": "Declared Jitsi hosts for meeting-link parsing \u2014 the SAME setting meeting-api reads, because two parsers that disagree about what a link is accept different meetings.",
+      "targets": [
+        "compose"
+      ]
+    },
+    {
+      "key": "ADMIN_API_URL",
+      "class": "capability",
+      "capability": "assembly",
+      "description": "identity's base URL. A domain whose URL is set is ASKED for its tool manifest; one whose URL is unset is never asked and its tools are absent. Identity is the one domain everyone may depend on.",
+      "targets": [
+        "compose"
+      ]
+    },
+    {
+      "key": "MEETING_API_URL",
+      "class": "capability",
+      "capability": "assembly",
+      "description": "meetings' base URL, on the same terms.",
+      "targets": [
+        "compose"
+      ]
+    },
+    {
+      "key": "FLOWS_API_URL",
+      "class": "capability",
+      "capability": "assembly",
+      "description": "flows' base URL, on the same terms.",
+      "targets": [
+        "compose"
+      ]
+    },
+    {
+      "key": "AGENT_API_URL",
+      "class": "capability",
+      "capability": "assembly",
+      "description": "agent's base URL, on the same terms. Unset is the no-agents deployment, which is a product and not a degraded state.",
+      "targets": [
+        "compose"
+      ]
+    },
+    {
+      "key": "VEXA_MCP_MANIFEST_DIR",
+      "class": "capability",
+      "capability": "private_domains",
+      "description": "A directory a private deployment mounts its own tool manifests into \u2014 billing, seats, entitlement. Assembled identically to the OSS ones and competing for names in the same space, so a mount can COLLIDE but never SHADOW. EMPTY IS THE OSS PRODUCT, exactly.",
+      "targets": [
+        "compose"
+      ]
+    },
+    {
+      "key": "VEXA_TICKET_SINK_URL",
+      "class": "capability",
+      "capability": "ticket_sink",
+      "description": "Where `report_issue` files an agent-written ticket. POINT IT AT A DEDICATED TICKETS REPO: ticket bodies are third-party text, and an operational repo's issues are read as work signal by planning loops.",
+      "targets": [
+        "compose"
+      ]
+    },
+    {
+      "key": "VEXA_TICKET_SINK_TOKEN",
+      "class": "capability",
+      "capability": "ticket_sink",
+      "secret": true,
+      "description": "Credential for that sink. Fine-grained, SINGLE-REPO, issues:write only, from a secret store.",
+      "targets": [
+        "compose"
+      ]
+    },
+    {
+      "key": "VEXA_TICKET_SINK_FORMAT",
+      "class": "capability",
+      "capability": "ticket_sink",
+      "description": "`raw` (default) POSTs the ticket JSON to an opaque webhook; `github` maps it onto POST /repos/{owner}/{repo}/issues so an issue tracker IS the sink.",
+      "targets": [
+        "compose"
+      ]
+    },
+    {
+      "key": "VEXA_TICKET_SINK_LABELS",
+      "class": "capability",
+      "capability": "ticket_sink",
+      "description": "Labels applied to filed tickets.",
+      "targets": [
+        "compose"
+      ]
+    },
+    {
+      "key": "VEXA_TICKET_FINGERPRINT_SALT",
+      "class": "defaulted",
+      "default": "vexa-mcp-report-issue",
+      "description": "Salt for the caller fingerprint that dedupes tickets. A deployment SHOULD set its own so fingerprints are not comparable across deployments.",
+      "targets": [
+        "compose"
+      ]
+    }
+  ],
+  "capabilities": {
+    "assembly": {
+      "description": "Assembling one MCP surface from the tool manifests of the domains this deployment carries (PRD decision 40). Each domain serves its own manifest and its OpenAPI; this service asks, refuses the combinations that cannot be right, and presents the union.",
+      "mode": "any",
+      "when_unconfigured": "No domain is asked, so the surface is exactly this service's own built-in tools. That is a smaller product, never a broken one \u2014 a tool whose domain is absent is ABSENT from tools/list rather than present-and-failing."
+    },
+    "private_domains": {
+      "description": "A paid or private domain composing onto this line without a line of it living in this repo: its manifest is mounted, discovered and assembled like any other.",
+      "when_unconfigured": "There are no mounted manifests, which IS the OSS product. This repo never carries a gate shipped dark."
+    },
+    "ticket_sink": {
+      "description": "`report_issue` \u2014 an agent filing a ticket a human reads.",
+      "mode": "any",
+      "when_unconfigured": "`report_issue` answers 503 `not configured` and nothing else changes."
+    }
+  }
+}

--- a/core/meetings/services/mcp/src/vexa_mcp/config_preflight.py
+++ b/core/meetings/services/mcp/src/vexa_mcp/config_preflight.py
@@ -1,0 +1,392 @@
+"""config.v1 preflight — the shared boot-time deployment-config validator (ADR-0026).
+
+CANONICAL COPY: ``deploy/contracts/config.v1/preflight.py``. Every adopted service vendors this
+file VERBATIM as ``config_preflight.py`` next to its ``config.v1.json`` declaration —
+``gate:config-contract`` enforces byte-equality — so the module is importable inside every image
+without a cross-domain package dependency (P2: the services stay isolated bricks; they share a
+contract, not a code distribution).
+
+The three declaration classes (see the contract README):
+
+* **required-explicit** — unset/empty at boot ⇒ :class:`ConfigError` (the deploy refuses to boot
+  with ONE message naming every missing key — fail loud, P18/ADR-0010);
+* **defaulted** — the documented code default applies; nothing to enforce at boot;
+* **capability** — the key belongs to a named capability whose tri-state is computed from the env:
+  ``configured`` / ``not_configured`` / ``misconfigured`` (mode=all: some-but-not-all keys set).
+  The service RUNS either way; capability-gated endpoints consult :func:`capability_state` and fail
+  loud with a typed, actionable error; ``/health`` exposes the rows via :func:`capability_health`
+  (ADDITIVE — existing health consumers keep working).
+
+A capability may also declare a **live probe** (contract ``$defs/Probe``): one cheap verification
+that the SET values actually work — an authenticated HTTP call (``http``: an unauthorized answer or
+a network failure ⇒ misconfigured; any other status ⇒ the credential was accepted) or a credentials
+FILE check (``file``: regular readable non-empty JSON ⇒ ok; a directory — docker's bind-mount of a
+MISSING host path — or unreadable/non-JSON ⇒ misconfigured). Probes run only when the env-level
+state is already ``configured``: once at boot (logged, never boot-blocking) and lazily on ``/health``
+when the cached result is older than the probe's ``ttl_s``. This is what turns the silent-401 STT
+token and the absent claude-credentials mount into a visible ``misconfigured`` row BEFORE any
+meeting/agent runs.
+
+Any declaration class may also carry **forbidden_values** — the placeholder literals a stock deploy
+surface once supplied. A boot whose env holds one raises :class:`ConfigError` beside the missing-key
+refusal, because an unconfigured secret that LOOKS configured is the worse of the two failures: the
+service comes up green and the value is in the public repository (F95).
+
+Env-level state is computed AT CALL TIME (no boot-time snapshot), so tests monkeypatching the
+environment and long-lived processes both observe the truth.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import time
+import urllib.error
+import urllib.request
+from functools import lru_cache
+from pathlib import Path
+from typing import List, Mapping, Optional
+
+log = logging.getLogger("config.v1.preflight")
+
+CONFIGURED = "configured"
+NOT_CONFIGURED = "not_configured"
+MISCONFIGURED = "misconfigured"
+
+
+class ConfigError(RuntimeError):
+    """A deployment-config violation the boot must not survive (fail loud + attributable, P18)."""
+
+
+@lru_cache(maxsize=1)
+def load_declaration() -> dict:
+    """This service's config.v1 declaration (``config.v1.json``, vendored next to this module).
+
+    Sanity-checks the declaration's internal references (a ``capability``-classed key must name a
+    declared capability) so a broken declaration fails at first use, not silently.
+    """
+    path = Path(__file__).resolve().parent / "config.v1.json"
+    decl = json.loads(path.read_text(encoding="utf-8"))
+    caps = decl.get("capabilities") or {}
+    for entry in decl.get("keys") or []:
+        if entry.get("class") == "capability" and entry.get("capability") not in caps:
+            raise ConfigError(
+                f"config.v1 declaration for {decl.get('service')!r} is inconsistent: key "
+                f"{entry.get('key')!r} names undeclared capability {entry.get('capability')!r}"
+            )
+    return decl
+
+
+def _is_set(env: Mapping[str, str], key: str) -> bool:
+    # Empty string counts as UNSET: the deploy surfaces default absent vars to "" (compose
+    # `${VAR:-}`, lite `export VAR="${VAR:-}"`), so "" and absent must mean the same thing.
+    return bool((env.get(key) or "").strip())
+
+
+def capability_states(env: Optional[Mapping[str, str]] = None) -> dict:
+    """The env-level tri-state of every declared capability — PURE (no probe I/O), computed from
+    the live env. This is the request-path oracle capability-gated endpoints use."""
+    env = os.environ if env is None else env
+    decl = load_declaration()
+    caps = decl.get("capabilities") or {}
+    keys_by_cap: dict = {name: [] for name in caps}
+    for entry in decl.get("keys") or []:
+        if entry.get("class") == "capability":
+            keys_by_cap[entry["capability"]].append(entry["key"])
+    states = {}
+    for name, cap in caps.items():
+        keys = keys_by_cap.get(name) or []
+        present = [k for k in keys if _is_set(env, k)]
+        if (cap.get("mode") or "all") == "any":
+            states[name] = CONFIGURED if present else NOT_CONFIGURED
+        elif keys and len(present) == len(keys):
+            states[name] = CONFIGURED
+        elif not present:
+            states[name] = NOT_CONFIGURED
+        else:
+            states[name] = MISCONFIGURED
+    return states
+
+
+def capability_state(name: str, env: Optional[Mapping[str, str]] = None) -> str:
+    """One capability's env-level tri-state. An UNDECLARED name raises — gating on a capability the
+    declaration does not carry is a bug, not a runtime condition."""
+    states = capability_states(env)
+    if name not in states:
+        raise ConfigError(
+            f"capability {name!r} is not declared in {load_declaration().get('service')!r}'s config.v1"
+        )
+    return states[name]
+
+
+def missing_capability_keys(name: str, env: Optional[Mapping[str, str]] = None) -> List[str]:
+    """The unset member keys behind a not_configured/misconfigured capability — so a gated
+    endpoint's error can name EXACTLY what to set (actionable, not just 'unavailable')."""
+    env = os.environ if env is None else env
+    decl = load_declaration()
+    keys = [
+        e["key"]
+        for e in decl.get("keys") or []
+        if e.get("class") == "capability" and e.get("capability") == name
+    ]
+    return [k for k in keys if not _is_set(env, k)]
+
+
+# ── live probes (contract $defs/Probe) — do the SET values actually work? ────────────────────────
+
+_probe_cache: dict = {}
+
+
+def _reset_probe_cache() -> None:
+    """Test seam: forget cached probe results (the cache is per-process, keyed by capability)."""
+    _probe_cache.clear()
+
+
+def probe_url(base: str, path: str) -> str:
+    """Join a configured base URL to the probe's declared path, accepting BOTH accepted shapes:
+    a bare base (``https://api.openai.com``) and a full endpoint URL that already carries the path
+    (``https://api.openai.com/v1/audio/transcriptions``). Appending blindly would double-path the
+    latter into a 404 — the same URL that works in a meeting. This is the ONE rule, shared with the
+    bot's client (``whisper/src/transcription-client.ts``) and the terminal's dictation route."""
+    base = (base or "").strip().rstrip("/")
+    if not path:
+        return base
+    return base if base.endswith(path) else base + path
+
+
+#: A ~1s 16 kHz mono WAV of a quiet tone — the smallest body that is unambiguously *audio*, so a
+#: metered backend must price it and answer 200 or 402 rather than rejecting it unparsed.
+_PROBE_WAV_SECONDS = 1
+_PROBE_WAV_RATE = 16000
+
+
+def _probe_wav() -> bytes:
+    """Build the probe's WAV in memory (stdlib only — this file is vendored into every service and
+    takes no dependencies)."""
+    import math
+    import struct
+
+    frames = b"".join(
+        struct.pack("<h", int(6000 * math.sin(i * 0.06)))
+        for i in range(_PROBE_WAV_RATE * _PROBE_WAV_SECONDS)
+    )
+    data_len = len(frames)
+    byte_rate = _PROBE_WAV_RATE * 2
+    return (
+        b"RIFF" + struct.pack("<I", 36 + data_len) + b"WAVEfmt "
+        + struct.pack("<IHHIIHH", 16, 1, 1, _PROBE_WAV_RATE, byte_rate, 2, 16)
+        + b"data" + struct.pack("<I", data_len) + frames
+    )
+
+
+def audio_probe_body(model: str = "whisper-1") -> tuple:
+    """The audio round-trip's (content_type, body) — the ONE definition of "ask the STT backend the
+    real question", shared with the terminal's Test button (``core/agent/control_plane/config_test``)
+    exactly as ``probe_url`` shares the URL rule. Both must ask identically, or the wizard greens
+    what the boot refuses."""
+    return _multipart({"model": model, "response_format": "json"}, "probe.wav", _probe_wav())
+
+
+def _multipart(fields: Mapping[str, str], filename: str, payload: bytes) -> tuple:
+    """Encode one file + simple fields as multipart/form-data (urllib has no encoder, and this file
+    takes no dependencies). Returns (content_type, body)."""
+    boundary = "----ConfigV1Probe0dcb1f7a"
+    out = bytearray()
+    for k, v in fields.items():
+        out += (f"--{boundary}\r\nContent-Disposition: form-data; name=\"{k}\"\r\n\r\n{v}\r\n").encode()
+    out += (f"--{boundary}\r\nContent-Disposition: form-data; name=\"file\"; "
+            f"filename=\"{filename}\"\r\nContent-Type: audio/wav\r\n\r\n").encode()
+    out += payload + b"\r\n"
+    out += f"--{boundary}--\r\n".encode()
+    return f"multipart/form-data; boundary={boundary}", bytes(out)
+
+
+def _http_probe(spec: dict, env: Mapping[str, str], timeout: float) -> dict:
+    """One authenticated request against the configured endpoint.
+
+    The oracle, in order: network failure ⇒ ``unreachable`` · declared ``unauthorized_statuses``
+    (401/403) ⇒ ``unauthorized``, the token was rejected · declared ``exhausted_statuses`` (402) ⇒
+    ``exhausted``, the token is authentic but cannot buy the work · declared ``invalid_statuses``
+    (404 for an OpenAI-compatible transcriptions path) ⇒ ``invalid_endpoint``, the URL shape is
+    wrong. Any OTHER status proves reachability + accepted auth ⇒ ok.
+
+    ``payload: "audio"`` makes the probe send the REAL thing — a ~1s WAV, the same request shape a
+    bot's first chunk makes — because an empty body cannot answer the question. A metered backend
+    answers an empty POST 400/422 whether the credential is funded or worthless, so the probe that
+    never sends audio greens a token that will 402 on every segment of every meeting. Sending audio
+    also makes the verdict independent of WHO the token belongs to: a billing-exempt account and a
+    funded one both answer 200, and neither has to be named anywhere. It costs a fraction of a
+    minute, so declare a long ``ttl_s`` — usability changes when an operator acts, not by the second.
+
+    A failure carries ``kind`` because the classes are NOT interchangeable to a consumer:
+    ``unauthorized``/``invalid_endpoint``/``exhausted`` are CONFIGURATION faults, true until an
+    operator edits a value or tops up, so a request path may refuse on them; ``unreachable`` is a
+    LIVENESS fault that a restart or a DNS blip produces, so refusing on it would couple this
+    service's availability to the endpoint's. All demote the /health row identically — only actors
+    that REFUSE need the distinction."""
+    base = (env.get(spec["url_key"]) or "").strip().rstrip("/")
+    url = probe_url(base, spec.get("path") or "")
+    body = b""
+    content_type = None
+    if (spec.get("payload") or "") == "audio":
+        content_type, body = audio_probe_body(spec.get("payload_model") or "whisper-1")
+    req = urllib.request.Request(url, data=body, method=(spec.get("method") or "POST"))
+    if content_type:
+        req.add_header("Content-Type", content_type)
+    token = (env.get(spec["auth_key"]) or "").strip() if spec.get("auth_key") else ""
+    if token:
+        req.add_header("Authorization", f"Bearer {token}")
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as r:  # noqa: S310 — declared endpoint
+            status = int(r.status)
+    except urllib.error.HTTPError as e:
+        status = int(e.code)
+    except Exception as e:  # noqa: BLE001 — a probe must never throw past here
+        return {"ok": False, "kind": "unreachable",
+                "reason": f"unreachable: {e.__class__.__name__}: {e}"}
+    if status in (spec.get("unauthorized_statuses") or [401, 403]):
+        return {"ok": False, "status": status, "kind": "unauthorized",
+                "reason": "unauthorized — the configured token was REJECTED by the endpoint"}
+    if status in (spec.get("exhausted_statuses") or []):
+        return {"ok": False, "status": status, "kind": "exhausted",
+                "reason": f"the token is VALID but cannot pay for the work (HTTP {status}) — every "
+                          f"transcription will fail and meetings will complete with no transcript; "
+                          f"top up the account or configure a token that can transcribe"}
+    if status in (spec.get("invalid_statuses") or []):
+        return {"ok": False, "status": status, "kind": "invalid_endpoint",
+                "reason": f"endpoint path not found ({url}) — check the URL shape; some gateways "
+                          f"also answer 404 for a rejected credential"}
+    return {"ok": True, "status": status}
+
+
+#: Probe-failure kinds that mean the CONFIGURATION is wrong (true until an operator changes a
+#: value), as opposed to the endpoint merely being down. A request path may refuse on these.
+CONFIG_FAULT_KINDS = frozenset({"unauthorized", "invalid_endpoint", "exhausted"})
+
+
+def _file_probe(spec: dict, env: Mapping[str, str], timeout: float) -> dict:
+    """Verify a credentials file AS VISIBLE TO THIS SERVICE (the key's own path, then any declared
+    in-container mirror mounts of a docker-HOST path). A directory here is the signature of docker
+    bind-mounting a MISSING host path — exactly the 'Not logged in' worker failure, caught early."""
+    raw = (env.get(spec["path_key"]) or "").strip()
+    if not raw:
+        return {"ok": True, "skipped": f"{spec['path_key']} unset — this credential path is not in use"}
+    tried = []
+    for p in [raw, *(spec.get("fallback_paths") or [])]:
+        path = Path(p)
+        if not path.exists():
+            tried.append(f"{p}: not found")
+            continue
+        if not path.is_file():
+            return {"ok": False, "path": p,
+                    "reason": f"{p} is not a regular file — docker bind-mounts a MISSING host path "
+                              f"as a DIRECTORY, so the host file behind {spec['path_key']} is absent"}
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except Exception as e:  # noqa: BLE001
+            return {"ok": False, "path": p, "reason": f"{p}: unreadable or not JSON ({e.__class__.__name__})"}
+        if not data:
+            return {"ok": False, "path": p, "reason": f"{p}: empty credentials JSON"}
+        return {"ok": True, "path": p}
+    return {"ok": False, "reason": "; ".join(tried)}
+
+
+def _run_probe(spec: dict, env: Mapping[str, str]) -> dict:
+    timeout = float(spec.get("timeout_s") or 2)
+    kind = spec.get("kind")
+    if kind == "http":
+        return _http_probe(spec["http"], env, timeout)
+    if kind == "file":
+        return _file_probe(spec["file"], env, timeout)
+    return {"ok": False, "reason": f"unknown probe kind {kind!r}"}
+
+
+def _cached_probe(name: str, spec: dict, env: Mapping[str, str], force: bool = False) -> dict:
+    ttl = float(spec.get("ttl_s") or 60)
+    now = time.monotonic()
+    hit = _probe_cache.get(name)
+    if not force and hit is not None and (now - hit["at"]) < ttl:
+        return hit["result"]
+    result = _run_probe(spec, env)
+    _probe_cache[name] = {"at": now, "result": result}
+    return result
+
+
+def cached_probe_verdict(name: str, max_age_s: Optional[float] = None) -> Optional[dict]:
+    """The last probe verdict for ``name``, or None when there is no opinion fresh enough to act on.
+
+    A pure cache READ — it never issues a request, so a REQUEST path may consult it (boot preflight
+    seeds the cache, ``/health`` refreshes it; probe I/O stays on those two paths). ``max_age_s``
+    bounds staleness: an older entry reads as None. None means "no verdict" and must never be
+    treated as a failure — an unprobed capability is not a broken one."""
+    hit = _probe_cache.get(name)
+    if hit is None:
+        return None
+    if max_age_s is not None and (time.monotonic() - hit["at"]) > max_age_s:
+        return None
+    return hit["result"]
+
+
+def capability_health(env: Optional[Mapping[str, str]] = None, force_probe: bool = False) -> dict:
+    """The /health rows: env-level tri-state per capability, PLUS the live-probe verdict for
+    capabilities that declare one (probe failure demotes the row to ``misconfigured`` with a
+    reason). Probe results are cached per the probe's ``ttl_s``; a row's shape is
+    ``{"state": ..., "probe"?: {"ok": ..., ...}}`` — additive next to the env-only state."""
+    env = os.environ if env is None else env
+    decl = load_declaration()
+    caps = decl.get("capabilities") or {}
+    rows = {}
+    for name, state in capability_states(env).items():
+        row: dict = {"state": state}
+        spec = (caps.get(name) or {}).get("probe")
+        if spec and state == CONFIGURED:
+            result = _cached_probe(name, spec, env, force=force_probe)
+            row["probe"] = result
+            if not result.get("ok"):
+                row["state"] = MISCONFIGURED
+        rows[name] = row
+    return rows
+
+
+def preflight(env: Optional[Mapping[str, str]] = None) -> dict:
+    """Boot-time validation of the declaration against the environment.
+
+    Raises :class:`ConfigError` naming EVERY missing required-explicit key (one actionable message,
+    not a peel-the-onion loop); runs each configured capability's live probe once; logs one line per
+    capability so a deploy's config completeness is visible in the boot log (a failed probe logs a
+    WARNING but never blocks boot — capabilities gate endpoints, not the process).
+    Returns ``{"service", "capabilities"}`` (the same row shape as :func:`capability_health`).
+    """
+    env = os.environ if env is None else env
+    decl = load_declaration()
+    required = [e for e in decl.get("keys") or [] if e.get("class") == "required-explicit"]
+    missing = [e for e in required if not _is_set(env, e["key"])]
+    if missing:
+        detail = "; ".join(f"{e['key']} ({e['description']})" for e in missing)
+        raise ConfigError(
+            f"{decl.get('service')} is misconfigured and refuses to boot — required environment "
+            f"variable(s) not set: {detail}. Each is declared required-explicit in this service's "
+            "config.v1 declaration (config.v1.json, gate:config-contract); set them and restart."
+        )
+    # A key sitting on a documented placeholder is UNCONFIGURED wearing a configured face — worse
+    # than unset, because nothing 503s and the value is published (F95). Never echo the value.
+    placeheld = [e["key"] for e in decl.get("keys") or []
+                 if e.get("forbidden_values")
+                 and (env.get(e["key"]) or "").strip() in set(e["forbidden_values"])]
+    if placeheld:
+        raise ConfigError(
+            f"{decl.get('service')} is misconfigured and refuses to boot — {', '.join(placeheld)} "
+            "still hold(s) a documented PLACEHOLDER value. That literal is published in this "
+            "repository, so it is not a secret: anyone can present it. Generate a real value "
+            "(`openssl rand -hex 32`), set it on every service that shares the tier, and restart. "
+            "The forbidden literals are declared per key in this service's config.v1 declaration "
+            "(config.v1.json, gate:config-contract)."
+        )
+    rows = capability_health(env, force_probe=True)
+    for name, row in sorted(rows.items()):
+        if row["state"] == MISCONFIGURED:
+            log.warning("config.v1 capability %s: MISCONFIGURED — %s", name,
+                        (row.get("probe") or {}).get("reason", "some-but-not-all keys set"))
+        else:
+            log.info("config.v1 capability %s: %s", name, row["state"])
+    return {"service": decl.get("service"), "capabilities": rows}

--- a/core/meetings/services/mcp/tests/test_app.py
+++ b/core/meetings/services/mcp/tests/test_app.py
@@ -15,7 +15,17 @@ from conftest import API_KEY, FakeGateway
 def test_health_no_auth(client):
     r = client.get("/health")
     assert r.status_code == 200
-    assert r.json() == {"status": "ok", "service": "mcp"}
+    body = r.json()
+    assert body["status"] == "ok" and body["service"] == "mcp"
+
+
+def test_health_states_each_capability(client):
+    """ADR-0026. A green health check on a service whose ticket sink is unset, or whose assembly
+    reached no domain, is a green light on a product that quietly does less than the operator
+    thinks — so the tri-state rides the same response, computed from the declaration."""
+    caps = client.get("/health").json()["capabilities"]
+    assert set(caps) == {"assembly", "private_domains", "ticket_sink"}
+    assert set(caps.values()) <= {"configured", "not_configured", "misconfigured"}
 
 
 # --- auth: fail-closed + the three accepted credential forms -----------------

--- a/scripts/gates.mjs
+++ b/scripts/gates.mjs
@@ -976,6 +976,19 @@ const CONFIG_ADOPTED = [
     compose: "admin-api", helm: ["deployment-admin-api.yaml"], lite: "admin-api",
   },
   {
+    // PRD decision 40 — the MCP surface a person's own agent connects to. Adopted late: it shipped
+    // with ELEVEN env keys and no declaration and no preflight, so the one service whose whole job
+    // is to be the product's front door was the one service nothing checked.
+    // helm/lite are EMPTY because it has no template and no supervisord program — every key it does
+    // plumb is declared for compose, and the ones it does not are `targets: []` rather than a
+    // pretence that a surface carries them.
+    service: "mcp",
+    decl: "core/meetings/services/mcp/src/vexa_mcp/config.v1.json",
+    preflight: "core/meetings/services/mcp/src/vexa_mcp/config_preflight.py",
+    scan: ["core/meetings/services/mcp/src"],
+    compose: "mcp", helm: [], lite: null,
+  },
+  {
     service: "gateway",
     decl: "core/gateway/services/gateway/src/gateway/config.v1.json",
     preflight: "core/gateway/services/gateway/src/gateway/config_preflight.py",
@@ -1068,7 +1081,9 @@ function gateConfigContract() {
     const compose = composeServiceEnv(svc.compose);
     if (!compose) { errs.push(`${svc.service}: compose service '${svc.compose}' not found`); continue; }
     const helm = helmEnvKeys(svc.helm);
-    const lite = liteProgramEnv(svc.lite);
+    // A service that is not on a surface yet declares no keys for it (`targets: []`); an
+    // absent program name means that surface simply contributes nothing to check 4.
+    const lite = svc.lite ? liteProgramEnv(svc.lite) : new Set();
     // 3. declaration → surfaces (per the key's declared targets; default = all three)
     for (const k of decl.keys || []) {
       const targets = k.targets ?? ["compose", "helm", "lite"];


### PR DESCRIPTION
**Delivers issue:** #1463

## Contribution rights
<!-- Select exactly ONE. This is a legal certification: an agent may explain the choices but
     must not select one for you. See CONTRIBUTOR_RIGHTS.md. -->

- [ ] **Independent:** I created this contribution, or otherwise have the right to submit it
  under Apache-2.0, and it is not owned or controlled by an employer, client, or other entity.
  <!-- rights:independent -->
- [ ] **Employer/client authorization required:** an employer, client, or other entity owns or
  may control this contribution. I am requesting Vexa's private corporate-authorization process.
  <!-- rights:corporate -->
- [ ] **Unsure:** I need a private rights review before merge.
  <!-- rights:uncertain -->

Every commit must also carry the contributor's own DCO `Signed-off-by` line. Selecting the
independent path means no individual CLA is required. Corporate and unsure paths do not stop
technical review, but they do block merge until resolved.

## Observation bundle (the record of your harnessed loop)

- **C1 — what it actually reads.** ran: a scan for literal env reads across the service's source ·
  saw: eleven keys, and no declaration anywhere · concluded: this is the only service in the stack
  whose keys are outside every scan, so a twelfth could be added tomorrow and nothing would notice.

- **C1 — the surfaces it is really on.** ran: looked for a helm template and a supervisord program
  for this service · saw: neither exists; it is on compose alone · concluded: the gate assumes three
  deploy surfaces, so declaring the truth was not expressible. Rather than declare keys against
  surfaces that do not exist, the gate now permits a service to be on fewer — one three-line change,
  and the declaration says what is true instead of what the gate expected.

- **C1 — the gate caught its own paragraph.** ran: the contract gate after writing the declaration ·
  saw: RED on an undeclared key named `KEY` · concluded: the scanner had matched a literal
  `os.environ.get("KEY")` *inside a docstring I had written to explain the scanner*. That is the
  check working, and it is why the reads in this service are spelled as literals rather than hidden
  behind a tidy accessor — a wrapper would leave the declaration green over nothing.

- **C2 — the health signal.** ran: the service's suite after adding the capability tri-state · saw:
  `test_health_no_auth` RED — it asserted the body was exactly two keys · concluded: the assertion
  was the old contract, so it was rewritten to state the new one (status and service still hold,
  plus a capability map), rather than loosened.

- **Boot behaviour.** ran: `preflight()` as the first move in `create_app` · saw: the whole suite
  still green at 192 · concluded: refusing to boot misconfigured is now this service's first move,
  the same as every other adopted service.

- **Whole-repo.** ran: `gate:config-contract` at head · saw: six adopted services, 275 declared
  keys, 11 capabilities, declarations ≡ deploy surfaces ≡ code reads · concluded: six, not seven —
  `core/mcp` is not a directory on this line and will not be; the manifests live with their domains.

## Acceptance floor

Base `2d7a3d469` → head `353d19f4d`.

| Row | Evidence |
|---|---|
| A1 | `test_health_states_each_capability` — `/health` names `assembly`, `private_domains` and `ticket_sink` with a tri-state each. RED at base: the body is exactly `{"status":"ok","service":"mcp"}` with the sink unset, which is indistinguishable from a working sink. |
| A2 | `gate:config-contract` green at head listing **six** adopted services / 275 keys. RED at base: the service is absent from `CONFIG_ADOPTED`, so none of its eleven keys is scanned. The stronger negative control is in the loop above — the gate went red on a key that existed only inside a docstring, which is the scan proving it can see this service's source. |
| A3 | The declaration names `compose` for every plumbed key and `targets: []` for the rest; `helm: []` / `lite: null` in the adopted entry. The gate change (`svc.lite ? liteProgramEnv(svc.lite) : new Set()`) is what makes that expressible — before it, an honest declaration for a one-surface service could not pass. |
| A- | MCP suite 192 green at head. `gate:config-contract` green. |

Rows exceeded: `preflight()` now runs at boot (A1 and A2 only asked for declaration and reporting),
so a deployment missing a required key fails loudly at start rather than at first use.

## Docs diff (D6c)
`docs:` none. **Argued:** the eleven keys are operator-facing and already carry their explanations
in `deploy/compose/docker-compose.yml`, which is where an operator configuring this service reads
them; the new `config.v1.json` is the reference. No service in this repo has a per-service
deployment-configuration page, so adding one only here would teach an inconsistent story — worth a
separate item covering all six adopted services at once.

## Security checks (required on the diff)
No dependency change. Two of the declared keys are credentials and are marked `secret: true`
(`VEXA_TICKET_SINK_TOKEN`); the declaration is what makes that visible to the contract gate at all,
which is a small security improvement rather than a neutral one. The vendored `config_preflight.py`
is byte-identical to `deploy/contracts/config.v1/preflight.py` — asserted by the gate's own check 2,
so it cannot drift. No secret value is logged or returned: the capability report on `/health` is a
tri-state per capability, never a value.

## Validation request
Any competent non-author; the operator who runs the dogfood deployment is the natural signer.

**Deployment:** full compose, built from this branch at `353d19f4d`,
`deploy/compose/docker-compose.yml`, long-lived instance, no env deltas from stock.

What to watch: start with `VEXA_TICKET_SINK_URL` unset, read `/health`, see `ticket_sink:
not_configured`; set it, restart, see it flip. Then unset a required key and confirm the service
refuses to start rather than coming up green. **Lite and k8s-helm are not claimed** — this service
has no supervisord program and no chart template, which is the same fact that made its declaration
name one surface.

## Authorship
Sole author: the human submitting this. No agent co-author trailers (D13).
Tooling disclosure (optional, welcome, never an attribution): drafted with Claude Code.

<!-- vexa-agent -->
