### PR TITLE
CI never reaps the trimmed worker child — evidence run

### DIFF
--- a/core/agent/tests/test_entity_writeback_trim.py
+++ b/core/agent/tests/test_entity_writeback_trim.py
@@ -8,6 +8,7 @@ the budget is enforced rather than requested.
 from __future__ import annotations
 
 import json
+import sys
 import time
 
 import pytest
@@ -268,7 +269,37 @@ def test_a_phase_over_budget_leaves_no_child_process(tmp_path, monkeypatch):
             '"name":"mcp__vexa__entity_upsert","id":"c","input":{}}]}}')
     argv = ["sh", "-c", f"echo '{line}'; echo '{line}'; echo '{line}'; sleep 300"]
 
-    events = cc.parse_stream_json(cc._exec_subprocess(argv, str(tmp_path)))
+    # ── DIAGNOSTIC INSTRUMENT (Vexa-ai/vexa#1434) — temporary, do not merge ──────────────────
+    # This test reds on CI and on no machine anybody can reach: 40 single-CPU-pinned runs, 25 more,
+    # and the full suite on 3.12, on 3.14 and pinned to two CPUs are all green on bbb. The bounded
+    # wait added by #1441 did not help — CI waited the full 5 s with the child still alive — which
+    # refutes "the reap is merely late" and says the reap does not happen at all. Rather than guess
+    # a third time, capture the state INTO the failure message and let the runner answer.
+    import gc
+    import weakref
+
+    reap_log = []
+    _real_reap = cc._reap
+
+    def _spy_reap(p, grace=None):
+        reap_log.append(f"enter(grace={grace!r}, poll={p.poll()!r})")
+        try:
+            _real_reap(p, grace)
+        except BaseException as exc:                       # noqa: BLE001 — reported, not handled
+            reap_log.append(f"raised {type(exc).__name__}: {exc}")
+            raise
+        finally:
+            reap_log.append(f"exit(poll={p.poll()!r})")
+
+    monkeypatch.setattr(cc, "_reap", _spy_reap)
+
+    # A weakref, and the strong reference is dropped IMMEDIATELY: holding the inner generator here
+    # would itself pin the thing whose finalization is under test.
+    inner = cc._exec_subprocess(argv, str(tmp_path))
+    inner_ref = weakref.ref(inner)
+    events = cc.parse_stream_json(inner)
+    del inner
+
     out = list(engine.bounded(events, max_tool_calls=2, max_seconds=10))
 
     assert sum(1 for e in out if e["type"] == "tool-call") == 2
@@ -276,31 +307,37 @@ def test_a_phase_over_budget_leaves_no_child_process(tmp_path, monkeypatch):
     assert len(seen) == 1
     proc = seen[0]
 
-    # WAIT FOR THE REAP — bounded, and not a sleep.
-    #
-    # The property is that the budget kills the CLI, and it is delivered by a cascade: `bounded`
-    # closes its iterator, GeneratorExit unwinds `parse_stream_json`, THAT frame's teardown drops
-    # the last reference to the `_exec_subprocess` generator, and only then does its `finally`
-    # reap. The last hop is finalization, not a call — so the guarantee the code offers is PROMPT,
-    # never INSTANTANEOUS, and an assertion taken on the next bytecode was reading a coin flip.
-    # It came up heads on every developer machine and tails on CI: red on three consecutive PRs
-    # into this line (#1426, #1428, #1431), and not reproducible in 40 single-CPU-pinned runs or a
-    # full-suite run on 3.12 and 3.14 (Vexa-ai/vexa#1434).
-    #
-    # This is a poll with a deadline, not `sleep(n)`: it returns the microsecond the reap lands, so
-    # a healthy run costs nothing, and 5s is far outside any scheduling delay while staying far
-    # inside the suite's patience. Every property the docstring above names survives it — with the
-    # kill path deleted, `_reap`'s bare `proc.wait()` still blocks inside the cascade and this test
-    # still hangs, which is the failure it was written to name.
-    #
-    # `events` is deliberately still referenced here. Dropping it would close the chain from the
-    # test instead of from `bounded`, and the test would then pass with `bounded`'s own
-    # `finally: gen.close()` deleted — proving the cascade, not the budget.
     deadline = time.monotonic() + 5.0
     while proc.poll() is None and time.monotonic() < deadline:
         time.sleep(0.005)
 
