### PR TITLE
The target architecture is readable in the repository, with its picture

### DIFF
--- a/docs/adr/0037-the-target-architecture-one-edge-domains-over-identity-and-runtime.md
+++ b/docs/adr/0037-the-target-architecture-one-edge-domains-over-identity-and-runtime.md
@@ -1,0 +1,195 @@
+# ADR 0037 — The target architecture: one edge, three domains over identity and runtime, everything else an event
+
+**Status:** accepted · 2026-09-03 · records the shape the 2026-09-02/03 seam pass was measured
+against · supersedes decision 2 of
+[ADR-0036](0036-the-mcp-is-an-edge-core-mcp-beside-the-gateway.md) (`core/mcp` as a tree beside the
+gateway; the rest of 0036 stands) · the reference the domain-doors gate (P9) is written against
+
+## Context
+
+Two days of reading the line's call sites — not running it — turned a taxonomy question into a
+measured seam inventory. The MCP surface existed in two unrelated shapes and neither had a place in
+the model (ADR-0036); underneath it, the domains were reaching each other in ways nothing enforced:
+the agent reached meetings and flows **three different ways** (five direct service calls, three
+through the gateway, one through a prototype rig), a client held an internal service secret and
+called two domains past the edge, the edge forwarded a person's bearer to a domain that answered
+`401 admin key required` while the JSON-RPC envelope still said `200`, one domain minted another's
+UI URL and made it a boot blocker, the runtime carried 131 lines of knowledge about the one caller
+that used it, a person-fact store lived in an agent workspace, and the support sink for "what did
+not work" was agent-api state — which meant a deployment without agents could not have one. Each
+of those is a different symptom of the same absence: **there was no written statement of which
+door a domain is allowed to open, so no gate could be written and every crossing looked local and
+reasonable at its own call site.** This ADR is that statement. It is the design the founder
+approved on 2026-09-03 (*"0. The design — looks correct"*) and it is the reference shape, not a
+description of the tree: the distance between the picture below and the code is the backlog.
+
+## The design
+
+![Target architecture: clients call one edge with a bearer; the edge assembles routes.v1 and mcp.tools.v1 from the domains present; meetings, flows and agent depend only on identity and runtime; domains publish events into flows over flows.v1; an optional dependency degrades to not_present; behavior/ is content the runtime loads and deploy/ is config.v1 per service.](0037-the-target-architecture-one-edge-domains-over-identity-and-runtime.svg)
+
+Legend — a solid green arrow is a call over a published contract in the allowed direction; a dashed
+grey arrow is an optional dependency that degrades to `not_present`; a blue arrow is an event
+published into flows and is never a dependency. Dashed boxes are the `full` profile only.
+
+> The rules the picture obeys: identity is the only shared dependency and runtime the only
+> primitive (P3, inward and acyclic); every cross-domain call crosses a published contract at the
+> edge (P2, P4); the edge assembles from declarations and owns no policy or credential (P5); a
+> domain that needs another declares it optional and degrades (P16); anything one domain wants
+> another to react to is an event in flows (P23, one writer per carrier); content is loaded, not
+> compiled (P11); configuration is a validated contract per service (P14).
+
+Nothing in the figure is a violation. Every arrow crosses one published contract and points the way
+the rule says.
+
+## Decision
+
+**1. One door in, and it is the edge.** Every client — a person's own Claude Code, the web
+terminal, and the cloud worker while it runs — reaches the system at the gateway with a **bearer in
+the header**. One authentication path: no `?token=` query bridge, no token-as-call-argument
+fallback, no mode flag that relaxes it; a session is bound by `Mcp-Session-Id` and a token minted
+mid-conversation binds to that session. Fetch-only agents lose access by design. *(P20 — authorize
+every access, default-deny; P5 — adapt at the boundary someone else owns.)*
+
+**2. The edge assembles; it owns nothing.** There is **one MCP server, at the gateway**, and its
+tool list is the union of manifests exported by the domains that are deployed — schema, route
+binding, required identity, deployment profiles. The same is true of HTTP: the gateway composes
+`routes.v1` scopes from what each domain declares and holds none of its own. It strips inbound
+authority, re-stamps it, forwards, and **refuses what it cannot authenticate — per tool, never per
+server**. Duplicate tool names at assembly are a startup refusal, not a last-wins. No MCP over MCP,
+no separate control service, and **no `core/mcp` tree** — this supersedes ADR-0036 decision 2; the
+manifests live with their domains and the assembling server is the gateway's MCP service. The
+agent appears on both sides of this without inverting ownership: the server *reads* the agent's
+manifest at assembly, and the agent's cloud worker *calls* the server as an ordinary client, with
+the same bearer and the same tools a person's Claude Code uses. *(P2 — couple only through
+contracts; P5 — the edge owns no policy or credential.)*
+
+**3. Identity is the only shared dependency; runtime is the only primitive.** Meetings, flows and
+agent each depend on identity — who is this bearer, what are this person's facts, who is a member —
+and on runtime, and on nothing else. Any subset of the three is a legal deployment. *(P3 —
+dependencies point inward, the graph is acyclic.)*
+
+**4. A domain that needs another declares it optional and degrades.** Coupling among meetings,
+flows and agent is never a hard import or an assumed URL: the dependency is declared, and when the
+target is not deployed the call resolves to **`not_present`** and the caller states that fact — a
+flow step that names an agent in a no-agents deployment reports `not_present`, it does not crash and
+does not silently no-op. The same shape covers a capability a deployment does not have: flows owns a
+**link port**, the terminal is one adapter, and a deployment without one carries a passthrough that
+states the fact in words rather than a boot blocker. *(P16 — defer the implementation, not the
+seam; P18 — fail loud, never silent degradation.)*
+
+**5. Anything one domain wants another to react to is an event in flows.** Publishing is not a
+dependency and is tolerated absent. `meeting.started` / `meeting.completed`, `onboarding.completed`,
+`desk.unscaffolded`, `claim.proposed`, `friction.reported` / `friction.fixed` are declared in
+`flows.v1`; flows holds the pending reactions and **`whats_waiting` is a flows read model** over
+them. The consequence is accepted explicitly: a live meeting, a desk card or a friction prompt
+appears in the queue only if it is modelled as a reaction — anything not modelled leaves the queue.
+The friction sink is one of these events, not a domain and not agent state. *(P23 — one writer per
+data carrier, a reader never re-derives a producer's data; P4 — a cross-process carrier is sealed
+and versioned.)*
+
+**6. Identity publishes `onboarding.completed`.** It is a first-class event in the identity
+contract, carrying subject, org and seat, published by identity and **never by agent-api**. The
+workspace a person gets is a *reaction* to it where agents are deployed, not a step inside
+onboarding. This is what makes onboarding work in a deployment that has no agent domain, and it is
+the seam a per-seat billing product consumes without either side knowing the other. *(P3 — the
+inward direction; P23 — the publisher owns the carrier.)*
+
+**7. Runtime spawns what it is told and decodes nothing.** Mounts, names and env arrive through
+`runtime.v1` from the caller; runtime carries no knowledge of what a bot or a worker is for, and its
+destructive half is guaranteed at the boundary rather than requested over a channel a booting
+workload can miss. *(P22 — guarantee teardown, don't request it; P11 — mechanism, not policy.)*
+
+**8. `behavior/` is loaded, not compiled.** Mail copy, flow definitions, presets, prompts and
+workspace seeds are **content**: a top-level tree, a peer of `core/`, with no routes and no state,
+read at run time by flows and by the edge. Each deployment mounts its own private tree of the same
+shape, resolved ahead of the in-repo showcase. A behaviour change is a data change, never an image
+rebuild. *(P11 — mechanism, not policy: a specific schema, voice or integration is config at the
+edge, never a platform domain.)*
+
+**9. `config.v1` per service, delivered by env, validated at boot.** Every service in the figure —
+the MCP service included — is under the config contract, its doors are **required and never
+defaulted** to a neighbour's URL, and a missing required door is a loud boot refusal rather than a
+placeholder that fails at the first call. *(P14 — config is a validated contract, validate at boot,
+fail fast; P18.)*
+
+**10. Two profiles, and they are the unit of deployment.** `no-agents` = identity + meetings +
+flows + the edge, carrying the meetings tools and `whats_waiting`. `full` adds agent. The config
+contract is profile-scoped, and the gateway assembles whatever is present. A profile is
+identity + any subset of the three domains; nothing in the figure is load-bearing for a subset it
+is not in. *(P14; P10 — carve a service only when a force requires it.)*
+
+**11. The figure is measured, not admired.** The **domain-doors gate** reads each domain's declared
+doors — identity, its own, and whatever it declares optional — and turns CI red on a call that
+crosses any other. Until it exists, this ADR is a README rule and by P9 it will rot. *(P9 — every
+boundary is mechanically enforced, not aspirational.)*
+
+## Trade-off
+
+**Assembly at the gateway means a tool cannot exist without a domain owning a route behind it.**
+Three of today's tools have no server-side home (`start_onboarding`, `bot_send`, `bot_schedule`) and
+each must grow one before it can be a manifest entry. That is the intended cost — the same cost
+ADR-0036 accepted when it said a tool reaching a host is a missing endpoint wearing a shell command
+— and it is paid in routes, not in exceptions.
+
+**Events instead of calls lose the things nobody models.** Under decision 5 the queue shows what
+`behavior/` says waits. A capability that was implicitly visible because some code path happened to
+compose it is gone until someone writes its trigger and its definition. We prefer the absence to be
+visible in a file over being invisible in a composition.
+
+**Optional-and-degrade multiplies the paths that need testing.** Every `not_present` branch is a
+branch, and the profile matrix has to be exercised in CI or decision 4 becomes a claim. Two
+profiles is the smallest matrix that proves the rule; it is not free.
+
+**Naming identity the single shared dependency makes it the single point of failure.** That is
+accepted deliberately: one dependency that everything has is auditable, where three optional ones
+that everything sometimes has are not.
+
+## Consequences
+
+- **The domain-doors gate is to build, and the backlog it will red is 27 call sites.** The known
+  list at the time of this ADR: the agent reaching meetings and flows five ways directly, three
+  through the gateway and one through the rig; the terminal's three agent-api and four identity
+  calls made with an internal secret past the edge; flows minting a terminal URL; the runtime's 131
+  lines of agent knowledge. Each is branch work with a rule to satisfy, not a judgement call.
+- **`whats_waiting`, friction, onboarding and person facts leave the agent domain.** `whats_waiting`
+  becomes a flows read model over pending reactions. Friction becomes two events on flows' ingress
+  (`friction.reported`, `friction.fixed`) with a read model over the timeline filtered by kind —
+  present in every profile because flows is, and reported into by every client including a person's
+  own Claude Code. `start_onboarding` becomes an identity route that publishes
+  `onboarding.completed`. Person facts (timezone, mail preferences) move to identity and the bot
+  name to the meetings bot-context store. Presets and mail copy move to `behavior/`. What stays in
+  the agent domain is what it actually owns: workspaces, turns, entities, claims, scaffolds, the
+  desk — `full` profile only.
+- **`no-agents` must be deployable, and that is the acceptance test for all of the above.** Gateway
+  + identity + meetings + flows, no `core/agent` on disk, serving the meetings tools and
+  `whats_waiting`, with the post-meeting mail arriving as a fact in words when there is no agent to
+  compose a link. If that deployment needs an agent-only module to boot, the coupling is the defect
+  — not a reason to ship the module.
+- **`core/meetings/services/mcp` keeps its 14 tools and its seal** until the assembly covers them,
+  and the prototype control rig is ported and deleted rather than merged. Both were already
+  ADR-0036's disposition; nothing here reopens them.
+- **The rig is stateless and a mid-conversation token takes effect on the next connection.**
+  `stateless_http=True` issues no session id, so nothing can bind a token minted mid-conversation to
+  the running one; the stateful alternative breaks every in-flight client on each restart. Register
+  → reconnect → continue is the copy; the product answer is the OAuth flow the gateway's MCP service
+  speaks.
+- **Nothing here is proven by running.** Every count above is a code read of the line at
+  `a5ba8e952`. The claims that need a live leg before the first release are decision 4 (a
+  `not_present` resolved in a real no-agents deployment) and decision 10 (both profiles booting from
+  the same tree).
+
+## Enforcement map
+
+| Decision | Enforced by | State |
+|---|---|---|
+| 1 · one auth path, bearer in the header | the removal itself — no bridge, no argument fallback, no mode flag to gate | landed |
+| 2 · the edge assembles and owns nothing | `gate:dataflow` completeness (a node not in `architecture.calm.json` is RED) + a duplicate-name refusal at assembly | partial · assembly landed, refusal to build |
+| 3 · identity the only shared dependency | **domain-doors gate** (P9) | **to build** — 27 sites |
+| 4 · optional dependencies degrade to `not_present` | a profile-matrix leg in CI booting `no-agents` and exercising the degraded paths | to build |
+| 5 · cross-domain reactions are events in flows | `gate:dataflow` single-writer over the `flows.v1` carriers | partial |
+| 6 · `onboarding.completed` published by identity | the event declared in `flows.v1`; `gate:schema` / `gate:contract-version` | to build |
+| 7 · runtime decodes nothing | domain-doors gate + the 131-line removal | to build |
+| 8 · `behavior/` is loaded, not compiled | none — the private tree is data, and data has no gate | accepted gap |
+| 9 · `config.v1` per service, doors required | `gate:config-contract` (`CONFIG_ADOPTED`), MCP service adopted | landed for the MCP service |
+| 10 · two profiles | profile-scoped `gate:config-contract` + the CI profile matrix | to build |
+| 11 · the figure is measured | the domain-doors gate is decision 11 and decision 3's enforcement both | **to build** |

--- a/docs/adr/0037-the-target-architecture-one-edge-domains-over-identity-and-runtime.svg
+++ b/docs/adr/0037-the-target-architecture-one-edge-domains-over-identity-and-runtime.svg
@@ -1,0 +1,105 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1100" height="700" viewBox="0 0 1100 700" role="img" aria-label="Target architecture: clients call the gateway with a bearer; the gateway assembles routes and the MCP tool list from each domain's declarations; meetings, flows and agent each depend only on identity and runtime; domains publish events into flows over the flows.v1 contract; flows and agent may declare an optional dependency on another domain that degrades to not-present; behavior content and deploy config feed the services by contract.">
+<style>
+  svg { font-family: "IBM Plex Mono", ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 12px; }
+  :root {
+    --ink:#1E2328; --muted:#5F6A73; --ok:#1F8A70;
+    --ship:#E7ECF7; --ship-line:#3B5BDB; --hold:#EFEFEC; --hold-line:#8A9199;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --ink:#E6E9EC; --muted:#A3ACB5; --ok:#3FBF9C;
+      --ship:#1E2740; --ship-line:#7C93F0; --hold:#1C2024; --hold-line:#6B737B;
+    }
+  }
+</style>
+<defs>
+  <marker id="d-ok" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto"><path d="M0,0 L10,5 L0,10 z" fill="var(--ok)"/></marker>
+  <marker id="d-deg" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto"><path d="M0,0 L10,5 L0,10 z" fill="var(--muted)"/></marker>
+  <marker id="d-ev" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto"><path d="M0,0 L10,5 L0,10 z" fill="var(--ship-line)"/></marker>
+</defs>
+
+<!-- clients -->
+<rect x="40" y="30" width="230" height="54" rx="4" fill="var(--hold)" stroke="var(--hold-line)"/>
+<text x="155" y="52" text-anchor="middle" fill="var(--ink)">a person's Claude Code</text>
+<text x="155" y="70" text-anchor="middle" fill="var(--muted)" font-size="11">local · their workspace · their thinking</text>
+<rect x="310" y="30" width="200" height="54" rx="4" fill="var(--hold)" stroke="var(--hold-line)"/>
+<text x="410" y="52" text-anchor="middle" fill="var(--ink)">web client (terminal)</text>
+<text x="410" y="70" text-anchor="middle" fill="var(--muted)" font-size="11">full profile · a client like any other</text>
+<rect x="550" y="30" width="230" height="54" rx="4" fill="var(--hold)" stroke="var(--hold-line)"/>
+<text x="665" y="52" text-anchor="middle" fill="var(--ink)">the cloud worker (agent)</text>
+<text x="665" y="70" text-anchor="middle" fill="var(--muted)" font-size="11">full profile · ephemeral · a client too</text>
+
+<!-- the edge -->
+<rect x="40" y="150" width="740" height="64" rx="4" fill="var(--ship)" stroke="var(--ship-line)"/>
+<text x="410" y="174" text-anchor="middle" fill="var(--ink)">the edge — gateway + one MCP server · owns nothing</text>
+<text x="410" y="194" text-anchor="middle" fill="var(--muted)" font-size="11">strips and re-stamps authority · assembles routes.v1 and mcp.tools.v1 from the domains present · refuses what it cannot authenticate</text>
+
+<!-- clients -> edge -->
+<line x1="155" y1="84" x2="200" y2="150" stroke="var(--ok)" stroke-width="1.5" marker-end="url(#d-ok)"/>
+<line x1="410" y1="84" x2="410" y2="150" stroke="var(--ok)" stroke-width="1.5" marker-end="url(#d-ok)"/>
+<line x1="665" y1="84" x2="620" y2="150" stroke="var(--ok)" stroke-width="1.5" marker-end="url(#d-ok)"/>
+<text x="410" y="120" text-anchor="middle" fill="var(--ok)" font-size="11">bearer in the header · one auth path (40.8) · the same tools for every client</text>
+
+<!-- domains -->
+<rect x="40" y="300" width="220" height="80" rx="4" fill="var(--ship)" stroke="var(--ship-line)"/>
+<text x="150" y="326" text-anchor="middle" fill="var(--ink)">meetings</text>
+<text x="150" y="344" text-anchor="middle" fill="var(--muted)" font-size="11">bots · rows · transcripts</text>
+<text x="150" y="360" text-anchor="middle" fill="var(--muted)" font-size="11">bot defaults · routes.v1 · mcp.tools.v1</text>
+<rect x="320" y="300" width="240" height="80" rx="4" fill="var(--ship)" stroke="var(--ship-line)"/>
+<text x="440" y="326" text-anchor="middle" fill="var(--ink)">flows</text>
+<text x="440" y="344" text-anchor="middle" fill="var(--muted)" font-size="11">schedule · reactions · what is waiting</text>
+<text x="440" y="360" text-anchor="middle" fill="var(--muted)" font-size="11">the event log (incl. the friction sink)</text>
+<rect x="620" y="300" width="220" height="80" rx="4" fill="var(--ship)" stroke="var(--ship-line)" stroke-dasharray="6 3"/>
+<text x="730" y="326" text-anchor="middle" fill="var(--ink)">agent</text>
+<text x="730" y="344" text-anchor="middle" fill="var(--muted)" font-size="11">workspaces · turns · desk</text>
+<text x="730" y="360" text-anchor="middle" fill="var(--muted)" font-size="11">full profile only</text>
+
+<!-- edge -> domains: route bindings -->
+<line x1="150" y1="214" x2="150" y2="300" stroke="var(--ok)" stroke-width="1.5" marker-end="url(#d-ok)"/>
+<line x1="440" y1="214" x2="440" y2="300" stroke="var(--ok)" stroke-width="1.5" marker-end="url(#d-ok)"/>
+<line x1="730" y1="214" x2="730" y2="300" stroke="var(--ok)" stroke-width="1.5" stroke-dasharray="6 3" marker-end="url(#d-ok)"/>
+<text x="295" y="262" text-anchor="middle" fill="var(--ok)" font-size="11">forwards each call to the route its manifest binds · auth per tool (15)</text>
+<text x="742" y="262" fill="var(--muted)" font-size="11">only when deployed</text>
+
+<!-- optional dependencies among the three (degrade) -->
+<line x1="320" y1="330" x2="260" y2="330" stroke="var(--muted)" stroke-width="1.5" stroke-dasharray="5 4" marker-end="url(#d-deg)"/>
+<text x="290" y="292" text-anchor="middle" fill="var(--muted)" font-size="11">bot join · optional (5)</text>
+<line x1="560" y1="330" x2="620" y2="330" stroke="var(--muted)" stroke-width="1.5" stroke-dasharray="5 4" marker-end="url(#d-deg)"/>
+<text x="590" y="292" text-anchor="middle" fill="var(--muted)" font-size="11">agent turn · not_present</text>
+
+<!-- events into flows (flows.v1) -->
+<path d="M 200 380 C 200 420, 380 420, 400 380" fill="none" stroke="var(--ship-line)" stroke-width="1.5" marker-end="url(#d-ev)"/>
+<path d="M 690 380 C 690 420, 500 420, 480 380" fill="none" stroke="var(--ship-line)" stroke-width="1.5" marker-end="url(#d-ev)"/>
+<text x="440" y="424" text-anchor="middle" fill="var(--ship-line)" font-size="11">events, flows.v1: meeting.started / .completed · desk.unscaffolded · claim.proposed · friction.reported</text>
+<text x="440" y="438" text-anchor="middle" fill="var(--muted)" font-size="10">a publish is not a dependency · definitions in behavior/ decide what waits (42.2)</text>
+
+<!-- shared dependencies -->
+<rect x="40" y="480" width="520" height="64" rx="4" fill="var(--ship)" stroke="var(--ship-line)"/>
+<text x="300" y="504" text-anchor="middle" fill="var(--ink)">identity — the only shared dependency</text>
+<text x="300" y="524" text-anchor="middle" fill="var(--muted)" font-size="11">accounts · who is this bearer · person facts (timezone, mail prefs) · membership · publishes onboarding.completed</text>
+<rect x="620" y="480" width="220" height="64" rx="4" fill="var(--ship)" stroke="var(--ship-line)"/>
+<text x="730" y="504" text-anchor="middle" fill="var(--ink)">runtime — a primitive</text>
+<text x="730" y="524" text-anchor="middle" fill="var(--muted)" font-size="11">spawns what it is told, knows nothing</text>
+
+<line x1="150" y1="380" x2="150" y2="480" stroke="var(--ok)" stroke-width="1.5" marker-end="url(#d-ok)"/>
+<line x1="440" y1="380" x2="440" y2="480" stroke="var(--ok)" stroke-width="1.5" marker-end="url(#d-ok)"/>
+<line x1="640" y1="380" x2="560" y2="480" stroke="var(--ok)" stroke-width="1.5" marker-end="url(#d-ok)"/>
+<text x="470" y="466" fill="var(--ok)" font-size="11">who is this · what are their facts</text>
+<line x1="760" y1="380" x2="760" y2="480" stroke="var(--ok)" stroke-width="1.5" marker-end="url(#d-ok)"/>
+<path d="M 240 380 C 240 450, 640 450, 700 480" fill="none" stroke="var(--ok)" stroke-width="1.5" marker-end="url(#d-ok)"/>
+<text x="768" y="440" fill="var(--ok)" font-size="11">runtime.v1: spawn a bot / a worker</text>
+<text x="768" y="454" fill="var(--muted)" font-size="10">mounts and names passed in, never decoded</text>
+<path d="M 560 500 C 590 500, 600 500, 620 500" fill="none" stroke="var(--ship-line)" stroke-width="1.5" stroke-dasharray="3 3"/>
+<text x="590" y="492" text-anchor="middle" fill="var(--ship-line)" font-size="10">onboarding.completed →</text>
+
+<!-- content and deploy -->
+<rect x="40" y="620" width="340" height="50" rx="4" fill="var(--ship)" stroke="var(--ship-line)"/>
+<text x="210" y="641" text-anchor="middle" fill="var(--ink)">behavior/ — content the runtime loads</text>
+<text x="210" y="658" text-anchor="middle" fill="var(--muted)" font-size="11">mail · flow definitions · presets · prompts · seeds · a private tree mounted per deployment</text>
+<rect x="420" y="620" width="420" height="50" rx="4" fill="var(--ship)" stroke="var(--ship-line)"/>
+<text x="630" y="641" text-anchor="middle" fill="var(--ink)">deploy/ — config.v1 per service, delivered by env, validated at boot</text>
+<text x="630" y="658" text-anchor="middle" fill="var(--muted)" font-size="11">profiles: no-agents = identity + meetings + flows + edge · full adds agent</text>
+<line x1="380" y1="330" x2="380" y2="300" stroke="none"/>
+<path d="M 210 620 C 210 590, 380 590, 400 380" fill="none" stroke="var(--ok)" stroke-width="1.2" stroke-dasharray="1 3" marker-end="url(#d-ok)"/>
+<text x="230" y="598" fill="var(--muted)" font-size="10">read at run time, never compiled in (P11)</text>
+</svg>


