### PR TITLE
a phase that runs over budget always leaves no child process behind, on every supported interpreter

### DIFF
--- a/core/agent/llm/__init__.py
+++ b/core/agent/llm/__init__.py
@@ -16,6 +16,7 @@ from llm.errors import (
 from llm.ports import (
     HarnessExec,
     HarnessPort,
+    close_event_stream,
     run_harness_turn,
 )
 from llm.registry import (
@@ -34,6 +35,7 @@ __all__ = [
     "provider_host",
     "HarnessExec",
     "HarnessPort",
+    "close_event_stream",
     "run_harness_turn",
     "HARNESS_RUNNERS",
     "harness_from_env",

--- a/core/agent/llm/claude_code.py
+++ b/core/agent/llm/claude_code.py
@@ -20,7 +20,7 @@ from pathlib import Path
 from typing import Iterable, Iterator, Optional
 
 from llm.errors import looks_like_auth_failure, preflight_provider_guard
-from llm.ports import HarnessExec, harness_subprocess_env
+from llm.ports import HarnessExec, close_event_stream, harness_subprocess_env
 
 
 # Tools whose SUCCESS means a document now exists that the person should be looking at. The
@@ -165,112 +165,120 @@ def parse_stream_json(lines: Iterable[str]) -> Iterator[dict]:
     pending_terms: set[str] = set()
     # callIds of in-flight `bot_send` calls — same per-stream, popped-on-result discipline.
     pending_bots: set[str] = set()
-    for raw in lines:
-        raw = raw.strip()
-        if not raw:
-            continue
-        try:
-            obj = json.loads(raw)
-        except json.JSONDecodeError:
-            continue
-        t = obj.get("type")
-        if t == "stream_event":
-            event = obj.get("event", {}) or {}
-            if event.get("type") == "content_block_delta":
-                delta = event.get("delta", {}) or {}
-                if delta.get("type") == "text_delta" and delta.get("text"):
-                    streamed_partial = True
-                    yield {"type": "message-delta", "text": delta["text"]}
-        elif t == "assistant":
-            for block in obj.get("message", {}).get("content", []) or []:
-                bt = block.get("type")
-                if bt == "text" and block.get("text"):
-                    if not streamed_partial:  # no partials → emit the whole block (back-compat)
-                        yield {"type": "message-delta", "text": block["text"]}
-                elif bt == "tool_use":
-                    tool_name = block.get("name", "")
-                    call_id = block.get("id", "")
-                    # THE PANEL FOLLOWS THE WRITE, and the record is what makes it follow (decision
-                    # 18: layout is a function of the chat's state, never of the client's guess).
-                    # The founder watched the agent create a shared workspace and write its README
-                    # while the panel sat on `_global/README.md` — the document it had just made was
-                    # the one thing not on screen. The argument names the file; remember it now,
-                    # because the tool RESULT carries only a summary string and by then the path is
-                    # gone.
-                    if tool_name in _WRITER_TOOLS:
-                        target = _written_artifact(tool_name, block.get("input", {}) or {})
-                        if target:
-                            pending_writes[call_id] = target
-                    elif tool_name in _TERMS_TOOLS:
-                        pending_terms.add(call_id)
-                    elif tool_name in _BOT_TOOLS:
-                        pending_bots.add(call_id)
-                    yield {
-                        "type": "tool-call",
-                        "tool": tool_name,
-                        "args": block.get("input", {}),
-                        "callId": call_id,
-                    }
-        elif t == "user":
-            for block in obj.get("message", {}).get("content", []) or []:
-                if block.get("type") == "tool_result":
-                    call_id = block.get("tool_use_id", "")
-                    ok = not block.get("is_error", False)
-                    yield {
-                        "type": "tool-result",
-                        "callId": call_id,
-                        "ok": ok,
-                        "summary": _short(block.get("content")),
-                    }
-                    # ONLY ON SUCCESS. A failed write must not open a tab: the file is not there,
-                    # and a tab on a path that does not exist is exactly the "page that can never
-                    # load" this stream is careful about elsewhere. `pop` either way, so a failed
-                    # call cannot leave an entry that a later, unrelated result matches.
-                    # THE CHIPS (decision 35). Same success-only rule as the artifact below:
-                    # a failed read must not paint a transcript.
-                    was_terms = call_id in pending_terms
-                    pending_terms.discard(call_id)
-                    if was_terms and ok:
-                        ev = _published_terms(block.get("content"))
-                        if ev:
-                            yield ev
-                    # THE BOT IS IN THE ROOM — open its transcript. Success-only, like the two
-                    # above: a send that failed must not front a transcript that will stay empty.
-                    was_bot = call_id in pending_bots
-                    pending_bots.discard(call_id)
-                    if was_bot and ok:
-                        ev = _bot_artifact(block.get("content"))
-                        if ev:
-                            yield ev
-                    target = pending_writes.pop(call_id, None)
-                    if target and ok:
-                        workspace, path = target
+    try:
+        for raw in lines:
+            raw = raw.strip()
+            if not raw:
+                continue
+            try:
+                obj = json.loads(raw)
+            except json.JSONDecodeError:
+                continue
+            t = obj.get("type")
+            if t == "stream_event":
+                event = obj.get("event", {}) or {}
+                if event.get("type") == "content_block_delta":
+                    delta = event.get("delta", {}) or {}
+                    if delta.get("type") == "text_delta" and delta.get("text"):
+                        streamed_partial = True
+                        yield {"type": "message-delta", "text": delta["text"]}
+            elif t == "assistant":
+                for block in obj.get("message", {}).get("content", []) or []:
+                    bt = block.get("type")
+                    if bt == "text" and block.get("text"):
+                        if not streamed_partial:  # no partials → emit the whole block (back-compat)
+                            yield {"type": "message-delta", "text": block["text"]}
+                    elif bt == "tool_use":
+                        tool_name = block.get("name", "")
+                        call_id = block.get("id", "")
+                        # THE PANEL FOLLOWS THE WRITE, and the record is what makes it follow (decision
+                        # 18: layout is a function of the chat's state, never of the client's guess).
+                        # The founder watched the agent create a shared workspace and write its README
+                        # while the panel sat on `_global/README.md` — the document it had just made was
+                        # the one thing not on screen. The argument names the file; remember it now,
+                        # because the tool RESULT carries only a summary string and by then the path is
+                        # gone.
+                        if tool_name in _WRITER_TOOLS:
+                            target = _written_artifact(tool_name, block.get("input", {}) or {})
+                            if target:
+                                pending_writes[call_id] = target
+                        elif tool_name in _TERMS_TOOLS:
+                            pending_terms.add(call_id)
+                        elif tool_name in _BOT_TOOLS:
+                            pending_bots.add(call_id)
                         yield {
-                            "type": "artifact",
-                            "workspace": workspace,
-                            "path": path,
-                            "focus": True,
+                            "type": "tool-call",
+                            "tool": tool_name,
+                            "args": block.get("input", {}),
+                            "callId": call_id,
                         }
-        elif t == "result":
-            reply = obj.get("result", "")
-            done = {
-                "type": "done",
-                "reply": reply,
-                "sessionId": obj.get("session_id"),
-                "ok": obj.get("is_error") is not True and obj.get("subtype") != "error",
-            }
-            if not done["ok"] and looks_like_auth_failure(reply):
-                # The CLI's own auth text ("Not logged in · Please run /login") is an internal of
-                # THIS adapter — /login doesn't exist for an API consumer. Rewrite to the
-                # platform-actionable message; the raw text rides along in `detail` (additive).
-                done["detail"] = _short(reply, 200)
-                done["reply"] = (
-                    "Model credentials are missing or expired for this deployment. "
-                    "Set or refresh one of HOST_CLAUDE_CREDENTIALS, ANTHROPIC_API_KEY, "
-                    "ANTHROPIC_AUTH_TOKEN or CLAUDE_CODE_OAUTH_TOKEN, "
-                    "or configure a model under Settings → Models."
-                )
-            yield done
+            elif t == "user":
+                for block in obj.get("message", {}).get("content", []) or []:
+                    if block.get("type") == "tool_result":
+                        call_id = block.get("tool_use_id", "")
+                        ok = not block.get("is_error", False)
+                        yield {
+                            "type": "tool-result",
+                            "callId": call_id,
+                            "ok": ok,
+                            "summary": _short(block.get("content")),
+                        }
+                        # ONLY ON SUCCESS. A failed write must not open a tab: the file is not there,
+                        # and a tab on a path that does not exist is exactly the "page that can never
+                        # load" this stream is careful about elsewhere. `pop` either way, so a failed
+                        # call cannot leave an entry that a later, unrelated result matches.
+                        # THE CHIPS (decision 35). Same success-only rule as the artifact below:
+                        # a failed read must not paint a transcript.
+                        was_terms = call_id in pending_terms
+                        pending_terms.discard(call_id)
+                        if was_terms and ok:
+                            ev = _published_terms(block.get("content"))
+                            if ev:
+                                yield ev
+                        # THE BOT IS IN THE ROOM — open its transcript. Success-only, like the two
+                        # above: a send that failed must not front a transcript that will stay empty.
+                        was_bot = call_id in pending_bots
+                        pending_bots.discard(call_id)
+                        if was_bot and ok:
+                            ev = _bot_artifact(block.get("content"))
+                            if ev:
+                                yield ev
+                        target = pending_writes.pop(call_id, None)
+                        if target and ok:
+                            workspace, path = target
+                            yield {
+                                "type": "artifact",
+                                "workspace": workspace,
+                                "path": path,
+                                "focus": True,
+                            }
+            elif t == "result":
+                reply = obj.get("result", "")
+                done = {
+                    "type": "done",
+                    "reply": reply,
+                    "sessionId": obj.get("session_id"),
+                    "ok": obj.get("is_error") is not True and obj.get("subtype") != "error",
+                }
+                if not done["ok"] and looks_like_auth_failure(reply):
+                    # The CLI's own auth text ("Not logged in · Please run /login") is an internal of
+                    # THIS adapter — /login doesn't exist for an API consumer. Rewrite to the
+                    # platform-actionable message; the raw text rides along in `detail` (additive).
+                    done["detail"] = _short(reply, 200)
+                    done["reply"] = (
+                        "Model credentials are missing or expired for this deployment. "
+                        "Set or refresh one of HOST_CLAUDE_CREDENTIALS, ANTHROPIC_API_KEY, "
+                        "ANTHROPIC_AUTH_TOKEN or CLAUDE_CODE_OAUTH_TOKEN, "
+                        "or configure a model under Settings → Models."
+                    )
+                yield done
+    finally:
+        # THE KILL HAPPENS HERE, on every interpreter. `lines` is `_exec_subprocess`'s generator and
+        # its `finally` is what reaps the CLI child; a `for` loop hands that last hop to refcount
+        # finalization, which on CPython 3.12.3 did not run it at all (Vexa-ai/vexa#1434) — the
+        # phase's budget then stopped READING the process without stopping it. Closing explicitly is
+        # what makes the budget's stop a kill rather than a hope.
+        close_event_stream(lines)
 
 
 def build_argv(

--- a/core/agent/llm/ports.py
+++ b/core/agent/llm/ports.py
@@ -345,6 +345,34 @@ def _commit_mount(work: Path, *, message: str, author: Optional[tuple[str, str]]
 
 
 
+def close_event_stream(events: object) -> None:
+    """Close a harness event stream we have stopped reading — NOW, at the boundary.
+
+    ⚠ THE HOP THAT ONLY LOOKS LIKE IT CLOSES ITSELF. A generator that wraps another one with a
+    plain ``for ev in inner:`` releases ``inner`` when its OWN frame is torn down, and that teardown
+    is a CPython implementation detail rather than a language guarantee. Measured on
+    Vexa-ai/vexa#1434: on CPython 3.12.3, closing the outer generator left the inner one ALIVE
+    (``gi_frame`` not ``None``, one referrer — itself a generator), so
+    ``llm.claude_code._exec_subprocess``'s ``finally`` never ran and the CLI child was never killed.
+    The write-back budget stopped reading the process and bounded nothing; the worker stayed exactly
+    as busy as before. The identical tree passed in 0.67 s on 3.12.13. Both interpreters satisfy
+    ``requires-python = ">=3.11"``, so this is not a supported-versus-unsupported line — it is a
+    guarantee the chain never had, on any interpreter, and got right by luck on most.
+
+    So EVERY hop of the harness event chain closes what it wraps EXPLICITLY (P22 — guarantee
+    teardown at the boundary, never delegate it to something that may not run). ``yield from``
+    already does this; a ``for`` loop does not, and this call is the whole of the difference.
+
+    A plain iterable with no ``close`` (a list, a test's fake) is a no-op, and closing an exhausted
+    or already-closed generator is one too — so it belongs in a ``finally``, on the normal path as
+    much as the early-exit one.
+    """
+    close = getattr(events, "close", None)
+    if close is None:
+        return
+    close()
+
+
 def run_harness_turn(
     work: Path | str,
     prompt: str,
@@ -402,11 +430,18 @@ def run_harness_turn(
         for _mount in mounts:
             policy_baselines[str(_mount.resolve())] = _policy_head_sha(_mount)
     done: Optional[dict] = None
-    for ev in harness.run_turn(work, prompt, allowed_tools=allowed_tools, session=session,
-                               model=model, mcp_config=mcp_config):
-        if ev.get("type") == "done":
-            done = ev
-        yield ev
+    # Held in a NAME, not consumed inline, so the `finally` below has something to close. A caller
+    # may stop reading this turn mid-stream — the write-back phase's budget does exactly that — and
+    # the harness generator underneath owns the CLI subprocess. See `close_event_stream`.
+    stream = harness.run_turn(work, prompt, allowed_tools=allowed_tools, session=session,
+                              model=model, mcp_config=mcp_config)
+    try:
+        for ev in stream:
+            if ev.get("type") == "done":
+                done = ev
+            yield ev
+    finally:
+        close_event_stream(stream)
 
     if not commit:
         return

--- a/core/agent/tests/test_entity_writeback_trim.py
+++ b/core/agent/tests/test_entity_writeback_trim.py
@@ -276,33 +276,80 @@ def test_a_phase_over_budget_leaves_no_child_process(tmp_path, monkeypatch):
     assert len(seen) == 1
     proc = seen[0]
 
-    # WAIT FOR THE REAP — bounded, and not a sleep.
+    # THE KILL IS SYNCHRONOUS, and this assertion is taken on the next bytecode on purpose.
     #
-    # The property is that the budget kills the CLI, and it is delivered by a cascade: `bounded`
-    # closes its iterator, GeneratorExit unwinds `parse_stream_json`, THAT frame's teardown drops
-    # the last reference to the `_exec_subprocess` generator, and only then does its `finally`
-    # reap. The last hop is finalization, not a call — so the guarantee the code offers is PROMPT,
-    # never INSTANTANEOUS, and an assertion taken on the next bytecode was reading a coin flip.
-    # It came up heads on every developer machine and tails on CI: red on three consecutive PRs
-    # into this line (#1426, #1428, #1431), and not reproducible in 40 single-CPU-pinned runs or a
-    # full-suite run on 3.12 and 3.14 (Vexa-ai/vexa#1434).
+    # Every hop of the cascade now closes what it wraps EXPLICITLY: `bounded` closes its iterator,
+    # `parse_stream_json` closes `_exec_subprocess`'s generator in its own `finally`, and that
+    # generator's `finally` reaps. Nothing is left to finalization, so by the time `bounded` has
+    # returned the child is already gone — on every interpreter, not just the ones whose refcount
+    # teardown happened to run it.
     #
-    # This is a poll with a deadline, not `sleep(n)`: it returns the microsecond the reap lands, so
-    # a healthy run costs nothing, and 5s is far outside any scheduling delay while staying far
-    # inside the suite's patience. Every property the docstring above names survives it — with the
-    # kill path deleted, `_reap`'s bare `proc.wait()` still blocks inside the cascade and this test
-    # still hangs, which is the failure it was written to name.
+    # ⚠ THE 5-SECOND WAIT THAT USED TO BE HERE IS DELETED, AND ITS DELETION IS PART OF THE FIX.
+    # #1441 replaced this assertion with a bounded poll on the theory that the reap was merely late.
+    # CI then waited the full five seconds with the child still alive (#1434): the last hop was
+    # finalization and on CPython 3.12.3 it never ran at all. A wait cannot turn a kill that does
+    # not happen into one, and it would hide the day this one stops happening again.
     #
     # `events` is deliberately still referenced here. Dropping it would close the chain from the
     # test instead of from `bounded`, and the test would then pass with `bounded`'s own
     # `finally: gen.close()` deleted — proving the cascade, not the budget.
-    deadline = time.monotonic() + 5.0
-    while proc.poll() is None and time.monotonic() < deadline:
-        time.sleep(0.005)
 
     assert proc.poll() is not None, "the CLI is still running after the budget stopped reading it"
     with pytest.raises(ProcessLookupError):
         os.kill(proc.pid, 0)
+
+
+def test_the_kill_survives_somebody_else_holding_the_stream(tmp_path, monkeypatch):
+    """The reap is delivered by a CLOSE, never by whoever happens to drop the last reference.
+
+    The test above proves the child dies. This one proves WHY, and it is the property #1434 was
+    actually missing: there, `parse_stream_json` released `_exec_subprocess`'s generator only when
+    its own frame was torn down, so the kill was really being delivered by CPython's refcounting.
+    On 3.12.3 that teardown did not run and the child outlived the budget; on 3.12.13 it did. Same
+    code, same tree, same machine — a coin the interpreter tossed.
+
+    So this holds a SECOND strong reference to that generator for the whole run — a spy, a
+    debugger, a future caller that keeps the stream around to read `gi_frame` — under which
+    refcount finalization simply cannot fire, on any interpreter. Measured with
+    `parse_stream_json`'s explicit close deleted: the child is STILL RUNNING when `bounded`
+    returns, on 3.12.3 and on 3.12.13 alike. With it: reaped, both. That is the difference between
+    a budget that bounds something and one that only stops reading.
+    """
+    import os
+    import subprocess as sp
+
+    from llm import claude_code as cc
+
+    seen = []
+
+    class _Recorder:
+        TimeoutExpired = sp.TimeoutExpired
+        PIPE, STDOUT = sp.PIPE, sp.STDOUT
+
+        @staticmethod
+        def Popen(*a, **kw):
+            proc = sp.Popen(*a, **kw)
+            seen.append(proc)
+            return proc
+
+    monkeypatch.setattr(cc, "subprocess", _Recorder)
+    monkeypatch.setenv("VEXA_HARNESS_REAP_GRACE_SEC", "0.3")
+
+    line = ('{"type":"assistant","message":{"content":[{"type":"tool_use",'
+            '"name":"mcp__vexa__entity_upsert","id":"c","input":{}}]}}')
+    argv = ["sh", "-c", f"echo '{line}'; echo '{line}'; echo '{line}'; sleep 300"]
+
+    # THE SECOND REFERENCE, and it is the whole test. `inner` stays live in this frame past the
+    # assertions, so nothing about the child's death can be attributed to a refcount reaching zero.
+    inner = cc._exec_subprocess(argv, str(tmp_path))
+    out = list(engine.bounded(cc.parse_stream_json(inner), max_tool_calls=2, max_seconds=10))
+
+    assert out[-1]["type"] == "writeback-truncated"
+    proc = seen[0]
+    assert proc.poll() is not None, "the CLI outlived the budget because somebody still held the stream"
+    with pytest.raises(ProcessLookupError):
+        os.kill(proc.pid, 0)
+    assert inner.gi_frame is None, "the subprocess generator was never closed, only abandoned"
 
 
 def test_a_phase_inside_its_budget_is_waited_for_not_killed(tmp_path, monkeypatch):

--- a/core/agent/worker/engine.py
+++ b/core/agent/worker/engine.py
@@ -33,6 +33,7 @@ from typing import Callable, Iterator, Protocol
 from llm import (
     HarnessPort,
     auth_error_event,
+    close_event_stream,
     harness_from_env,
     looks_like_auth_failure,
     preflight_provider_guard,
@@ -772,9 +773,7 @@ def bounded(events: Iterator[dict], *, max_tool_calls: int, max_seconds: float) 
                        "seconds": round(time.monotonic() - t0, 1), "tool_calls": calls}
                 return
     finally:
-        close = getattr(gen, "close", None)
-        if close is not None:
-            close()
+        close_event_stream(gen)
 
 
 def writeback_events(events: Iterator[dict]) -> Iterator[dict]:
@@ -784,11 +783,16 @@ def writeback_events(events: Iterator[dict]) -> Iterator[dict]:
 
     The `artifact` event is dropped for the same reason the text is: it steals the right panel onto
     an entity page the person did not ask to see, one turn after the document they did."""
-    for ev in events:
-        t = ev.get("type")
-        if t in ("message-delta", "artifact", "done"):
-            continue
-        yield {**ev, "phase": "writeback"}
+    try:
+        for ev in events:
+            t = ev.get("type")
+            if t in ("message-delta", "artifact", "done"):
+                continue
+            yield {**ev, "phase": "writeback"}
+    finally:
+        # `bounded` is underneath and the CLI subprocess is underneath that: whoever stops reading
+        # THIS generator must reach both. See `llm.ports.close_event_stream`.
+        close_event_stream(events)
 
 
 class _Stream(Protocol):
@@ -1182,6 +1186,9 @@ def run_turn_over_workspace(
             and not first.get("ok", True) and not first.get("reason")):
         if sess_file.exists():
             sess_file.unlink()
+        # The refused-resume turn is ABANDONED here — reap its CLI now rather than leaving a second
+        # harness subprocess to whatever the interpreter does with an unreferenced generator.
+        close_event_stream(gen)
         gen = run_harness_turn(work, turn_prompt, harness, allowed_tools=allowed, session=None, model=model,
                                commit=commit, author=author, extra_mounts=extras, mcp_config=mcp_config)
         first = next(gen, None)
@@ -1189,16 +1196,23 @@ def run_turn_over_workspace(
     # THE TURN'S OWN ROUGH EDGES (PRD decision 33 §1). Only the two event types the scan reads are
     # kept — a turn's full stream is unbounded and this is a footnote, not a recorder.
     tool_events: list[dict] = []
-    for ev in (gen if first is None else itertools.chain([first], gen)):
-        if ev.get("type") in ("tool-call", "tool-result"):
-            tool_events.append(ev)
-        if ev.get("type") == "done" and ev.get("sessionId"):
-            captured = ev["sessionId"]
-        if ev.get("type") == "done" and ev.get("reason"):
-            # WHAT THE TURN GAVE UP (F89). Before this the budget/trim events had no consumer at
-            # all, so a turn that stopped halfway looked in every log exactly like one that finished.
-            log.warning("turn incomplete for session=%s: %s", session or "-", ev["reason"])
-        yield ev
+    try:
+        for ev in (gen if first is None else itertools.chain([first], gen)):
+            if ev.get("type") in ("tool-call", "tool-result"):
+                tool_events.append(ev)
+            if ev.get("type") == "done" and ev.get("sessionId"):
+                captured = ev["sessionId"]
+            if ev.get("type") == "done" and ev.get("reason"):
+                # WHAT THE TURN GAVE UP (F89). Before this the budget/trim events had no consumer at
+                # all, so a turn that stopped halfway looked in every log exactly like one that
+                # finished.
+                log.warning("turn incomplete for session=%s: %s", session or "-", ev["reason"])
+            yield ev
+    finally:
+        # `itertools.chain` does not forward a close to what it chains, and neither does the `for`.
+        # The budget closes THIS generator when the write-back phase runs out; the CLI underneath it
+        # must go with it. See `llm.ports.close_event_stream`.
+        close_event_stream(gen)
     # AFTER the stream, never inside it: a report is a footnote to a turn, and a turn must not
     # stall on one. `report` never raises (see worker/friction.py) — this try is the belt.
     try:

--- a/docs/changelog.d/1434-harness-child-reap.md
+++ b/docs/changelog.d/1434-harness-child-reap.md
@@ -1,0 +1,6 @@
+- **A write-back phase that runs over its budget no longer leaves the harness process running
+  (#1434).** When the post-turn write-back phase hit its tool-call or time budget, the agent worker
+  stopped reading the Claude Code CLI but, on some CPython builds, never killed it — so the worker
+  stayed as busy as it was before the budget fired, one orphaned process per over-budget turn. The
+  teardown is now explicit at every hop of the event chain instead of relying on the interpreter's
+  garbage collection, so the budget ends the process on every supported interpreter.


### PR DESCRIPTION
**COMMITMENTS IN THIS DRAFT — none.** Code and one changelog fragment; no money, no date, no right,
no published term, no precedent. No commit carries a `Signed-off-by`.

**Delivers issue:** #1434 — the acceptance floor is in [this comment](https://github.com/Vexa-ai/vexa/issues/1434#issuecomment-5524415526) (the issue was filed without one).

## Contribution rights
<!-- Select exactly ONE. This is a legal certification: an agent may explain the choices but
     must not select one for you. See CONTRIBUTOR_RIGHTS.md. -->

- [ ] **Independent:** I created this contribution, or otherwise have the right to submit it
  under Apache-2.0, and it is not owned or controlled by an employer, client, or other entity.
  <!-- rights:independent -->
- [ ] **Employer/client authorization required:** an employer, client, or other entity owns or
  may control this contribution. I am requesting Vexa's private corporate-authorization process.
  <!-- rights:corporate -->
- [ ] **Unsure:** I need a private rights review before merge.
  <!-- rights:uncertain -->

**Unticked, and no commit carries a `Signed-off-by`.** Both are human certifications and an agent
must not make either.

## What changed

The write-back budget kills the Claude Code CLI by closing the event stream. The kill was reaching
the process only through **refcount finalization**: every hop between `bounded` and
`_exec_subprocess` was a plain `for ev in inner:`, which releases the inner generator when the outer
frame is torn down rather than when it is closed. #1458 showed that on CPython 3.12.3 that teardown
does not run — the inner generator was still alive with its frame intact, `_exec_subprocess`'s
`finally` never fired, and the child was left running. On 3.12.13 it did run. Both satisfy
`requires-python = ">=3.11"`.

Every hop now closes what it wraps **explicitly**, through one named helper:

| Hop | Where |
|---|---|
| `parse_stream_json` → `_exec_subprocess` (the one that owns the child) | `core/agent/llm/claude_code.py:281` |
| `run_harness_turn` → the harness stream | `core/agent/llm/ports.py:444` |
| `run_turn_over_workspace` → the turn, **and the resume-refused turn it abandons** | `core/agent/worker/engine.py:1215` · `:1191` |
| `writeback_events` → `bounded` | `core/agent/worker/engine.py:795` |
| `bounded` → its iterator (already did; now says so in the same vocabulary) | `core/agent/worker/engine.py:776` |

The helper is `close_event_stream` (`core/agent/llm/ports.py:348`), added to the `llm` front door.

## Observation bundle (the record of your harnessed loop)

All runs on `bbb`, in one worktree off `origin/minutes-mcp-viewer`, with both interpreters installed
via `uv python install 3.12.3 3.12.13` into two separate project environments.

- **C1 — the base is not flaky on 3.12.3, it is broken.** Ran: the named test **20×** on base
  `a5ba8e952` under CPython **3.12.3**. Saw: `pass=0 fail=20`, every one
  `AssertionError: the CLI is still running after the budget stopped reading it`, `1 failed in 5.11s`
  (the five seconds are #1441's wait, spent and wasted). Same test on **3.12.13**, same tree, same
  machine: `1 passed in 0.41s`. Concluded: #1458's finding reproduces on demand, the variable is the
  interpreter, and a wait cannot help — nothing happens during it.

- **C2 — head, on the interpreter CI runs.** Ran: the named test **20×** on head `635dbc671` under
  **3.12.3**. Saw: `pass=20 fail=0`, `1 passed in 0.37s`. Concluded: the reap is now synchronous with
  `bounded`'s return; the assertion is back on the next bytecode and the wait is deleted.

- **C3 — the finding that changed the fix, and it is why there is a second test.** Ran: head with
  **only** `parse_stream_json`'s explicit close replaced by `pass` (the `try/finally` left in place).
  Saw: the named test still **passed** on 3.12.3. Concluded: on this interpreter the `try/finally`
  structure alone is enough to unwind the frame — so the original test could not tell an explicit
  close from another piece of interpreter luck, and a fix resting on that would be the same bug with
  a better shape. Then ran, with that same close removed, a harness that holds a **second strong
  reference** to `_exec_subprocess`'s generator for the whole run — under which refcounting cannot
  fire on any interpreter:

  ```
  python 3.12.3  | child after the budget: STILL RUNNING   | inner gen frame: True
  python 3.12.13 | child after the budget: STILL RUNNING   | inner gen frame: True
  ```

  and with the close restored:

  ```
  python 3.12.3  | child after the budget: reaped rc=-9     | inner gen frame: False
  python 3.12.13 | child after the budget: reaped rc=-9     | inner gen frame: False
  ```

  Concluded: the explicit close is the guarantee, the structure is not, and the property is testable
  without depending on a patch level. That harness is now
  `test_the_kill_survives_somebody_else_holding_the_stream`.

- **C4 — no regression, both interpreters.** Ran: the full `core/agent` suite on head under **3.12.3**
  and **3.12.13**. Saw: `1588 passed, 1 warning in 38.50s` and `1588 passed, 1 warning in 35.02s`,
  both `exit=0`. Concluded: nothing else in the harness chain depended on the old teardown timing.

- **C5 — what the red was hiding.** Ran: `node scripts/gates.mjs python` on head. Saw:
  `✓ gate:python — 16 package(s) · pytest green`. Concluded: `gatePython` now walks past `core/agent`
  and reaches `core/flows`, `deploy/lite` and `deploy/dogfood/rig` — the three #1431 adds that CI has
  never executed. That is the issue's stated cost, closed.

- **C6 — the local static gates.** Ran: the pre-push hook (14 fast gates) plus `isolation-py`,
  `graph-py`, `exports`, `arch-report` explicitly. Saw: all green; the push was not bypassed
  (`✓ pre-push: static gates green`). Concluded: the new front-door export and the new cross-module
  edge are within the declared graph.

## Acceptance floor

Base `a5ba8e952` → head `635dbc671`.

| Row | Evidence |
|---|---|
| **A1** — green on CPython 3.12.3, red on base | C1 (`pass=0 fail=20`) → C2 (`pass=20 fail=0`), same machine, same tree, consecutive. |
| **A2** — still green on CPython 3.12.13 | C1 base `1 passed in 0.41s` → C4 head, whole suite green. |
| **A3** — the kill is delivered by the close, not by the last reference | C3. New test `test_the_kill_survives_somebody_else_holding_the_stream`; **negative control red on BOTH interpreters** with the explicit close deleted (`1 failed, 22 passed`, `tests/test_entity_writeback_trim.py:349`). |
| **A4** — #1441's 5-second wait removed, not merely redundant | `core/agent/tests/test_entity_writeback_trim.py`: `deadline`/`while proc.poll() is None` deleted; the assertion is immediate again. The comment records why, so it does not come back. |
| **A5** — no regression on either interpreter | C4 — `1588 passed` twice. |
| **A6** — the hidden packages run | C5 — 16 packages green. |

**Negative controls, all shown red:**

1. explicit close deleted + a second live reference → child **still running** on 3.12.3 **and**
   3.12.13 (C3);
2. `_reap` neutered (early `return` before its wait/kill) → the over-budget test reds in 0.71 s on
   3.12.3 and 0.09 s on 3.12.13 — the test still asserts the kill, not the close;
3. base `claude_code.py` with the new test file → reds in 0.10 s on 3.12.3, i.e. the test's own
   change does not manufacture the green.

## Docs diff (D6c)

`docs/changelog.d/1434-harness-child-reap.md` — one fragment, on the grounds the README for that
directory gives: an orphaned CLI process per over-budget turn is something a `:v012` operator would
want to read about (the worker stays as busy as it was before the budget fired). No page teaches this
seam, so no other page changes and `changelog.mdx` is untouched by design.

## Security checks (required on the diff)

No dependency added or changed, no licence surface, no secret, no network or auth path. The diff is
generator teardown in four functions plus one helper, one test, one changelog fragment.
`gate:licenses` and `gate:execution-env` ran green in the pre-push set. The change strictly
**reduces** exposure: it removes a path where a subprocess holding the turn's environment outlives
the turn that owns it.

## Validation request

Any competent non-author. What to watch, and it is one thing: **the interpreter**. Check out
`635dbc671`, run

```
uv python install 3.12.3
cd core/agent && uv run --python 3.12.3 pytest -q tests/test_entity_writeback_trim.py
```

and confirm both `test_a_phase_over_budget_leaves_no_child_process` and
`test_the_kill_survives_somebody_else_holding_the_stream` pass — then delete the
`close_event_stream(lines)` line in `parse_stream_json` and confirm the second one reds. A run on
3.12.13 alone cannot see the bug this fixes, which is exactly how it survived three PRs.

**Deployment validated: none** — worker seam, unit altitude, real `subprocess` child. No Lite /
compose / k8s / hosted run is claimed, and the path has no deployment divergence.

## Authorship

Sole author: the human submitting this. No agent co-author trailers (D13).
Tooling disclosure (optional, welcome, never an attribution): drafted with Claude Code.

<!-- vexa-agent -->