-    assert proc.poll() is not None, "the CLI is still running after the budget stopped reading it"
+    if proc.poll() is None:
+        alive = inner_ref()
+        refs = []
+        if alive is not None:
+            for r in gc.get_referrers(alive):
+                kind = type(r).__name__
+                if kind == "frame":
+                    kind = f"frame({getattr(r, 'f_code', None) and r.f_code.co_name})"
+                refs.append(kind)
+        try:
+            import os as _os
+            waited = _os.waitpid(proc.pid, _os.WNOHANG)
+        except Exception as exc:                            # noqa: BLE001
+            waited = f"{type(exc).__name__}: {exc}"
+        raise AssertionError(
+            "the CLI is still running after the budget stopped reading it\n"
+            f"  _reap calls          : {reap_log or 'NEVER ENTERED'}\n"
+            f"  outer gen closed     : {events.gi_frame is None} (gi_running={events.gi_running})\n"
+            f"  inner gen collected  : {alive is None}\n"
+            f"  inner gen frame      : {None if alive is None else (alive.gi_frame is None)}\n"
+            f"  inner referrers      : {refs}\n"
+            f"  proc.poll/returncode : {proc.poll()!r} / {proc.returncode!r}\n"
+            f"  waitpid(WNOHANG)     : {waited!r}\n"
+            f"  gc enabled / counts  : {gc.isenabled()} / {gc.get_count()}\n"
+            f"  python               : {sys.version.split()[0]}\n"
+            f"  argv                 : {argv!r}\n")
+
     with pytest.raises(ProcessLookupError):
         os.kill(proc.pid, 0)
 


### PR DESCRIPTION
**COMMITMENTS IN THIS DRAFT — none.** One test file, failure-path instrumentation only. **This must not merge.** No commit is signed off.

**Delivers issue:** #1434 — evidence only. The fix is a separate PR against the same issue, and is not written yet.

## Contribution rights
<!-- Select exactly ONE. This is a legal certification: an agent may explain the choices but
     must not select one for you. See CONTRIBUTOR_RIGHTS.md. -->

- [ ] **Independent:** I created this contribution, or otherwise have the right to submit it
  under Apache-2.0, and it is not owned or controlled by an employer, client, or other entity.
  <!-- rights:independent -->
- [ ] **Employer/client authorization required:** an employer, client, or other entity owns or
  may control this contribution. I am requesting Vexa's private corporate-authorization process.
  <!-- rights:corporate -->
- [ ] **Unsure:** I need a private rights review before merge.
  <!-- rights:uncertain -->

**Unticked, and no commit carries a `Signed-off-by`.** Both are human certifications and an agent must not make either.

## What this measures