### PR DESCRIPTION
**Delivers issue:** #1466

Docs-only, against `minutes-mcp-viewer`. Two files under `docs/adr/`: the ADR and its figure.

## Contribution rights
<!-- Select exactly ONE. This is a legal certification: an agent may explain the choices but
     must not select one for you. See CONTRIBUTOR_RIGHTS.md. -->

- [ ] **Independent:** I created this contribution, or otherwise have the right to submit it
  under Apache-2.0, and it is not owned or controlled by an employer, client, or other entity.
  <!-- rights:independent -->
- [ ] **Employer/client authorization required:** an employer, client, or other entity owns or
  may control this contribution. I am requesting Vexa's private corporate-authorization process.
  <!-- rights:corporate -->
- [ ] **Unsure:** I need a private rights review before merge.
  <!-- rights:uncertain -->

Every commit must also carry the contributor's own DCO `Signed-off-by` line. Selecting the
independent path means no individual CLA is required. Corporate and unsure paths do not stop
technical review, but they do block merge until resolved.

**Unticked by the author of this branch, deliberately.** The box is a legal certification and only
the submitting human may select it. The commit carries no `Signed-off-by` for the same reason — the
DCO path on this line is the founder's call, not a trailer an agent adds.

## Observation bundle (the record of your harnessed loop)

