### PR TITLE
gateway: a deployment without agents gets no /agent/* routes at all — 404, not 401 — and adding a domain never edits the edge

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,8 @@
-# Root .dockerignore — used by the meeting-api build (compose `context: ../..`). The other three
-# services build from their own narrow contexts. Keep the context light: exclude vendored/build
-# trees + venvs; the Dockerfile COPYs only the meeting-api src/, its pyproject+lock, and the five
-# sealed contract files it loads by path.
+# Root .dockerignore — used by every build whose context is the repository root: meeting-api,
+# agent-api, agent-worker and the gateway (compose `context: ../..`). Those Dockerfiles COPY only
+# their own src/ + pyproject/lock plus the specific files they load BY PATH — meeting-api's five
+# sealed contract schemas, the gateway's five routes.v1 manifests. Keep the context light: exclude
+# vendored/build trees + venvs. The remaining services build from their own narrow contexts.
 node_modules/
 **/node_modules/
 **/.venv/

--- a/core/agent/routes.v1.json
+++ b/core/agent/routes.v1.json
@@ -1,0 +1,66 @@
+{
+  "contract": "routes.v1",
+  "domain": "agent",
+  "owner": "core/agent",
+  "edge": "gateway",
+  "note": "The agent control plane. ABSENT in the no-agents profile (PRD decision 40.6) \u2014 these seven rows and the routes that carry them are simply not there, so a request 404s.",
+  "presence_env": "AGENT_API_URL",
+  "routes": [
+    {
+      "method": "POST",
+      "path": "/agent/chat",
+      "scopes": [
+        "bot",
+        "tx"
+      ]
+    },
+    {
+      "method": "GET",
+      "path": "/agent/meeting/stream",
+      "scopes": [
+        "bot",
+        "tx"
+      ]
+    },
+    {
+      "method": "DELETE",
+      "path": "/agent/{path:path}",
+      "scopes": [
+        "bot",
+        "tx"
+      ]
+    },
+    {
+      "method": "GET",
+      "path": "/agent/{path:path}",
+      "scopes": [
+        "bot",
+        "tx"
+      ]
+    },
+    {
+      "method": "PATCH",
+      "path": "/agent/{path:path}",
+      "scopes": [
+        "bot",
+        "tx"
+      ]
+    },
+    {
+      "method": "POST",
+      "path": "/agent/{path:path}",
+      "scopes": [
+        "bot",
+        "tx"
+      ]
+    },
+    {
+      "method": "PUT",
+      "path": "/agent/{path:path}",
+      "scopes": [
+        "bot",
+        "tx"
+      ]
+    }
+  ]
+}

--- a/core/gateway/services/gateway/Dockerfile
+++ b/core/gateway/services/gateway/Dockerfile
@@ -1,6 +1,13 @@
 # syntax=docker/dockerfile:1
 # Gateway (v0.12 P4) — the production edge: auth · routing · /ws fan-out.
-# Build context: gateway/services/gateway (pyproject.toml + uv.lock + src/).
+#
+# BUILD CONTEXT: THE REPOSITORY ROOT (root .dockerignore keeps it light), like meeting-api and
+# agent-api. It was this service's own directory until the edge stopped owning its route table:
+# `routes_manifest.py` assembles the table from each domain's `routes.v1.json`, read BY PATH at
+# import, so the image must carry the manifests of the domains it fronts — and a narrow context
+# cannot reach them. Same reason meeting-api builds from the root and COPYs the five sealed
+# contract files it loads. A missing manifest is not a degraded gateway: the process refuses to
+# start, which is correct and is exactly how this was found (compose stack, gateway unhealthy).
 FROM python:3.12-slim
 
 # uv via PyPI (ghcr.io is unreachable in this build env) — pinned for deterministic resolves.
@@ -15,7 +22,7 @@ ENV UV_LINK_MODE=copy \
 WORKDIR /app
 
 # 1) Resolve + install the pinned dependency set from the lockfile (no project — package=false).
-COPY pyproject.toml uv.lock ./
+COPY core/gateway/services/gateway/pyproject.toml core/gateway/services/gateway/uv.lock ./
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --frozen --no-install-project
 
@@ -26,7 +33,18 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     uv pip install "uvicorn[standard]==0.34.0" "redis==5.2.1"
 
 # 3) The shipped source (src/ is on PYTHONPATH; the package is not pip-installed).
-COPY src ./src
+COPY core/gateway/services/gateway/src ./src
+
+# 4) THE ROUTE MANIFESTS OF THE DOMAINS THIS EDGE FRONTS. Kept at their repo-relative paths so
+#    `routes_manifest._repo_root()` — which walks up for core/gateway + core/meetings rather than
+#    counting parents — resolves them exactly as it does in a checkout. One file per domain, listed
+#    rather than globbed, for the same reason `manifest_paths()` is a map: a glob would silently
+#    miss one whose service moved. A domain that adds a route changes only its own file here.
+COPY core/gateway/services/gateway/routes.v1.json ./core/gateway/services/gateway/routes.v1.json
+COPY core/meetings/routes.v1.json                 ./core/meetings/routes.v1.json
+COPY core/meetings/services/mcp/routes.v1.json    ./core/meetings/services/mcp/routes.v1.json
+COPY core/identity/routes.v1.json                 ./core/identity/routes.v1.json
+COPY core/agent/routes.v1.json                    ./core/agent/routes.v1.json
 
 EXPOSE 8000
 # python -m gateway → uvicorn gateway.adapters:app (HOST/PORT from env).

--- a/core/gateway/services/gateway/routes.v1.json
+++ b/core/gateway/services/gateway/routes.v1.json
@@ -1,0 +1,19 @@
+{
+  "contract": "routes.v1",
+  "domain": "gateway",
+  "owner": "core/gateway/services/gateway",
+  "edge": "gateway",
+  "note": "The edge's OWN two routes, and the only ones it may declare: /health is the LB probe and /auth/me is 'who is this key'. Both are identity-only and forward nothing downstream, which is why they carry no scope \u2014 an empty `scopes` is a DECLARATION of that, never an omission.",
+  "routes": [
+    {
+      "method": "GET",
+      "path": "/auth/me",
+      "scopes": []
+    },
+    {
+      "method": "GET",
+      "path": "/health",
+      "scopes": []
+    }
+  ]
+}