`test_a_phase_over_budget_leaves_no_child_process` reds on CI and on no machine anybody could reach. My earlier fix ([#1441](https://github.com/Vexa-ai/vexa/pull/1441), merged) assumed the reap was merely *late* and added a bounded wait — **CI then waited the full 5 seconds with the child still alive**, which refuted the assumption. Three diagnoses had been written from reasoning and one of them shipped wrong, so this asks the runner instead of guessing a fourth time.

## Observation bundle

- **B1 — the instrument.** Ran: a spy on `cc._reap` (entry, the grace handed to it, `poll()` in and out, any exception), a **weakref** to the `_exec_subprocess` generator with the strong reference dropped immediately — holding it would pin the very object whose finalization is under test — plus `gc.get_referrers` when it is still alive, `events.gi_frame is None`, `proc.poll()`/`returncode`, `os.waitpid(WNOHANG)`, `gc.get_count()` and the interpreter version. Saw, locally with `_reap` neutered: `_reap calls: ['enter…','exit…']`, `inner gen collected: True`, `inner referrers: []` — so locally the whole cascade runs and only the kill is missing. Concluded: the message renders real state and is worth spending a CI round-trip on.

- **B2 — CI answered it.** Ran: [`gates` run 33734517846](https://github.com/Vexa-ai/vexa/actions/runs/33734517846), head `fc52085cf`. Saw:

  ```
  _reap calls          : NEVER ENTERED
  outer gen closed     : True (gi_running=False)
  inner gen collected  : False
  inner gen frame      : False
  inner referrers      : ['generator']
  proc.poll/returncode : None / None
  waitpid(WNOHANG)     : (0, 0)
  gc enabled / counts  : True / (322, 9, 5)
  python               : 3.12.3
  ```

  Concluded: **`bounded` did close the outer generator, and the inner one was never closed at all.** `gi_frame` is not `None`, it is still alive, and it has exactly one referrer — another generator. The reference is not released when `parse_stream_json` closes, so `_exec_subprocess`'s `finally` never runs and nothing ever reaps the child. This is not a race the assertion loses by microseconds; **the kill does not happen.**

- **B3 — the variable, found in that block and confirmed.** Ran: the same test on the two exact CPython patch levels, same machine, same tree, back to back:

  ```
  === CPython 3.12.3 : FAILED … 1 failed in 5.18s
  === CPython 3.12.13: .        1 passed in 0.67s
  ```

  Concluded: **CI runs 3.12.3 and every local run had been on 3.12.13.** That is why 40 single-CPU-pinned runs, 25 more, and full-suite runs on 3.12.13, on 3.14, and pinned to two CPUs were all green — none of them varied the thing that matters. It now reproduces deterministically on demand.

- **B4 — the finding this promotes, and it is a product question, not a test one.** The property under test is that closing `bounded` *kills* the harness subprocess — the whole point of the budget (F45/F46: a phase that stops consuming while the process keeps running leaves the worker exactly as busy as it was). The block shows that on 3.12.3 the kill is delivered by **garbage collection**, not by the close: the inner generator sits in a reference cycle with another generator, so refcounting never frees it and `_reap` waits on the cyclic collector. **On that interpreter the budget does not bound anything promptly** — which is the stall the budget exists to remove, in production and not only in a test. Marked unconfirmed: I have not yet read which generator holds the reference, and no fix is proposed here.

## Acceptance floor

Base `2d7a3d469` → head `fc52085cf`. This PR's floor is that it *produces evidence*, not that it fixes anything.

| Row | Evidence |
|---|---|
| The diagnostic renders real state | B1 — verified locally with `_reap` neutered before pushing; the block prints populated fields, not `None`s. |
| CI produces the block | B2 — printed in full in the `python` job of run 33734517846. |
| The block identifies a variable that reproduces | B3 — 3.12.3 fails, 3.12.13 passes, same machine, same tree, consecutive runs. |
| The test still asserts the real property | only the failure branch is instrumented; the assertions and the negative-control properties in the docstring are untouched. |
| No production code changed | diff is one test file. |

**Negative control:** with `_reap` neutered locally the instrumented test still REDs in 5.10 s with the same message — the instrument does not paper over a missing reap.

## Docs diff (D6c)

**None, and none is needed:** test-only, no user-visible surface, no changelog fragment (per `docs/changelog.d/README.md` — a `:v012` user would not want to read about it). `docs-current` is nevertheless red here, and that is a gate defect worth its own change: the gate's own header (`scripts/docs-current-gate.mjs:7`) and ADR-0032 both promise **"test-only PRs are exempt"**, but `isSurface` (`:19-21`) is a bare `core/` prefix check with no test carve-out, so the promised exemption never fires. Requesting the `docs: none` label rather than self-applying it.

## Security checks

No dependency, no licence, no secret, no runtime code path. The diff adds a spy, a weakref and a formatted assertion message to one test's failure branch. GitGuardian **pass**.

## Validation request

**This is not asking for a value attestation — it is asking to be read and then closed.** A maintainer confirms the block in B2 is the evidence they want on #1434, and this branch is deleted. The fix follows as its own PR against #1434, with its own bundle. **Deployment validated: none** — test-only; the instrument's target *is* the CI runner, and B2 is the run.

**Do not merge.**