- **C1 — the ADR and its figure.**
  - **ran:** `grep -rln "mermaid\|<img\|!\[" docs/adr/` · **saw:** no output — no ADR in the
    repository carries a diagram, so there is no in-folder precedent to copy · **concluded:** look
    one level out for how the repo does embed diagrams before inventing a convention.
  - **ran:** `grep -rn "\.svg" --include="*.md" docs/ *.md` and read
    `docs/docs/governance/architecture.mdx:143` · **saw:** rendered architecture perspectives are
    generated by `pnpm arch:viz` **from `architecture.calm.json`** into `docs/views/*.svg`; the root
    `README.md` embeds `assets/architecture.svg` as an `<img>` · **concluded:** `docs/views/` is for
    *renders of the model*, and this figure describes a target the model does not hold yet — a
    generated render would be a picture of today, which is exactly what the ADR exists to be
    measured against. The drawing is committed beside its ADR and referenced as a markdown image.
  - **ran:** transformed the approved figure into a standalone file, then
    `python3 -c "xml.dom.minidom.parse(...)"` · **saw:** `XML OK` · **concluded:** the source figure
    inherited its palette as CSS custom properties from its host page and used
    `fill="currentColor"`, neither of which survives in an `<img>`-embedded SVG. Declared the
    properties in a `<style>` block inside the SVG with a `prefers-color-scheme: dark` override, and
    replaced `currentColor` with `var(--ink)`. Geometry, text and `aria-label` unchanged.
  - **ran:** `grep -n "core/mcp\|core-mcp" architecture.calm.json`; `grep -rn "0036"` across
    `*.md`/`*.mdx`/`*.json` · **saw:** no `core/mcp` node in the model; no reference to ADR-0036
    anywhere outside its own file · **concluded:** the ADR-0036 decision this one supersedes never
    reached the model, so there is no node to retire and no cross-reference to repair. `docs/adr/README.md`
    carries no index. **No third file is touched, and each omission is argued in the docs diff below
    rather than assumed.**
  - **ran:** `node scripts/gates.mjs readme`, `node scripts/gates.mjs docs-version`, and the
    pre-push hook · **saw:** `gate:readme — 367 dirs each carry a README`; `gate:docs-version — docs
    reflect v0.12.26, matching Chart.yaml appVersion`; `pre-push: static gates green` (after putting
    `uv` on PATH — the hook's `gate:contract-conformance` leg needs it, and `✗ /bin/sh: 1: uv: not
    found` was an environment gap on the host, not a finding about this diff) · **concluded:** green
    at head; `docs-current` needs a PR number and is recorded below against this PR.

## Acceptance floor

| Row | Evidence |
|---|---|
| A1 — the ADR page renders the figure inline, legible in both web themes | The Files-changed view and the rendered blob at head sha `f75d457f9`. The SVG carries its own palette and a `prefers-color-scheme: dark` override, so it does not depend on the page around it. **Negative control:** with the internal `<style>` block removed, every `var(--…)` resolves to nothing — boxes and arrows fall back to black on transparent and the dark theme is unreadable; that is precisely the state the transform fixes, and it is why the figure is not a verbatim copy of the source markup. **Not claimed:** a human has not yet opened the rendered page in a dark theme — that is the validation request below. |
| A2 — every arrow has a rule, every rule names its principles | `docs/adr/0037-…md` § Decision: eleven numbered rules, citing P2, P3, P4, P5, P9, P11, P14, P16, P20, P22, P23, each read back against its row in `docs/docs/governance/architecture.mdx` at head. The figure's own caption text is preserved as the block-quote under the image, so the rule list travels with the picture. **Negative control:** a reviewer naming one arrow with no rule, or one P-number whose text in `architecture.mdx` does not say what the ADR claims, reds this row. |
| A3 — supersession stated, the rest of ADR-0036 left standing | The status line: *"supersedes decision 2 of ADR-0036 (`core/mcp` as a tree beside the gateway; the rest of 0036 stands)"*, restated in Decision 2 where the replacement is made and in Consequences where 0036's disposition of the 14 meetings tools and the prototype rig is explicitly **not** reopened. **Negative control:** ADR-0036 read alone still answers `core/mcp` — this row is why the supersession is in the header rather than buried. |
| A4 — the three moves are named as to-build, not as done | § Consequences: the domain-doors gate (P9) **to build**, with the 27 call sites it will red enumerated by kind; the two profiles (`no-agents` = identity + meetings + flows + edge, `full` adds agent) and the profile matrix CI leg that is to build; what leaves the agent domain (`whats_waiting` → flows, friction → two flows events, `start_onboarding` → identity, person facts → identity, bot name → meetings, presets and mail copy → `behavior/`) against what stays. The § Enforcement map states per decision whether it is **landed**, **partial**, **to build**, or an **accepted gap** — five of eleven are to-build and say so. |
| A- — no-regression | `gate:readme` and `gate:docs-version` green locally at head (output in the bundle above); pre-push static gates green including `gate:contract-conformance`; `docs-current` resolves this PR as **no product surface touched — docs decision N/A**, since every changed path is under `docs/` and none is under `core/`, `clients/`, `deploy/`, `libs/` or `package.json`. Full suite in CI at head sha. |

## Docs diff (D6c)

This PR **is** the docs change; there is no code behind it.

| Page | Altitude | What it says |
|---|---|---|
| `docs/adr/0037-the-target-architecture-one-edge-domains-over-identity-and-runtime.md` **(new)** | decision | The target architecture as eleven rules with their principles, in ADR-0036's shape: context · the design · decision · trade-off · consequences · enforcement map. Status `accepted · 2026-09-03`. |
| `docs/adr/0037-the-target-architecture-one-edge-domains-over-identity-and-runtime.svg` **(new)** | figure | The approved design figure, standalone and theme-aware, beside the ADR so the picture is versioned with the rule it illustrates. |

Named pages that needed **no** change, each argued rather than assumed:

- **`docs/adr/README.md`** — it states the folder's one concern and carries no ADR index; there is no
  row to append. Verified by reading the file, not by assuming.
- **`docs/docs/governance/architecture.mdx`** — its principle table cites the ADR that *introduced*
  each principle. ADR-0037 introduces none; it applies eleven existing ones to one seam map. Its gate
  table gains a domain-doors row when the gate exists, not when an ADR proposes it.
- **`architecture.calm.json`** — no `core/mcp` node exists, so ADR-0036's superseded decision never
  reached the model and nothing is retired here. The model changes when the code does.
- **The Mintlify site (`docs/docs/**`)** — ADRs are repository documents for contributors, not
  published pages; no ADR is in the site navigation today, and adding one would be a separate
  decision.

## Security checks (required on the diff)

**n/a, and stated rather than skipped.** The diff adds two static documents and no code, no
dependency, no manifest and no workflow: dependency and licence scans have nothing new to resolve,
and SAST has no executable surface. The one security-shaped question a diff like this can raise is
**active content in the committed SVG** — it contains a `<style>` block, `<defs>`/`<marker>`, and
`<rect>`/`<line>`/`<path>`/`<text>` only: no `<script>`, no `<foreignObject>`, no event-handler
attribute, no external reference (`xlink:href`, `<image>`, `<use>` to a remote document), and no
embedded data URI. GitHub additionally sanitizes and proxies SVGs it serves. The maintainer's
closing security bundle before release is unaffected by this PR.

## Validation request

**Who:** any competent non-author — the reader this ADR is written for, ideally someone who has not
followed the 2026-09-02/03 seam pass, since the whole claim is that the page works cold.

**What they'll watch,** opening the ADR on GitHub and nothing else:

1. **A1 — the picture.** Does the figure render inline, and is it legible in *their* theme? Please
   say which theme you were in; light and dark are different renders and only one of them can be
   checked at a time.
2. **A2 — an arrow to a rule.** Pick any arrow in the figure, find its rule in § Decision, and check
   the principle it cites against `docs/docs/governance/architecture.mdx`. One arrow is enough to
   sign this row; more is better.
3. **A4 — what is not done.** After reading § Consequences and § Enforcement map, can you say what
   the domain-doors gate will turn red, and which rules are still to build? A reader who comes away
   thinking any of it is enforced today reds this row.

**Deployment validated (D12b):** none, and honestly unclaimed. This change touches no runtime path
on any setup — Lite, full compose, k8s or hosted — so there is no install, sha or values file to
anchor. Build provenance for the artifact under review is the head sha of this branch.

**The design itself is already signed** — founder, 2026-09-03, on the figure. What this validation
covers is whether the repository now carries that design faithfully, not whether the design is
right.

## Authorship
Sole author: the human submitting this. No agent co-author trailers (D13).
Tooling disclosure (optional, welcome, never an attribution): drafted with Claude Code from the
2026-09-03 seam pass and the approved design figure; every claim above is a read of this tree at
`a5ba8e952` or the output of a command shown in the bundle.

<!-- vexa-agent -->