--- a/core/gateway/services/gateway/src/gateway/adapters.py
+++ b/core/gateway/services/gateway/src/gateway/adapters.py
@@ -201,7 +201,12 @@ def build_production_app(
 
     admin_api_url = admin_api_url or os.getenv("ADMIN_API_URL", "http://admin-api:8001")
     meeting_api_url = meeting_api_url or os.getenv("MEETING_API_URL", "http://meeting-api:8080")
-    agent_api_url = os.getenv("AGENT_API_URL", "http://agent-api:8100")
+    # THE AGENT DOMAIN'S PRESENCE SIGNAL (PRD decisions 40.6 + 40.7). Unset means the deployment
+    # does not run agents — the `no-agents` product — and the edge then registers no `/agent/*`
+    # route and loads no `core/agent/routes.v1.json`, so a request there is a 404. A URL default
+    # here would assert the domain exists and make absence unsayable, which is the same defect a
+    # host-port default has one layer down. Every shipped deployment names it: compose, helm, lite.
+    agent_api_url = os.getenv("AGENT_API_URL", "")
     # #795: the MCP service, fronted at the gateway edge under /mcp (streamable-HTTP transport).
     mcp_url = os.getenv("MCP_URL", "http://mcp:8010")
     redis_url = redis_url or os.getenv("REDIS_URL", "redis://redis:6379/0")

--- a/core/gateway/services/gateway/src/gateway/app.py
+++ b/core/gateway/services/gateway/src/gateway/app.py
@@ -37,6 +37,8 @@ from urllib.parse import quote
 import httpx  # the downstream adapter's transport errors are mapped to 502/504 (not leaked as a 500)
 
 from fastapi import FastAPI, Request, Response, WebSocket, WebSocketDisconnect
+
+from . import routes_manifest
 from fastapi.responses import StreamingResponse
 from fastapi.routing import APIRoute
 
@@ -79,126 +81,35 @@ def _auth_unavailable_response(exc: Exception, *, span: str) -> Response:
 #             NEITHER — a browser-only key — is refused.
 #   browser   grants NO gateway route. v0.12 serves no browser-tool surface at this edge, so a
 #             browser-only key can authenticate (GET /auth/me) and do nothing else.
-BOT: FrozenSet[str] = frozenset({"bot"})
-TX: FrozenSet[str] = frozenset({"tx"})
-BOT_OR_TX: FrozenSet[str] = frozenset({"bot", "tx"})
-
-# (HTTP method, ROUTE TEMPLATE) → the scopes that satisfy it; a multi-scope token passes when it
-# holds ANY of them. Keyed by the route's own template (``request.scope["route"].path``), never by
-# a path PREFIX: prefix matching is what let ``/user/webhook`` and ``/user/calendar`` fall through
-# to "no entry, therefore no check", and what made ``{"bot","browser"}`` on the ``/bots`` prefix
-# hand a browser-only key the whole bot lifecycle (rc.18 sweep finding B2 — a browser-only key
-# spawned container ``mtg-26362-7c9e8908`` on staging and then stopped it).
+# ── THE TABLE IS ASSEMBLED, NOT WRITTEN HERE (PRD decisions 40.5 + 40.7) ─────────────────────
 #
-# THIS TABLE IS EXHAUSTIVE AND ENFORCED AS SUCH. A proxied route that is absent from it is DENIED
-# at request time and, so the hole cannot ship, refuses to build at all: ``create_app`` raises when
-# any registered ``APIRoute`` is neither declared here nor in ``UNSCOPED_ROUTES``. Adding a route
-# therefore requires deciding its scope — the check is not an allowlist anyone must remember to
-# extend, it is a wall the new route walks into.
-ROUTE_SCOPES: Dict[Tuple[str, str], FrozenSet[str]] = {
-    # --- bot lifecycle: spawn · stop · list · status · config · speak · chat-read ---
-    ("GET", "/bots"): BOT,
-    ("POST", "/bots"): BOT,
-    ("GET", "/bots/status"): BOT,
-    ("DELETE", "/bots/{platform}/{native_meeting_id}"): BOT,
-    ("PUT", "/bots/{platform}/{native_meeting_id}/config"): BOT,
-    ("POST", "/bots/{platform}/{native_meeting_id}/speak"): BOT,
-    ("GET", "/bots/{platform}/{native_meeting_id}/chat"): BOT,
-    # --- the meeting record plane ---
-    ("GET", "/meetings"): TX,
-    ("POST", "/meetings"): TX,
-    ("GET", "/meetings/{meeting_id}"): TX,
-    ("PATCH", "/meetings/{meeting_id}"): TX,
-    ("DELETE", "/meetings/{meeting_id}"): TX,
-    ("PATCH", "/meetings/{platform}/{native_meeting_id}"): TX,
-    ("DELETE", "/meetings/{platform}/{native_meeting_id}"): TX,
-    ("PUT", "/meetings/{platform}/{native_meeting_id}/intent"): TX,
-    ("POST", "/meetings/{platform}/{native_meeting_id}/annotate"): TX,
-    # Minting a share is the same power on either address shape — the row id and the (platform,
-    # native) pair name the same meeting; only the pair cannot name all of them.
-    ("POST", "/meetings/{meeting_id}/share"): TX,
-    # Importing a transcript writes the caller's OWN meeting — the same plane as annotating or
-    # sharing it, addressed by the row id for the same reason (the pair is not an identity).
-    ("POST", "/meetings/{meeting_id}/transcript-import"): TX,
-    ("POST", "/meetings/{platform}/{native_meeting_id}/share"): TX,
-    ("POST", "/meetings/{platform}/{native_meeting_id}/workspace"): TX,
-    # A participants read is meeting DATA, not bot control — same plane as the transcript it is
-    # derived from, so a key that may read the transcript may read who was heard in it.
-    ("GET", "/meetings/{platform}/{native_meeting_id}/participants"): TX,
-    # --- transcripts ---
-    ("GET", "/transcripts/by-id/{meeting_id}"): TX,
-    ("GET", "/transcripts/search"): TX,
-    ("GET", "/transcripts/{platform}/{native_meeting_id}"): TX,
-    ("POST", "/transcripts/by-id/{meeting_id}/share"): TX,
-    ("POST", "/transcripts/{platform}/{native_meeting_id}/share"): TX,
-    ("POST", "/transcripts/share/accept"): TX,
-    # --- recordings (unchanged: the sealed table already accepted either domain) ---
-    ("GET", "/recordings"): BOT_OR_TX,
-    ("GET", "/recordings/{recording_id}"): BOT_OR_TX,
-    ("GET", "/recordings/{recording_id}/master"): BOT_OR_TX,
-    ("GET", "/recordings/{recording_id}/media/{media_file_id}/raw"): BOT_OR_TX,
-    ("GET", "/recordings/{recording_id}/media/{media_file_id}/download"): BOT_OR_TX,
-    # Destruction is not a read, so it does not inherit the reads' scope. A `tx` key is handed out
-    # for transcript access — to an integration, to an MCP agent — and must never carry the power to
-    # erase an account's recordings and transcripts permanently. The map being per-(method, path) is
-    # what makes declaring this separately possible; declaring it BOT_OR_TX would hand every
-    # read-only key a delete.
-    ("DELETE", "/recordings/{recording_id}"): BOT,
-    # --- calendar connections: BOT, because auto-join spawns bots from the feed ---
-    ("GET", "/user/calendar"): BOT,
-    ("PUT", "/user/calendar"): BOT,
-    ("GET", "/user/calendar/sync"): BOT,
-    ("POST", "/user/calendar/sync"): BOT,
-    ("GET", "/user/calendars"): BOT,
-    ("POST", "/user/calendars"): BOT,
-    ("PATCH", "/user/calendars/{calendar_id}"): BOT,
-    ("DELETE", "/user/calendars/{calendar_id}"): BOT,
-    ("GET", "/user/calendars/{calendar_id}/sync"): BOT,
-    ("POST", "/user/calendars/{calendar_id}/sync"): BOT,
-    # --- the rest of the self-serve account config (no bot-spawn power of its own) ---
-    ("GET", "/user/webhook"): BOT_OR_TX,
-    ("PUT", "/user/webhook"): BOT_OR_TX,
-    ("GET", "/user/webhook/deliveries"): BOT_OR_TX,
-    ("GET", "/user/models"): BOT_OR_TX,
-    ("PUT", "/user/models"): BOT_OR_TX,
-    ("GET", "/user/transcription"): BOT_OR_TX,
-    ("PUT", "/user/transcription"): BOT_OR_TX,
-    # --- the agent control plane. Per-RESOURCE authorization here is still the open Stage-3 gap
-    # (see the strict-xfail in tests/test_proxy.py); this table only settles which KEYS reach it.
-    ("POST", "/agent/chat"): BOT_OR_TX,
-    ("GET", "/agent/meeting/stream"): BOT_OR_TX,
-    ("GET", "/agent/{path:path}"): BOT_OR_TX,
-    ("POST", "/agent/{path:path}"): BOT_OR_TX,
-    ("PUT", "/agent/{path:path}"): BOT_OR_TX,
-    ("PATCH", "/agent/{path:path}"): BOT_OR_TX,
-    ("DELETE", "/agent/{path:path}"): BOT_OR_TX,
-    # --- the MCP front door. Its tools call BACK through this gateway with the caller's own key,
-    # so /bots is gated on that second hop too; this is the first hop.
-    ("GET", "/mcp"): BOT_OR_TX,
-    ("POST", "/mcp"): BOT_OR_TX,
-    ("PUT", "/mcp"): BOT_OR_TX,
-    ("PATCH", "/mcp"): BOT_OR_TX,
-    ("DELETE", "/mcp"): BOT_OR_TX,
-    ("OPTIONS", "/mcp"): BOT_OR_TX,
-    ("GET", "/mcp/{path:path}"): BOT_OR_TX,
-    ("POST", "/mcp/{path:path}"): BOT_OR_TX,
-    ("PUT", "/mcp/{path:path}"): BOT_OR_TX,
-    ("PATCH", "/mcp/{path:path}"): BOT_OR_TX,
-    ("DELETE", "/mcp/{path:path}"): BOT_OR_TX,
-    ("OPTIONS", "/mcp/{path:path}"): BOT_OR_TX,
-}
+# This used to be a 92-line literal holding all 69 rows, seven of them the agent domain's. That
+# made the EDGE the place a domain's route list was written down, which 40.5 forbids in as many
+# words — *"the gateway still owns nothing: it composes, strips authority, re-stamps, forwards"* —
+# and which 40.7 makes concretely wrong rather than untidy: agents are OPTIONAL, and a table that
+# names `/agent/*` unconditionally cannot describe a deployment that has none.
+#
+# Each domain now declares its own routes and their scopes in a `routes.v1.json` beside its
+# service, the same shape as the `mcp.tools.v1` manifests and for the same reason. The rules the
+# assembly refuses to boot on — duplicate ownership, an unknown scope, a manifest for a domain
+# that is not deployed — are in `routes_manifest.py`.
+#
+# THE MODULE-LEVEL PAIR IS THE FULL PROFILE, kept because it is this package's published surface
+# (`gateway/__init__.py`) and because every existing reader means "what does a complete deployment
+# serve". An app built without a domain carries its OWN narrower table; see `create_app`.
+_FULL_PROFILE: FrozenSet[str] = frozenset({"gateway", "meetings", "identity", "mcp", "agent"})
+_ASSEMBLED = routes_manifest.load(_FULL_PROFILE)
+ROUTE_SCOPES: Dict[Tuple[str, str], FrozenSet[str]] = dict(_ASSEMBLED.scopes)
 
 # The routes that carry NO scope requirement, declared explicitly so "no entry" can mean "denied"
 # everywhere else. Both are identity-only and forward nothing downstream: /health is the LB probe
 # (unauthenticated by design) and /auth/me is "who is this key" — a browser-only key must be able
-# to learn that it is a browser-only key.
-UNSCOPED_ROUTES: FrozenSet[Tuple[str, str]] = frozenset({
-    ("GET", "/health"),
-    ("GET", "/auth/me"),
-})
+# to learn that it is a browser-only key. They are the EDGE's own two routes, and the only ones it
+# declares for itself (`core/gateway/services/gateway/routes.v1.json`).
+UNSCOPED_ROUTES: FrozenSet[Tuple[str, str]] = frozenset(_ASSEMBLED.unscoped)
 
 
-def undeclared_routes(app: FastAPI) -> List[Tuple[str, str]]:
+def undeclared_routes(app: FastAPI, table=None, unscoped=None) -> List[Tuple[str, str]]:
     """Every (method, route-template) on ``app`` with no entry in ROUTE_SCOPES or UNSCOPED_ROUTES.
 
     The executable form of the deny-by-default invariant, used by ``create_app``'s build-time
@@ -214,7 +125,8 @@ def undeclared_routes(app: FastAPI) -> List[Tuple[str, str]]:
             if method == "HEAD":
                 continue  # never registered by FastAPI itself; mirrors its GET sibling if it is
             key = (method, route.path)
-            if key not in ROUTE_SCOPES and key not in UNSCOPED_ROUTES:
+            if key not in (ROUTE_SCOPES if table is None else table) and \
+                    key not in (UNSCOPED_ROUTES if unscoped is None else unscoped):
                 missing.append(key)
     return missing
 
@@ -267,7 +179,7 @@ def _invalid_path_param_response() -> Response:
     )
 
 
-def _required_scopes(request: Request) -> Optional[FrozenSet[str]]:
+def _required_scopes(request: Request, table=None) -> Optional[FrozenSet[str]]:
     """The scopes declared for the route this request MATCHED, or ``None`` when it declares none.
 
     Resolved from the matched route's template (``request.scope["route"].path``) rather than from
@@ -280,7 +192,7 @@ def _required_scopes(request: Request) -> Optional[FrozenSet[str]]:
     path = getattr(route, "path", None)
     if not path:
         return None
-    return ROUTE_SCOPES.get((request.method.upper(), path))
+    return (ROUTE_SCOPES if table is None else table).get((request.method.upper(), path))
 
 
 # ── the authority-header strip (F95) ─────────────────────────────────────────────
@@ -319,7 +231,7 @@ def create_app(
     redis: RedisBus,
     *,
     meeting_api_url: str = _DEFAULT_MEETING_API_URL,
-    agent_api_url: str = _DEFAULT_AGENT_API_URL,
+    agent_api_url: Optional[str] = _DEFAULT_AGENT_API_URL,
     admin_api_url: str = _DEFAULT_ADMIN_API_URL,
     mcp_url: str = _DEFAULT_MCP_URL,
     rate_limiter=None,
@@ -331,6 +243,24 @@ def create_app(
                       /bots + /transcripts + /meetings + /recordings all live there now, P2).
     ``redis``       — pub/sub bus for the ``/ws`` fan-in.
     """
+    # ── WHICH DOMAINS THIS DEPLOYMENT FRONTS (PRD decisions 40.6 + 40.7) ─────────────────────
+    #
+    # Presence is a CONFIGURATION FACT — whether the deployment named the door — never a probe. A
+    # probe makes "agent-api is restarting" and "there is no agent-api" the same answer, and the
+    # second is a shipped product: `no-agents` is gateway + meetings + flows + identity (40.6).
+    #
+    # An absent domain's routes are not registered AND not in the table, and that pairing is the
+    # whole point. Declared-but-unregistered would be a dead row; registered-but-undeclared would
+    # 403 — "you may not", which is false. Absent on both sides answers **404**: this deployment
+    # does not serve it, which is the truth and the only answer a client can act on.
+    _present = {"gateway", "meetings", "identity", "mcp"}
+    _agent_present = bool((agent_api_url or "").strip())
+    if _agent_present:
+        _present.add("agent")
+    _assembly = routes_manifest.load(_present)
+    _route_scopes = _assembly.scopes
+    _unscoped = _assembly.unscoped
+
     app = FastAPI(title="Vexa API Gateway (v0.12)")
     # The edge: mint/read X-Trace-Id and bind it for the request (logevent.v1 trace_id).
     app.add_middleware(TraceMiddleware)
@@ -419,7 +349,7 @@ def create_app(
         # Per-RESOURCE authorization remains separate and still open on the agent domain: this
         # decides WHICH KEYS reach a route, not which of the owner's objects they may touch. See
         # the strict-xfail on GET /agent/meeting/stream in tests/test_proxy.py.
-        required = _required_scopes(request)
+        required = _required_scopes(request, _route_scopes)
         if required is None:
             log_event(
                 "request_denied_undeclared_route",
@@ -934,17 +864,22 @@ def create_app(
     # everything else (sessions · history · routines · workspace tree/file/git/upload · models) is
     # request/response JSON → the buffered _forward, with X-User-Id injected. All carry the path/method/
     # query/body verbatim to agent-api's matching /api/<path> via _agent().
-    @app.post("/agent/chat")
-    async def agent_chat(request: Request):
-        return await _forward_stream("POST", _agent("chat"), request)
+    #
+    # REGISTERED ONLY WHEN THE AGENT DOMAIN IS DEPLOYED. `core/agent/routes.v1.json` declares
+    # these seven rows and is loaded on the same condition, so in a no-agents deployment the
+    # routes and their declarations are absent together and `/agent/anything` is a 404.
+    if _agent_present:
+        @app.post("/agent/chat")
+        async def agent_chat(request: Request):
+            return await _forward_stream("POST", _agent("chat"), request)
 
-    @app.get("/agent/meeting/stream")
-    async def agent_meeting_stream(request: Request):
-        return await _forward_stream("GET", _agent("meeting/stream"), request)
+        @app.get("/agent/meeting/stream")
+        async def agent_meeting_stream(request: Request):
+            return await _forward_stream("GET", _agent("meeting/stream"), request)
 
-    @app.api_route("/agent/{path:path}", methods=["GET", "POST", "PUT", "PATCH", "DELETE"])
-    async def agent_proxy(path: str, request: Request):
-        return await _forward(request.method, _agent(path), request)
+        @app.api_route("/agent/{path:path}", methods=["GET", "POST", "PUT", "PATCH", "DELETE"])
+        async def agent_proxy(path: str, request: Request):
+            return await _forward(request.method, _agent(path), request)
 
     # ---- the MCP front door (#795): the streamable-HTTP transport, fronted at the edge ----
     # MCP streamable-HTTP is ONE endpoint driven by two methods with opposite lifetimes:
@@ -1009,13 +944,14 @@ def create_app(
     # BUILD is the point: a 403 at request time only tells whoever hits the route, and only after
     # it ships, whereas this fires in every unit test, every conformance run and the container's
     # own start-up. An under-declared gateway does not boot.
-    missing = undeclared_routes(app)
+    missing = undeclared_routes(app, _route_scopes, _unscoped)
     if missing:
         raise RuntimeError(
             "gateway routes with no scope declaration: "
             + ", ".join(f"{m} {p}" for m, p in missing)
-            + " — add each to gateway.app.ROUTE_SCOPES (or, for an identity-only route that needs "
-            "no scope, to UNSCOPED_ROUTES)."
+            + " — declare each in the OWNING DOMAIN's routes.v1.json (an identity-only route that "
+            "needs no scope is declared there with an empty `scopes`). The edge composes the table "
+            f"from the domains it fronts and owns none of it; this build fronts {sorted(_present)}."
         )
 
     return app

--- a/core/gateway/services/gateway/src/gateway/config.v1.json
+++ b/core/gateway/services/gateway/src/gateway/config.v1.json
@@ -1,6 +1,12 @@
 {
  "contract": "config.v1",
  "service": "gateway",
+ "capabilities": {
+  "agent_domain": {
+   "description": "Whether this deployment fronts the AGENT domain (PRD decision 40.7: meetings, agents and flows work independently and in any configuration, identity being the only shared dependency). Presence is a configuration fact \u2014 whether the deployment named the door \u2014 never a probe: a probe makes \"agent-api is restarting\" and \"there is no agent-api\" the same answer, and the second is a shipped product.",
+   "when_unconfigured": "The edge registers no /agent/* route and assembles no agent rows into its scope table, so a request to /agent/anything is 404 \u2014 this deployment does not serve it \u2014 rather than a 401 about a route that is not here. Everything else is unchanged: this is the `no-agents` product of decision 40.6 (gateway + meetings + flows + identity), not a degraded gateway."
+  }
+ },
  "keys": [
   {
    "key": "INTERNAL_API_SECRET",
@@ -31,10 +37,10 @@
   },
   {
    "key": "AGENT_API_URL",
-   "class": "defaulted",
-   "default": "http://agent-api:8100",
-   "description": "agent control-plane base URL fronted under /api/*",
-   "targets": ["helm", "lite"]
+   "class": "capability",
+   "capability": "agent_domain",
+   "description": "agent control-plane base URL fronted under /api/*. UNSET MEANS THE AGENT DOMAIN IS NOT DEPLOYED (PRD 40.6 no-agents, 40.7 domains are independent): the edge registers no /agent/* route and assembles no agent rows into its scope table, so a request there is 404 — this deployment does not serve it — rather than a 401 about a route that is not here. A URL default would assert the domain exists and make its absence unsayable.",
+   "targets": ["compose", "helm", "lite"]
   },
   {
    "key": "MCP_URL",

--- a/core/gateway/services/gateway/src/gateway/routes_manifest.py
+++ b/core/gateway/services/gateway/src/gateway/routes_manifest.py
@@ -1,0 +1,150 @@
+"""routes_manifest.py — the edge assembles its route table; it does not own one.
+
+PRD decision 40.5: *"The gateway still owns nothing: it composes, strips authority, re-stamps,
+forwards."* `ROUTE_SCOPES` was a 92-line literal in `app.py` holding all 69 rows — including the
+agent domain's seven, which made the edge the place where a domain's route list was written down.
+Decision 40.7 then makes that concretely wrong rather than merely untidy: **agents are optional**,
+and a table that names `/agent/*` unconditionally cannot describe a deployment that has no agents.
+
+So each domain declares its own routes beside its service, in a `routes.v1.json` — the same shape
+as the `mcp.tools.v1` manifests and for the same reason: the domain that owns the door behind a
+route is the only one that can say what the route is and what it costs.
+
+    core/meetings/routes.v1.json                   38 rows
+    core/identity/routes.v1.json                   12
+    core/meetings/services/mcp/routes.v1.json      12
+    core/agent/routes.v1.json                       7   ← absent in the no-agents profile
+    core/gateway/services/gateway/routes.v1.json    2   the edge's OWN /health and /auth/me
+
+WHAT THIS MODULE REFUSES, and why each is a boot failure rather than a log line — every one of them
+is otherwise found by a person hitting a route that answers wrongly:
+
+    a manifest that is not routes.v1        ->  a file shape nobody validated, silently ignored
+    the same (method, path) twice           ->  two domains claiming one route; last-one-wins
+    a scope name outside the vocabulary     ->  a typo'd scope is an empty set is a DENY-ALL
+    a manifest for an absent domain         ->  the table describing a service that is not there
+
+DENY-BY-DEFAULT SURVIVES THE MOVE. The assembled table is still exhaustive and still enforced as
+such by `create_app`: a registered route that no manifest declares refuses to build. What changed
+is only WHO writes the declaration down.
+"""
+from __future__ import annotations
+
+import json
+import pathlib
+from dataclasses import dataclass, field
+from typing import Dict, FrozenSet, Iterable, List, Optional, Set, Tuple
+
+CONTRACT = "routes.v1"
+#: The scope vocabulary `docs/docs/authentication.mdx` defines. A manifest may not invent one: an
+#: unknown scope name would be a set no key can satisfy, which reads as a deny and looks like a
+#: policy decision somebody made on purpose.
+SCOPES = frozenset({"bot", "tx", "browser"})
+METHODS = frozenset({"GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS", "HEAD"})
+
+RouteKey = Tuple[str, str]
+
+
+class ManifestError(Exception):
+    """A manifest, or a combination of them, this edge must not boot with."""
+
+
+@dataclass
+class Assembly:
+    scopes: Dict[RouteKey, FrozenSet[str]] = field(default_factory=dict)
+    unscoped: Set[RouteKey] = field(default_factory=set)
+    domains: Dict[str, int] = field(default_factory=dict)          # domain -> rows contributed
+    #: which domain declared each row, so a duplicate can name BOTH sides and an operator reading
+    #: the refusal knows which two files to open.
+    owner_of: Dict[RouteKey, str] = field(default_factory=dict)
+
+
+def manifest_paths(repo_root: pathlib.Path) -> Dict[str, pathlib.Path]:
+    """Where each domain's manifest lives. A map rather than a glob: a glob would silently pick up
+    a manifest somebody dropped in a build directory, and silently MISS one whose service moved."""
+    return {
+        "gateway": repo_root / "core/gateway/services/gateway/routes.v1.json",
+        "meetings": repo_root / "core/meetings/routes.v1.json",
+        "identity": repo_root / "core/identity/routes.v1.json",
+        "mcp": repo_root / "core/meetings/services/mcp/routes.v1.json",
+        "agent": repo_root / "core/agent/routes.v1.json",
+    }
+
+
+def read(path: pathlib.Path) -> dict:
+    try:
+        doc = json.loads(path.read_text())
+    except FileNotFoundError as e:
+        raise ManifestError(f"{path} is missing — a deployed domain must declare its routes") from e
+    except ValueError as e:
+        raise ManifestError(f"{path} is not readable JSON: {e}") from e
+    if doc.get("contract") != CONTRACT:
+        raise ManifestError(f"{path} declares contract {doc.get('contract')!r}, not {CONTRACT!r}")
+    if not doc.get("domain"):
+        raise ManifestError(f"{path} names no domain")
+    return doc
+
+
+def assemble(manifests: Iterable[dict]) -> Assembly:
+    """The union of what the DEPLOYED domains serve, or `ManifestError`.
+
+    Absence is not an error and never reaches here: a domain that is not deployed contributes no
+    manifest, so its routes are not in the table AND — because `create_app` registers a domain's
+    routes on the same condition — not on the app either. That pairing is the whole point. A route
+    present but unscoped would 403; a route absent answers **404**, which is the truth: this
+    deployment does not serve it.
+    """
+    out = Assembly()
+    for doc in manifests:
+        domain = doc["domain"]
+        rows = doc.get("routes") or []
+        for row in rows:
+            method = str(row.get("method", "")).upper()
+            path = str(row.get("path", ""))
+            if method not in METHODS:
+                raise ManifestError(f"{domain}: {method!r} is not an HTTP method ({path})")
+            if not path.startswith("/"):
+                raise ManifestError(f"{domain}: {path!r} is not a route template")
+            scopes = frozenset(row.get("scopes") or ())
+            unknown = scopes - SCOPES
+            if unknown:
+                raise ManifestError(
+                    f"{domain}: {method} {path} names scope(s) {sorted(unknown)} outside the "
+                    f"vocabulary {sorted(SCOPES)} — an unknown scope is a set no key can hold, "
+                    "which denies the route while reading like a decision")
+            key = (method, path)
+            if key in out.owner_of:
+                raise ManifestError(
+                    f"{method} {path} is declared by both {out.owner_of[key]!r} and {domain!r} — "
+                    "one route, one owner; the edge composes and cannot arbitrate")
+            out.owner_of[key] = domain
+            if scopes:
+                out.scopes[key] = scopes
+            else:
+                out.unscoped.add(key)
+        out.domains[domain] = len(rows)
+    return out
+
+
+def load(present: Iterable[str], *, repo_root: Optional[pathlib.Path] = None) -> Assembly:
+    """Assemble the table from the manifests of the domains this deployment runs."""
+    root = repo_root or _repo_root()
+    paths = manifest_paths(root)
+    unknown = sorted(set(present) - set(paths))
+    if unknown:
+        raise ManifestError(f"no routes.v1 manifest is known for domain(s) {unknown}")
+    return assemble(read(paths[d]) for d in sorted(present))
+
+
+def _repo_root() -> pathlib.Path:
+    """The carve root, found by walking up for a marker rather than counting `parents[n]`.
+
+    Counted parents break silently when a package moves — the `core-mcp` split is moving one right
+    now — and the breakage is an import error at boot in one deployment shape and not another."""
+    here = pathlib.Path(__file__).resolve()
+    for p in here.parents:
+        if (p / "core" / "gateway").is_dir() and (p / "core" / "meetings").is_dir():
+            return p
+    raise ManifestError(
+        "cannot find the repository root from "
+        f"{here} — the gateway image must carry the routes.v1 manifests of the domains it fronts")

--- a/core/gateway/services/gateway/tests/test_route_manifests.py
+++ b/core/gateway/services/gateway/tests/test_route_manifests.py
@@ -1,0 +1,160 @@
+"""The edge assembles its route table from the domains it fronts, and owns none of it.
+
+PRD decision 40.5 — *"the gateway still owns nothing: it composes, strips authority, re-stamps,
+forwards"* — and 40.7, which makes that concrete: **agents are optional**, so a table that names
+`/agent/*` unconditionally cannot describe a `no-agents` deployment (40.6: gateway + meetings +
+flows + identity).
+
+What these tests hold down, in the order they matter:
+
+  1. the FULL profile is byte-for-byte what shipped — 69 scoped rows and 2 unscoped, and every one
+     of them still matched to a route that exists;
+  2. without the agent domain the table lacks EXACTLY its seven rows and nothing else;
+  3. an absent domain's routes are absent from the APP too, so a request 404s rather than 403s;
+  4. the refusals that make the assembly safe to compose from files.
+"""
+from __future__ import annotations
+
+import pytest
+from fastapi.routing import APIRoute
+from starlette.testclient import TestClient
+
+from gateway import ROUTE_SCOPES, UNSCOPED_ROUTES, create_app, routes_manifest, undeclared_routes
+from gateway.routes_manifest import ManifestError
+
+from conftest import VALID_KEY, FakeAuthorizer, FakeDownstream, FakeRedis
+
+#: The agent domain's whole share of the edge — the seven rows that vanish in `no-agents`.
+AGENT_ROWS = frozenset({
+    ("POST", "/agent/chat"),
+    ("GET", "/agent/meeting/stream"),
+    ("GET", "/agent/{path:path}"),
+    ("POST", "/agent/{path:path}"),
+    ("PUT", "/agent/{path:path}"),
+    ("PATCH", "/agent/{path:path}"),
+    ("DELETE", "/agent/{path:path}"),
+})
+#: What shipped. A count, not a copy of the table: a second copy of 69 rows is a second thing to
+#: keep in step, and `test_the_assembled_table_matches_the_app_exactly` is what proves the
+#: CONTENT — against the routes themselves, which is a stronger anchor than a literal.
+FULL_SCOPED, FULL_UNSCOPED = 69, 2
+
+
+def _app(**kw):
+    return create_app(FakeAuthorizer(), FakeDownstream(), FakeRedis(), **kw)
+
+
+# ── 1 · the full profile is unchanged ────────────────────────────────────────────────────────────
+
+def test_the_full_profile_is_exactly_what_shipped():
+    assert (len(ROUTE_SCOPES), len(UNSCOPED_ROUTES)) == (FULL_SCOPED, FULL_UNSCOPED)
+    assert AGENT_ROWS <= set(ROUTE_SCOPES)
+
+
+def test_the_assembled_table_matches_the_app_exactly():
+    """Every declared row is a route, and every route is declared. This is the anchor: it ties the
+    manifests to the thing they describe, so a row that drifts is caught by the routes themselves
+    rather than by a copy of the table living in a test."""
+    app = _app()
+    registered = {(m, r.path) for r in app.routes if isinstance(r, APIRoute)
+                  for m in (r.methods or ()) if m != "HEAD"}
+    declared = set(ROUTE_SCOPES) | set(UNSCOPED_ROUTES)
+    assert registered == declared, {
+        "declared but not registered": sorted(declared - registered),
+        "registered but not declared": sorted(registered - declared)}
+
+
+def test_every_domain_declares_its_own_and_only_its_own():
+    a = routes_manifest.load({"gateway", "meetings", "identity", "mcp", "agent"})
+    assert a.domains == {"agent": 7, "gateway": 2, "identity": 12, "mcp": 12, "meetings": 38}
+    assert {k for k, d in a.owner_of.items() if d == "agent"} == AGENT_ROWS
+    # The EDGE declares two routes and they are its own — /health and /auth/me forward nothing.
+    assert {k for k, d in a.owner_of.items() if d == "gateway"} == set(UNSCOPED_ROUTES)
+
+
+# ── 2 · the no-agents profile lacks exactly the agent's rows ─────────────────────────────────────
+
+def test_without_the_agent_domain_the_table_lacks_exactly_its_seven_rows():
+    full = routes_manifest.load({"gateway", "meetings", "identity", "mcp", "agent"})
+    lean = routes_manifest.load({"gateway", "meetings", "identity", "mcp"})
+    assert set(full.scopes) - set(lean.scopes) == AGENT_ROWS
+    assert set(lean.scopes) - set(full.scopes) == set()
+    assert lean.unscoped == full.unscoped
+
+
+def test_the_no_agents_app_does_not_register_the_agent_routes():
+    app = _app(agent_api_url="")
+    registered = {(m, r.path) for r in app.routes if isinstance(r, APIRoute)
+                  for m in (r.methods or ()) if m != "HEAD"}
+    assert registered & AGENT_ROWS == set()
+    assert ("GET", "/bots") in registered, "only the agent domain went away"
+    assert undeclared_routes(app, routes_manifest.load(
+        {"gateway", "meetings", "identity", "mcp"}).scopes,
+        routes_manifest.load({"gateway", "meetings", "identity", "mcp"}).unscoped) == []
+
+
+# ── 3 · absent is 404, not 401 and not 403 ───────────────────────────────────────────────────────
+
+@pytest.mark.parametrize("method,path", [
+    ("post", "/agent/chat"), ("get", "/agent/meeting/stream"), ("get", "/agent/sessions"),
+])
+def test_a_request_to_an_absent_domain_is_404_not_401(method, path):
+    """404 is the only honest answer: this deployment does not serve it. 401 would say "sign in and
+    it will work" and 403 would say "you may not" — both describe a route that exists, and a client
+    told either one retries, escalates, or asks for a scope nobody can grant."""
+    client = TestClient(_app(agent_api_url=""))
+    for headers in ({}, {"x-api-key": VALID_KEY}):
+        r = getattr(client, method)(path, headers=headers)
+        assert r.status_code == 404, (path, headers, r.status_code)
+
+
+def test_the_same_request_is_served_when_the_agent_domain_is_there():
+    """The half a blanket 404 would break."""
+    client = TestClient(_app())
+    assert client.get("/agent/sessions", headers={"x-api-key": VALID_KEY}).status_code != 404
+
+
+# ── 4 · the refusals that make composing from files safe ─────────────────────────────────────────
+
+def _doc(domain, rows):
+    return {"contract": "routes.v1", "domain": domain, "routes": rows}
+
+
+def test_two_domains_claiming_one_route_refuse_to_boot():
+    with pytest.raises(ManifestError) as e:
+        routes_manifest.assemble([
+            _doc("meetings", [{"method": "GET", "path": "/x", "scopes": ["bot"]}]),
+            _doc("agent", [{"method": "GET", "path": "/x", "scopes": ["tx"]}]),
+        ])
+    assert "meetings" in str(e.value) and "agent" in str(e.value), \
+        "the refusal must name BOTH files, or the operator has two to find"
+
+
+def test_a_scope_outside_the_vocabulary_refuses_to_boot():
+    """An unknown scope is a set no key can hold — a deny that reads like a decision somebody made."""
+    with pytest.raises(ManifestError) as e:
+        routes_manifest.assemble([_doc("agent", [{"method": "GET", "path": "/x",
+                                                  "scopes": ["bot", "amin"]}])])
+    assert "amin" in str(e.value)
+
+
+@pytest.mark.parametrize("row", [
+    {"method": "FETCH", "path": "/x", "scopes": ["bot"]},
+    {"method": "GET", "path": "agent/x", "scopes": ["bot"]},
+])
+def test_a_row_that_is_not_a_route_refuses_to_boot(row):
+    with pytest.raises(ManifestError):
+        routes_manifest.assemble([_doc("agent", [row])])
+
+
+def test_a_manifest_of_the_wrong_contract_refuses_to_boot(tmp_path):
+    p = tmp_path / "routes.v1.json"
+    p.write_text('{"contract": "mcp.tools.v1", "domain": "agent", "routes": []}')
+    with pytest.raises(ManifestError) as e:
+        routes_manifest.read(p)
+    assert "routes.v1" in str(e.value)
+
+
+def test_a_deployed_domain_with_no_manifest_refuses_to_boot():
+    with pytest.raises(ManifestError):
+        routes_manifest.load({"gateway", "billing"})

--- a/core/gateway/services/gateway/tests/test_scope_matrix.py
+++ b/core/gateway/services/gateway/tests/test_scope_matrix.py
@@ -23,6 +23,8 @@ from fastapi.testclient import TestClient
 
 import gateway.app as app_module
 from gateway import ROUTE_SCOPES, UNSCOPED_ROUTES, create_app, undeclared_routes
+from gateway import app as gateway_app
+from gateway import routes_manifest
 from conftest import VALID_KEY, FakeAuthorizer, FakeDownstream, FakeRedis
 
 AUTH = {"x-api-key": VALID_KEY}
@@ -236,37 +238,50 @@ def test_the_guard_actually_catches_an_undeclared_route():
     assert undeclared_routes(app) == [("PUT", "/user/quota")]
 
 
-def test_an_undeclared_route_is_denied_at_request_time():
+
+def _without(monkeypatch, method: str, path: str):
+    """Build the app as if the OWNING DOMAIN had failed to declare one route.
+
+    These two tests used to `del ROUTE_SCOPES[...]` — the table was a module-level literal and the
+    app read it live. It is assembled from each domain's `routes.v1.json` now, so removing the row
+    at its source is removing it from the assembly the app is built with. Same invariant, one layer
+    out: the hole is a domain's missing declaration rather than an edit to the edge's own dict."""
+    real = routes_manifest.load
+
+    def _short(present, **kw):
+        a = real(present, **kw)
+        a.scopes.pop((method, path), None)
+        a.unscoped.discard((method, path))
+        return a
+
+    monkeypatch.setattr(routes_manifest, "load", _short)
+
+
+def test_an_undeclared_route_is_denied_at_request_time(monkeypatch):
     """The second wall, exercised through the real request path: with its declaration removed, a
     route refuses a FULL-scope key rather than forwarding it. So the failure mode of forgetting a
     declaration is a 403 the author trips over — never an open door."""
-    app = create_app(FakeAuthorizer(), FakeDownstream(), FakeRedis())
-    client = TestClient(app)
-    assert client.get("/bots/status", headers=AUTH).status_code == 200  # bot+tx+browser key
+    assert TestClient(create_app(FakeAuthorizer(), FakeDownstream(), FakeRedis())).get(
+        "/bots/status", headers=AUTH).status_code == 200            # bot+tx+browser key
 
-    saved = dict(ROUTE_SCOPES)
-    try:
-        del ROUTE_SCOPES[("GET", "/bots/status")]
-        r = client.get("/bots/status", headers=AUTH)
-        assert r.status_code == 403
-        assert r.json()["detail"] == "Insufficient scope for this endpoint"
-    finally:
-        ROUTE_SCOPES.clear()
-        ROUTE_SCOPES.update(saved)
+    _without(monkeypatch, "GET", "/bots/status")
+    # The BUILD-time wall fires first and by design, so this app is constructed with the check
+    # relaxed — the point here is the REQUEST path, which is the second wall behind it.
+    monkeypatch.setattr(gateway_app, "undeclared_routes", lambda *a, **k: [])
+    client = TestClient(create_app(FakeAuthorizer(), FakeDownstream(), FakeRedis()))
+    r = client.get("/bots/status", headers=AUTH)
+    assert r.status_code == 403
+    assert r.json()["detail"] == "Insufficient scope for this endpoint"
 
 
-def test_an_undeclared_route_cannot_be_built():
+def test_an_undeclared_route_cannot_be_built(monkeypatch):
     """The first wall: create_app refuses to return an app whose router has an undeclared route.
     An under-declared gateway does not boot — the hole cannot reach an image."""
-    saved = dict(ROUTE_SCOPES)
-    try:
-        del ROUTE_SCOPES[("POST", "/bots")]
-        with pytest.raises(RuntimeError) as exc:
-            create_app(FakeAuthorizer(), FakeDownstream(), FakeRedis())
-        assert "POST /bots" in str(exc.value)
-    finally:
-        ROUTE_SCOPES.clear()
-        ROUTE_SCOPES.update(saved)
+    _without(monkeypatch, "POST", "/bots")
+    with pytest.raises(RuntimeError) as exc:
+        create_app(FakeAuthorizer(), FakeDownstream(), FakeRedis())
+    assert "POST /bots" in str(exc.value)
+    assert "routes.v1.json" in str(exc.value), "the refusal must name where the declaration goes"
 
 
 def test_matrix_covers_every_declared_route():

--- a/core/identity/routes.v1.json
+++ b/core/identity/routes.v1.json
@@ -1,0 +1,100 @@
+{
+  "contract": "routes.v1",
+  "domain": "identity",
+  "owner": "core/identity",
+  "edge": "gateway",
+  "note": "The person's own account surface: calendar connections, webhook config, model and transcription preferences.",
+  "presence_env": "ADMIN_API_URL",
+  "routes": [
+    {
+      "method": "GET",
+      "path": "/user/calendar",
+      "scopes": [
+        "bot"
+      ]
+    },
+    {
+      "method": "PUT",
+      "path": "/user/calendar",
+      "scopes": [
+        "bot"
+      ]
+    },
+    {
+      "method": "GET",
+      "path": "/user/calendars",
+      "scopes": [
+        "bot"
+      ]
+    },
+    {
+      "method": "POST",
+      "path": "/user/calendars",
+      "scopes": [
+        "bot"
+      ]
+    },
+    {
+      "method": "DELETE",
+      "path": "/user/calendars/{calendar_id}",
+      "scopes": [
+        "bot"
+      ]
+    },
+    {
+      "method": "PATCH",
+      "path": "/user/calendars/{calendar_id}",
+      "scopes": [
+        "bot"
+      ]
+    },
+    {
+      "method": "GET",
+      "path": "/user/models",
+      "scopes": [
+        "bot",
+        "tx"
+      ]
+    },
+    {
+      "method": "PUT",
+      "path": "/user/models",
+      "scopes": [
+        "bot",
+        "tx"
+      ]
+    },
+    {
+      "method": "GET",
+      "path": "/user/transcription",
+      "scopes": [
+        "bot",
+        "tx"
+      ]
+    },
+    {
+      "method": "PUT",
+      "path": "/user/transcription",
+      "scopes": [
+        "bot",
+        "tx"
+      ]
+    },
+    {
+      "method": "GET",
+      "path": "/user/webhook",
+      "scopes": [
+        "bot",
+        "tx"
+      ]
+    },
+    {
+      "method": "PUT",
+      "path": "/user/webhook",
+      "scopes": [
+        "bot",
+        "tx"
+      ]
+    }
+  ]
+}

--- a/core/meetings/routes.v1.json
+++ b/core/meetings/routes.v1.json
@@ -1,0 +1,282 @@
+{
+  "contract": "routes.v1",
+  "domain": "meetings",
+  "owner": "core/meetings",
+  "edge": "gateway",
+  "note": "Bots, meeting records, transcripts, recordings \u2014 and the two calendar SYNC verbs, which run against the feed meeting-api owns even though the connection itself is identity's.",
+  "presence_env": "MEETING_API_URL",
+  "routes": [
+    {
+      "method": "GET",
+      "path": "/bots",
+      "scopes": [
+        "bot"
+      ]
+    },
+    {
+      "method": "POST",
+      "path": "/bots",
+      "scopes": [
+        "bot"
+      ]
+    },
+    {
+      "method": "GET",
+      "path": "/bots/status",
+      "scopes": [
+        "bot"
+      ]
+    },
+    {
+      "method": "DELETE",
+      "path": "/bots/{platform}/{native_meeting_id}",
+      "scopes": [
+        "bot"
+      ]
+    },
+    {
+      "method": "GET",
+      "path": "/bots/{platform}/{native_meeting_id}/chat",
+      "scopes": [
+        "bot"
+      ]
+    },
+    {
+      "method": "PUT",
+      "path": "/bots/{platform}/{native_meeting_id}/config",
+      "scopes": [
+        "bot"
+      ]
+    },
+    {
+      "method": "POST",
+      "path": "/bots/{platform}/{native_meeting_id}/speak",
+      "scopes": [
+        "bot"
+      ]
+    },
+    {
+      "method": "GET",
+      "path": "/meetings",
+      "scopes": [
+        "tx"
+      ]
+    },
+    {
+      "method": "POST",
+      "path": "/meetings",
+      "scopes": [
+        "tx"
+      ]
+    },
+    {
+      "method": "DELETE",
+      "path": "/meetings/{meeting_id}",
+      "scopes": [
+        "tx"
+      ]
+    },
+    {
+      "method": "GET",
+      "path": "/meetings/{meeting_id}",
+      "scopes": [
+        "tx"
+      ]
+    },
+    {
+      "method": "PATCH",
+      "path": "/meetings/{meeting_id}",
+      "scopes": [
+        "tx"
+      ]
+    },
+    {
+      "method": "POST",
+      "path": "/meetings/{meeting_id}/share",
+      "scopes": [
+        "tx"
+      ]
+    },
+    {
+      "method": "POST",
+      "path": "/meetings/{meeting_id}/transcript-import",
+      "scopes": [
+        "tx"
+      ]
+    },
+    {
+      "method": "DELETE",
+      "path": "/meetings/{platform}/{native_meeting_id}",
+      "scopes": [
+        "tx"
+      ]
+    },
+    {
+      "method": "PATCH",
+      "path": "/meetings/{platform}/{native_meeting_id}",
+      "scopes": [
+        "tx"
+      ]
+    },
+    {
+      "method": "POST",
+      "path": "/meetings/{platform}/{native_meeting_id}/annotate",
+      "scopes": [
+        "tx"
+      ]
+    },
+    {
+      "method": "PUT",
+      "path": "/meetings/{platform}/{native_meeting_id}/intent",
+      "scopes": [
+        "tx"
+      ]
+    },
+    {
+      "method": "GET",
+      "path": "/meetings/{platform}/{native_meeting_id}/participants",
+      "scopes": [
+        "tx"
+      ]
+    },
+    {
+      "method": "POST",
+      "path": "/meetings/{platform}/{native_meeting_id}/share",
+      "scopes": [
+        "tx"
+      ]
+    },
+    {
+      "method": "POST",
+      "path": "/meetings/{platform}/{native_meeting_id}/workspace",
+      "scopes": [
+        "tx"
+      ]
+    },
+    {
+      "method": "GET",
+      "path": "/recordings",
+      "scopes": [
+        "bot",
+        "tx"
+      ]
+    },
+    {
+      "method": "DELETE",
+      "path": "/recordings/{recording_id}",
+      "scopes": [
+        "bot"
+      ]
+    },
+    {
+      "method": "GET",
+      "path": "/recordings/{recording_id}",
+      "scopes": [
+        "bot",
+        "tx"
+      ]
+    },
+    {
+      "method": "GET",
+      "path": "/recordings/{recording_id}/master",
+      "scopes": [
+        "bot",
+        "tx"
+      ]
+    },
+    {
+      "method": "GET",
+      "path": "/recordings/{recording_id}/media/{media_file_id}/download",
+      "scopes": [
+        "bot",
+        "tx"
+      ]
+    },
+    {
+      "method": "GET",
+      "path": "/recordings/{recording_id}/media/{media_file_id}/raw",
+      "scopes": [
+        "bot",
+        "tx"
+      ]
+    },
+    {
+      "method": "GET",
+      "path": "/transcripts/by-id/{meeting_id}",
+      "scopes": [
+        "tx"
+      ]
+    },
+    {
+      "method": "POST",
+      "path": "/transcripts/by-id/{meeting_id}/share",
+      "scopes": [
+        "tx"
+      ]
+    },
+    {
+      "method": "GET",
+      "path": "/transcripts/search",
+      "scopes": [
+        "tx"
+      ]
+    },
+    {
+      "method": "POST",
+      "path": "/transcripts/share/accept",
+      "scopes": [
+        "tx"
+      ]
+    },
+    {
+      "method": "GET",
+      "path": "/transcripts/{platform}/{native_meeting_id}",
+      "scopes": [
+        "tx"
+      ]
+    },
+    {
+      "method": "POST",
+      "path": "/transcripts/{platform}/{native_meeting_id}/share",
+      "scopes": [
+        "tx"
+      ]
+    },
+    {
+      "method": "GET",
+      "path": "/user/calendar/sync",
+      "scopes": [
+        "bot"
+      ]
+    },
+    {
+      "method": "POST",
+      "path": "/user/calendar/sync",
+      "scopes": [
+        "bot"
+      ]
+    },
+    {
+      "method": "GET",
+      "path": "/user/calendars/{calendar_id}/sync",
+      "scopes": [
+        "bot"
+      ]
+    },
+    {
+      "method": "POST",
+      "path": "/user/calendars/{calendar_id}/sync",
+      "scopes": [
+        "bot"
+      ]
+    },
+    {
+      "method": "GET",
+      "path": "/user/webhook/deliveries",
+      "scopes": [
+        "bot",
+        "tx"
+      ]
+    }
+  ]
+}

--- a/core/meetings/services/mcp/routes.v1.json
+++ b/core/meetings/services/mcp/routes.v1.json
@@ -1,0 +1,106 @@
+{
+  "contract": "routes.v1",
+  "domain": "mcp",
+  "owner": "core/meetings/services/mcp",
+  "edge": "gateway",
+  "note": "The MCP front door. Its tools call BACK through this gateway with the caller's own key, so /bots is gated on that second hop too; this is the first hop.",
+  "presence_env": "MCP_URL",
+  "routes": [
+    {
+      "method": "DELETE",
+      "path": "/mcp",
+      "scopes": [
+        "bot",
+        "tx"
+      ]
+    },
+    {
+      "method": "GET",
+      "path": "/mcp",
+      "scopes": [
+        "bot",
+        "tx"
+      ]
+    },
+    {
+      "method": "OPTIONS",
+      "path": "/mcp",
+      "scopes": [
+        "bot",
+        "tx"
+      ]
+    },
+    {
+      "method": "PATCH",
+      "path": "/mcp",
+      "scopes": [
+        "bot",
+        "tx"
+      ]
+    },
+    {
+      "method": "POST",
+      "path": "/mcp",
+      "scopes": [
+        "bot",
+        "tx"
+      ]
+    },
+    {
+      "method": "PUT",
+      "path": "/mcp",
+      "scopes": [
+        "bot",
+        "tx"
+      ]
+    },
+    {
+      "method": "DELETE",
+      "path": "/mcp/{path:path}",
+      "scopes": [
+        "bot",
+        "tx"
+      ]
+    },
+    {
+      "method": "GET",
+      "path": "/mcp/{path:path}",
+      "scopes": [
+        "bot",
+        "tx"
+      ]
+    },
+    {
+      "method": "OPTIONS",
+      "path": "/mcp/{path:path}",
+      "scopes": [
+        "bot",
+        "tx"
+      ]
+    },
+    {
+      "method": "PATCH",
+      "path": "/mcp/{path:path}",
+      "scopes": [
+        "bot",
+        "tx"
+      ]
+    },
+    {
+      "method": "POST",
+      "path": "/mcp/{path:path}",
+      "scopes": [
+        "bot",
+        "tx"
+      ]
+    },
+    {
+      "method": "PUT",
+      "path": "/mcp/{path:path}",
+      "scopes": [
+        "bot",
+        "tx"
+      ]
+    }
+  ]
+}

--- a/deploy/compose/docker-compose.yml
+++ b/deploy/compose/docker-compose.yml
@@ -479,6 +479,12 @@ services:
       # NOT a depends_on: mcp itself depends on the gateway (GATEWAY_URL), and compose refuses a
       # dependency cycle. The forward simply 502s until mcp is up, like any other upstream.
       - MCP_URL=http://mcp:8010
+      # THE AGENT DOMAIN'S PRESENCE SIGNAL (PRD 40.6 / 40.7). This full profile runs agents, so it
+      # names the door and the edge fronts `/agent/*`. The `no-agents` profile leaves it EMPTY —
+      # the gateway then registers no /agent route and assembles no agent rows into its scope
+      # table, so a request there is 404 rather than a 401 about a route this stack does not have.
+      # It was a CODE default before, which made a deployment unable to say it has no agents.
+      - AGENT_API_URL=${AGENT_API_URL:-http://agent-api:8100}
       - REDIS_URL=redis://redis:6379/0
       - INTERNAL_API_SECRET=${INTERNAL_API_SECRET}
       - LOG_LEVEL=${LOG_LEVEL:-info}

--- a/deploy/compose/docker-compose.yml
+++ b/deploy/compose/docker-compose.yml
@@ -466,8 +466,11 @@ services:
 
   gateway:
     build:
-      context: ../../core/gateway/services/gateway
-      dockerfile: Dockerfile
+      # THE REPO ROOT, like meeting-api and agent-api. The edge reads each domain's
+      # routes.v1.json BY PATH at import (routes_manifest.py), so the image must carry the
+      # manifests of the domains it fronts; a context scoped to the service cannot reach them.
+      context: ../..
+      dockerfile: core/gateway/services/gateway/Dockerfile
     image: vexaai/v012-gateway:${IMAGE_TAG:-dev}
     ports:
       - "127.0.0.1:${API_GATEWAY_HOST_PORT:-18056}:8000"

--- a/release/candidate-image-map.mjs
+++ b/release/candidate-image-map.mjs
@@ -56,7 +56,14 @@ export const RUNTIME_INPUTS_BY_IMAGE = {
     "core/runtime/contracts/schedule.v1/schedule.schema.json",
   ],
   "vexaai/v012-gateway": [
+    ".dockerignore",
     "core/gateway/services/gateway",
+    // the routes.v1 manifests the edge assembles its table from: a domain changing its own
+    // route list must rebuild the gateway image, or the image ships a table the code disagrees with.
+    "core/meetings/routes.v1.json",
+    "core/meetings/services/mcp/routes.v1.json",
+    "core/identity/routes.v1.json",
+    "core/agent/routes.v1.json",
   ],
   "vexaai/v012-mcp": [
     "core/meetings/services/mcp",
@@ -122,7 +129,7 @@ export const BUILD_MATRIX_BY_IMAGE = {
   "vexaai/v012-gateway": {
     name: "gateway",
     repository: "v012-gateway",
-    context: "core/gateway/services/gateway",
+    context: ".",
     dockerfile: "core/gateway/services/gateway/Dockerfile",
   },
   "vexaai/v012-mcp": {

--- a/release/candidate-image-map.test.mjs
+++ b/release/candidate-image-map.test.mjs
@@ -208,6 +208,9 @@ test("a root .dockerignore-only change invalidates every affected candidate", (t
     "vexaai/v012-agent-worker: .dockerignore",
     "vexaai/v012-agent-api: .dockerignore",
     "vexaai/v012-meeting-api: .dockerignore",
+    // the gateway joined the root-context builds when the edge stopped owning its route table:
+    // it now COPYs each domain's routes.v1.json, which a service-scoped context cannot reach.
+    "vexaai/v012-gateway: .dockerignore",
     "vexaai/vexa-bot: .dockerignore",
   ]);
 });


### PR DESCRIPTION
**Delivers issue:** #1467

## Contribution rights
<!-- Select exactly ONE. This is a legal certification: an agent may explain the choices but
     must not select one for you. See CONTRIBUTOR_RIGHTS.md. -->

- [ ] **Independent:** I created this contribution, or otherwise have the right to submit it
  under Apache-2.0, and it is not owned or controlled by an employer, client, or other entity.
  <!-- rights:independent -->
- [ ] **Employer/client authorization required:** an employer, client, or other entity owns or
  may control this contribution. I am requesting Vexa's private corporate-authorization process.
  <!-- rights:corporate -->
- [ ] **Unsure:** I need a private rights review before merge.
  <!-- rights:uncertain -->

Every commit must also carry the contributor's own DCO `Signed-off-by` line. Selecting the
independent path means no individual CLA is required. Corporate and unsure paths do not stop
technical review, but they do block merge until resolved.

## Observation bundle (the record of your harnessed loop)

- **C1 — the manifests and the assembler.**
  **ran:** assembled the five `routes.v1.json` directly, both profiles, and pushed a duplicate declaration through `assemble()`:
  ```
  $ PYTHONPATH=src uv run python .evidence/assemble.py
  full profile   : 69 scoped + 2 unscoped = 71
  module table   : 69 scoped + 2 unscoped
  per-domain rows: {'agent': 7, 'gateway': 2, 'identity': 12, 'mcp': 12, 'meetings': 38}
  no-agents      : 62 scoped + 2 unscoped
  rows gone      : 7
  duplicate refused: GET /bots/status is declared by both 'meetings' and 'agent' —
                     one route, one owner; the edge composes and cannot arbitrate
  ```
  **saw:** the counts land where the mapping said they would — 38 + 12 + 12 + 7 + 2 = 71 — and the duplicate refusal names *both* domains, so an operator reading it has two files to open rather than a guess.
  **concluded:** the manifests are complete and the assembler's refusals fire on the composition, not just in a unit fixture. Also worth recording: the earlier reading of "60 rows" was counting source lines, not rows — the `api_route` families expand.

- **C2 — the edge composes, and absence is symmetric.**
  **ran:** `uv run pytest tests/test_route_manifests.py -v` in `core/gateway/services/gateway` on head `b81ee8b`, then the negative control: deleted one declared row from `core/meetings/routes.v1.json` and re-ran the table tests.
  **saw:** 15 passed. With the row deleted, three tests went RED with the build refusing rather than the table drifting:
  ```
  RuntimeError: gateway routes with no scope declaration: DELETE /bots/{platform}/{native_meeting_id}
    — declare each in the OWNING DOMAIN's routes.v1.json … this build fronts
    ['agent', 'gateway', 'identity', 'mcp', 'meetings'].
  src/gateway/app.py:949
  ```
  **concluded:** deny-by-default survived the move intact — the refusal now points at the owning domain's file, and it names which domains this build fronts, which is the one fact the old message could not carry. `test_the_assembled_table_matches_the_app_exactly` is the real anchor here: it ties the manifests to the routes themselves rather than to a second copy of the table living in a test.

- **C3 — presence is configuration, never a probe.**
  **ran:** `node scripts/gates.mjs config-contract` on head; and on the **base** worktree (`a5ba8e9`) a throwaway test asserting the value this PR delivers — `AGENT_API_URL` unset, `POST /agent/chat` → expect 404.
  **saw:** gate green. The base control failed exactly as it should:
  ```
  BASE: POST /agent/chat with no agent domain -> 200
  AssertionError: expected 404, got 200
  ```
  **concluded:** this is the defect stated as a number. On base, a stack that named no agent-api still served `/agent/chat` — 200, proxied at a defaulted host — so "we do not do agents" was unsayable. On head the same request is 404. (The throwaway test was deleted and the base worktree removed; the base tree is untouched.)

- **C4 — the image must carry the manifests it reads.** *(Not planned. CI found it, which is the finding.)*
  **ran:** the PR's own `value-fsm` job — the value scenarios on the PR's real compose stack.
  **saw:** the gateway container came up **unhealthy** and the stack refused to start:
  ```
  gateway-1 | gateway.routes_manifest.ManifestError: cannot find the repository root from
              /app/src/gateway/routes_manifest.py — the gateway image must carry the
              routes.v1 manifests of the domains it fronts
  ```
  **concluded:** the refusal is right and the message said exactly what was wrong — nothing had put the files there. `routes_manifest.py` reads each domain's manifest **by path** at import; every unit run, every gate and the Lite image see a checkout (Lite copies the whole `core/` tree to `/app/core`, so `_repo_root()` resolves there — by accident, which is why `lite-smoke` was green while compose was not). The compose gateway image built from `core/gateway/services/gateway`, a context that cannot reach another domain's file.
  **then ran:** the fix (`f8575c2b7`) — repo-root build context and an explicit COPY of the five manifests at their repo-relative paths, the pattern meeting-api, agent-api and agent-worker already use for the files *they* load by path. Built the image on the build host and booted `build_production_app()` inside the container, twice:
  ```
  AGENT_API_URL=http://agent-api:8100  ->  71 registered (method, template) pairs;
                                           agent rows: the seven /agent/* templates
  AGENT_API_URL=                       ->  64 pairs; agent rows: []
  ```
  **concluded:** the value is now witnessed **in a real image**, not only in a test process — 71 → 64, exactly the seven rows, decided by configuration. `value-fsm` went green on the fixed tree. A note for whoever reads this next: **no gate checks that an image carries the files its code reads by path.** meeting-api has the same exposure and survives on someone having remembered. That is a finding, not something this PR fixes.

- **C5 — the candidate map's own assertion.** **ran:** `node --test scripts/*.test.mjs release/*.test.mjs`, the `static` job's "gate script tests" step. **saw:** `not ok 9 — a root .dockerignore-only change invalidates every affected candidate`; the actual set had gained `vexaai/v012-gateway`. **concluded:** the assertion was right to notice — the gateway joined the root-context builds, so it belongs in that set, and the expected list is what needed updating (`791caa4e9`), not the map. Worth recording: this step is **neither one of the fourteen `scripts/gates.mjs` gates nor in the pre-push hook**, so a local green does not cover it.

## Acceptance floor

Base `b34bb8fbdd4966d458d3e7d7eb974927e7a67dd4` (`minutes-mcp-viewer`) → head `791caa4e9e356e9c814fedb08b6f1353ae3f70a1`. Three commits: `4699e7f49` the mechanism, `f8575c2b7` the image fix C4 describes, `791caa4e9` the candidate-map assertion C5 describes. **Rebased twice, both times clean — no conflicts, and no file was touched on both sides.** The base moved under this branch mid-run (`a5ba8e9` → `b34bb8fb`: #1470, #1476, #1479, #1473), so every number below was re-taken on the current base.

| Row | Evidence |
|---|---|
| **A1** — full profile is the identical table | GREEN at head: `69 scoped + 2 unscoped`, per-domain `meetings 38 · identity 12 · mcp 12 · agent 7 · gateway 2` (run above). `test_the_assembled_table_matches_the_app_exactly` PASSED — every declared row is a registered `(method, template)` and every registered route is declared, so there is no dead row and nothing undeclared. **RED control:** deleting `DELETE /bots/{platform}/{native_meeting_id}` from `core/meetings/routes.v1.json` turned `test_the_assembled_table_matches_the_app_exactly`, `test_the_full_profile_is_exactly_what_shipped` and `test_scope_matrix.py::test_every_registered_route_declares_its_scopes` RED, with `app.py:949` refusing the build. File restored; `git status` clean before push. |
| **A2** — agent absent → exactly the seven rows gone | GREEN at head: no-agents assembly is `62 scoped + 2 unscoped`; the set difference against the full profile is exactly `POST /agent/chat`, `GET /agent/meeting/stream`, `{GET,POST,PUT,PATCH,DELETE} /agent/{path:path}` — seven rows, nothing else. Absent from the **app** too: `test_a_request_to_an_absent_domain_is_404_not_401[post-/agent/chat]`, `[get-/agent/meeting/stream]`, `[get-/agent/sessions]` all PASSED, and `test_the_same_request_is_served_when_the_agent_domain_is_there` PASSED — so the 404 is absence, not a blanket refusal. **RED control at base `a5ba8e9`:** same request, `AGENT_API_URL` unset → **200**. **Exceeded at head:** the same 71 → 64 split witnessed inside the built container image, not only in a test process (C4). |
| **A3** — a duplicate declaration is refused at boot, naming it | GREEN at head: `ManifestError: GET /bots/status is declared by both 'meetings' and 'agent' — one route, one owner; the edge composes and cannot arbitrate`. `test_two_domains_claiming_one_route_refuse_to_boot` PASSED, with the four siblings: `test_a_scope_outside_the_vocabulary_refuses_to_boot`, `test_a_row_that_is_not_a_route_refuses_to_boot[row0,row1]`, `test_a_manifest_of_the_wrong_contract_refuses_to_boot`, `test_a_deployed_domain_with_no_manifest_refuses_to_boot`. |
| **A-** — no regression | All re-taken on the current base, same machine and toolchain. **gateway** `core/gateway/services/gateway`: **357 passed, 1 xfailed** at head against **342 passed, 1 xfailed** at base — the +15 is exactly `tests/test_route_manifests.py`; no test was removed or weakened. **agent** `core/agent`: **1588 passed** — the diff adds one JSON manifest under `core/agent/` and touches no Python there. **The fourteen static gates, green:** `readme · docs-version · isolation · exports · graph · schema · contract-version · config-contract · db-schema · db-budget · dataflow · licenses · image-licenses · runtime-parity`. **`node --test scripts/*.test.mjs release/*.test.mjs`: 141 passed, 0 failed** (see C5). `gate:node`: 18 packages green. The pre-push hook's `execution-env`, `test-isolation`, `contract-conformance` green on every push. On the earlier base `a5ba8e9`, `gate:python` was red on the CI-only timing flake tracked as #1434, which also aborted the lane before the gateway package was reached; #1473 has since landed the fix and this branch now sits on top of it. |

Two existing tests moved with the mechanism, neither weakened: `test_an_undeclared_route_{is_denied_at_request_time,cannot_be_built}` used to `del ROUTE_SCOPES[...]` because the table was a literal the app read live. They now remove the row at its **source**, so the hole is a domain's missing declaration rather than an edit to the edge's own dict — same invariant, one layer out.

## Docs diff (D6c)

**No docs page changes in this PR, and here is the argument.**

The public API surface is byte-identical: the same 71 routes with the same scopes, proven by A1 against the routes themselves rather than against a remembered table. `docs/docs/authentication.mdx` defines the `bot`/`tx`/`browser` vocabulary and stays correct unchanged — the assembler now *enforces* that vocabulary (an unknown scope refuses to boot) rather than describing it, which is a strengthening the page already claims.

`AGENT_API_URL` appears on no docs page today, before or after, so its move from `defaulted` to `capability` is invisible to a reader. It is declared where it is read: `core/gateway/services/gateway/src/gateway/config.v1.json`, under `gate:config-contract`.

**What the issue names and this PR does not deliver:** `docs/docs/deployment.mdx` owes a reference-altitude paragraph saying that leaving `AGENT_API_URL` unset yields a gateway that serves no `/agent/*` and answers 404 there. No page describes deployment profiles at all today, so the `no-agents` product has nowhere it is told. The issue puts the scoping question to the maintainer — this paragraph here, or with the profile's own delivery — and I have not decided it unilaterally. If the answer is "here", say so and it lands in this PR before merge.

## Security checks (required on the diff)

- **Dependency scan / delta:** none to scan — `git diff base..head -- '*/pyproject.toml' '*/uv.lock' package.json pnpm-lock.yaml` is **empty**. No dependency added, removed, or re-pinned. The new module `routes_manifest.py` imports stdlib only: `json`, `pathlib`, `dataclasses`, `typing`.
- **Licence scan:** `gate:licenses` and `gate:image-licenses` green at head (in the 14 above).
- **Secrets scan:** grepped the full diff for credential-shaped content (`secret|token|password|api[_-]?key|BEGIN … PRIVATE KEY|AKIA|ghp_|sk-`) — 6 hits, all of them env-var *names* or test constants already in the tree (`INTERNAL_API_SECRET=${INTERNAL_API_SECRET}` in compose, `x-api-key: VALID_KEY` in tests, the word "token" in a comment). No literal credential is introduced. The repo runs no gitleaks/trufflehog workflow, so this is a scan of the diff, not a repo baseline.
- **SAST:** no SAST workflow exists in `.github/workflows/`; nothing run, and I am not claiming one.
- **The image fix widens a build context, so it gets its own line.** `f8575c2b7` moves the gateway build from `core/gateway/services/gateway` to the repository root. What is *sent* to the daemon is governed by the root `.dockerignore` — the same file three existing root-context builds already rely on (it excludes `.git/`, `.env`, `.env.*`, venvs, `node_modules`, build trees, `clients/`, `sdks/`, `docs/`). What ends up *in the image* is unchanged except five JSON route manifests: the Dockerfile COPYs the service's own `pyproject.toml`, `uv.lock`, `src/`, and those five files by explicit path — no `COPY . .`, no wildcard. GitGuardian passed on the diff.
- **Security-relevant reasoning on the diff itself, since this touches authorization:** the change is to *where the scope table is written down*, never to what it says. A1 proves the assembled table equals the shipped one row-for-row. Deny-by-default is unchanged and still enforced at build time (`app.py:949`), and the assembler adds two refusals that close holes rather than open them — an unknown scope name (previously a typo that would read as an empty set, i.e. a silent deny-all that looks like policy) and a duplicate route (previously impossible in a single literal, newly possible across files, hence the check). The one *behaviour* change is that an undeployed domain's routes are absent rather than present-and-unreachable, which narrows the surface.

## Validation request

**Who:** any competent non-author with a machine that can run compose. No meeting and no second human — the observation is a route table and an HTTP status.

**What they'll watch:** bring the compose stack up twice from head `791caa4e9`, once with the gateway's `AGENT_API_URL` set and once with it empty. With it set, `POST /agent/chat` behaves as it does today. With it empty, the same request answers **404** (not 401, not 502, not a hang) and the gateway's start-up names a profile without the agent domain. Across both, confirm the rest of the API is untouched — a bot starts, a transcript reads. They also sign the docs story, including whether `docs/docs/deployment.mdx` should carry the `no-agents` paragraph in this PR.

**D12b — deployments, honestly:**
- **Ran — the compose gateway image:** built from the repo-root context and booted `build_production_app()` inside the container with `AGENT_API_URL` set and unset → 71 and 64 registered pairs, agent rows present then empty. Fresh worktree off `origin`, no env deltas beyond `INTERNAL_API_SECRET` (a throwaway value the boot preflight requires).
- **Ran — full compose stack, CI:** `value-fsm` brings the PR's own stack up. Before the image fix it was **red** with the gateway unhealthy — that is C4. On the fixed tree it went **green in 8m22s**. It re-runs on every push; read its live result on this PR's checks rather than from this paragraph.
- **Ran — Lite, CI:** `lite-smoke` built `deploy/lite/Dockerfile.lite` from the PR tree and probed the front doors — `✓ gateway (:8056)`, green. Lite was green even before the image fix, because it copies the whole `core/` tree; the fix does not touch it.
- **Not run, and nobody should read this table as if it had been:** the **`no-agents` compose profile end-to-end** — a live `POST /agent/chat` answering 404 on a running stack. That observation *is* the value, and only the app-build and image-build altitudes are proven here. Also **k8s-helm**.

A human/instrument divergence here blocks merge and is a finding.

## Authorship
Sole author: the human submitting this. No agent co-author trailers (D13).
Tooling disclosure (optional, welcome, never an attribution): rebase onto `minutes-mcp-viewer`, the suite and gate runs, and this bundle were produced with Claude Code.

<!-- vexa-agent -->

