### PR TITLE
Flows can be deployed: a compose service for the engine and its mail lane, so a stack that carries the domain serves its tools

### DIFF
--- a/core/flows/Dockerfile
+++ b/core/flows/Dockerfile
@@ -4,6 +4,12 @@ FROM python:3.12-slim
 WORKDIR /app
 RUN pip install --no-cache-dir "sqlalchemy>=2" "psycopg[binary]>=3" "fastapi>=0.110" "uvicorn>=0.29"
 COPY core/flows/schema.sql ./schema.sql
+# THE MCP TOOL MANIFEST — what the gateway assembly fetches from
+# `/.well-known/mcp-tools.json`. `flows_api` reads it at `parents[2]`, i.e. beside `src/`, so it has
+# to be IN the image: without it the route answers 503 and the assembled MCP surface silently loses
+# this domain's four tools. It is not under `src/` because it is the DOMAIN's declaration, read by
+# the gateway's tests from the repo as well as by this service at runtime — one copy, two readers.
+COPY core/flows/mcp.tools.v1.json ./mcp.tools.v1.json
 COPY core/flows/src ./src
 COPY behavior /behavior
 ENV PYTHONPATH=/app/src \

--- a/core/flows/src/config.v1.json
+++ b/core/flows/src/config.v1.json
@@ -1,0 +1,403 @@
+{
+  "contract": "config.v1",
+  "service": "flows-api",
+  "keys": [
+    {
+      "key": "VEXA_FLOWS_API_HOST",
+      "class": "defaulted",
+      "description": "The interface flows-api binds. LOOPBACK BY DEFAULT ON PURPOSE: this process also runs as a host lane on the dogfood rig, where 0.0.0.0 would publish its port on every interface of that box. The compose service says 0.0.0.0 in its own environment, next to the port that publishes it, rather than the code default being flipped underneath the rig.",
+      "default": "127.0.0.1",
+      "targets": [
+        "compose"
+      ]
+    },
+    {
+      "key": "VEXA_FLOWS_API_PORT",
+      "class": "defaulted",
+      "description": "The port flows-api binds.",
+      "default": "18200",
+      "targets": [
+        "compose"
+      ]
+    },
+    {
+      "key": "VEXA_FLOWS_DB_URL",
+      "class": "capability",
+      "description": "The engine's Postgres DSN. Unset falls back to the dogfood container lookup in `flows_steps.common.db_url`, which exists for the rig and never for a deployment — so a deployment always sets it.",
+      "capability": "own_database",
+      "targets": [
+        "compose"
+      ]
+    },
+    {
+      "key": "VEXA_FLOWS_API_KEY",
+      "class": "required-explicit",
+      "description": "The operator key gating `POST /flows` and `POST /events` on flows-api — PRD decision 4's whole access model. No default: a weak one makes an unconfigured deployment look configured (F95).",
+      "secret": true,
+      "targets": [
+        "compose"
+      ],
+      "forbidden_values": [
+        "vexa-internal-secret",
+        "lite-internal-secret",
+        "changeme",
+        "change-me",
+        "CHANGE-ME",
+        "default",
+        "secret"
+      ]
+    },
+    {
+      "key": "VEXA_FLOWS_ADMIN_KEY",
+      "class": "required-explicit",
+      "description": "admin-api's admin key, under the name flows reads it by. It opens `ensure_platform_user` and mints gateway tokens, so it is refused the same way as the internal secret rather than defaulting to a literal.",
+      "secret": true,
+      "targets": [
+        "compose"
+      ],
+      "forbidden_values": [
+        "vexa-internal-secret",
+        "lite-internal-secret",
+        "changeme",
+        "change-me",
+        "CHANGE-ME",
+        "default",
+        "secret"
+      ]
+    },
+    {
+      "key": "INTERNAL_API_SECRET",
+      "class": "required-explicit",
+      "description": "The internal-tier identity flows presents to the other domains — the ONE name the whole internal tier has used since F95. Read through `common.INTERNAL_SECRET_ENV`, which is why the brick's own declaration test scans `*_ENV` constants and not only literals.",
+      "secret": true,
+      "targets": [
+        "compose"
+      ],
+      "forbidden_values": [
+        "vexa-internal-secret",
+        "lite-internal-secret",
+        "changeme",
+        "change-me",
+        "CHANGE-ME",
+        "default",
+        "secret"
+      ]
+    },
+    {
+      "key": "VEXA_FLOWS_TIMELINE_KEY",
+      "class": "capability",
+      "description": "A read-only key that opens `GET /timeline` and nothing else. Unset, only the operator key opens it — the narrower reach, never the wider one.",
+      "capability": "timeline_read_key",
+      "secret": true,
+      "targets": [
+        "compose"
+      ]
+    },
+    {
+      "key": "VEXA_FLOWS_ADMIN_API_URL",
+      "class": "required-explicit",
+      "description": "identity's admin tier. NO HOST-PORT DEFAULT: `http://localhost:18057` is not 'unconfigured', it is A DIFFERENT DEPLOYMENT'S admin-api on any host running two stacks — found live 2026-09-03. A deployment default may name the SERVICE and lives in the deploy surface, never in code.",
+      "targets": [
+        "compose"
+      ]
+    },
+    {
+      "key": "VEXA_FLOWS_GATEWAY_URL",
+      "class": "required-explicit",
+      "description": "The meetings gateway, on the same terms.",
+      "targets": [
+        "compose"
+      ]
+    },
+    {
+      "key": "VEXA_FLOWS_AGENT_API_URL",
+      "class": "capability",
+      "description": "agent-api's internal tier. UNSET MEANS THE AGENT DOMAIN IS NOT DEPLOYED (PRD 40.7) — a supported product, not a misconfiguration, which is exactly what the `capability` class means. `defaulted` could not express it: a default URL asserts the domain exists and the absence then arrives as a connection error that retries forever.",
+      "capability": "agent_domain",
+      "targets": [
+        "compose"
+      ]
+    },
+    {
+      "key": "VEXA_UI_URL",
+      "class": "capability",
+      "description": "Where a person's own terminal lives; it goes into every link this deployment mails. A PORT WITH AN OPTIONAL ADAPTER (PRD decision 4): the terminal is one adapter and the no-agents product has none. It was required-explicit, which made a step-time link decide whether flows-api could BOOT.",
+      "capability": "terminal_link",
+      "targets": [
+        "compose"
+      ]
+    },
+    {
+      "key": "VEXA_MAIL_INBOX",
+      "class": "defaulted",
+      "description": "`imap` (real) or `mailpit` (the dev double).",
+      "default": "imap",
+      "targets": [
+        "compose"
+      ]
+    },
+    {
+      "key": "VEXA_MAIL_ADDR",
+      "class": "capability",
+      "description": "The address this deployment's mailbox answers as, and the identity every allow-list is anchored on. Unset = no mail intake, which is what the no-agents MCP product runs as.",
+      "capability": "mailbox",
+      "targets": [
+        "compose"
+      ]
+    },
+    {
+      "key": "VEXA_MAIL_APP_PASSWORD",
+      "class": "capability",
+      "description": "The IMAP/SMTP credential paired with VEXA_MAIL_ADDR.",
+      "capability": "mailbox",
+      "secret": true,
+      "targets": [
+        "compose"
+      ]
+    },
+    {
+      "key": "VEXA_MAIL_SMTP_HOST",
+      "class": "capability",
+      "description": "Unset = Gmail SMTP over SSL; set = a plain host (the mail double).",
+      "capability": "mail_double",
+      "targets": [
+        "compose"
+      ]
+    },
+    {
+      "key": "VEXA_MAIL_SMTP_PORT",
+      "class": "defaulted",
+      "description": "The port for a set VEXA_MAIL_SMTP_HOST.",
+      "default": "25",
+      "targets": [
+        "compose"
+      ]
+    },
+    {
+      "key": "VEXA_MAILPIT_URL",
+      "class": "defaulted",
+      "description": "mailpit's HTTP base, when the inbox is mailpit. THE ONE HOST-PORT DEFAULT IN THIS DECLARATION, and it states why: mailpit is a DEVELOPMENT inbox that only ever runs beside the process reading it, and the inbox mode has to be selected before the default is reached.",
+      "default": "http://127.0.0.1:8025",
+      "targets": [
+        "compose"
+      ]
+    },
+    {
+      "key": "VEXA_MAILPIT_LOOKBACK_S",
+      "class": "defaulted",
+      "description": "Re-scan window behind the mailpit watermark.",
+      "default": "300",
+      "targets": [
+        "compose"
+      ]
+    },
+    {
+      "key": "VEXA_NOTIFY_CHANNEL",
+      "class": "defaulted",
+      "description": "Where a notification goes; `smtp` is the only real one.",
+      "default": "smtp",
+      "targets": [
+        "compose"
+      ]
+    },
+    {
+      "key": "VEXA_FLOWS_MAIL_DOMAINS",
+      "class": "capability",
+      "description": "The domain allow-list for INBOUND mail (PRD §16.2). UNSET IS NOT `EVERYONE`: it means the mailbox's own domain. A sender who is neither a known user nor inside it gets no account, no agent turn and no model spend — only a quarantine row.",
+      "capability": "mail_intake_policy",
+      "targets": [
+        "compose"
+      ]
+    },
+    {
+      "key": "VEXA_FLOWS_MAIL_QUARANTINE_REPLY",
+      "class": "capability",
+      "description": "`1` answers a quarantined stranger ONCE with a fixed one-line template. Default off: any automatic reply to an unverified sender is a reflector.",
+      "capability": "mail_intake_policy",
+      "targets": [
+        "compose"
+      ]
+    },
+    {
+      "key": "VEXA_FLOWS_MAIL_RATE_PER_SENDER",
+      "class": "defaulted",
+      "description": "Mail-triggered agent turns one sender may cause per window; above it the mail is recorded and dropped.",
+      "default": "12",
+      "targets": [
+        "compose"
+      ]
+    },
+    {
+      "key": "VEXA_FLOWS_MAIL_RATE_GLOBAL",
+      "class": "defaulted",
+      "description": "Mail-triggered agent turns the whole deployment may run per window — the ceiling on what one inbox can cost, whoever sends it.",
+      "default": "120",
+      "targets": [
+        "compose"
+      ]
+    },
+    {
+      "key": "VEXA_FLOWS_MAIL_RATE_WINDOW_S",
+      "class": "defaulted",
+      "description": "The window both mail rate limits count over.",
+      "default": "3600",
+      "targets": [
+        "compose"
+      ]
+    },
+    {
+      "key": "VEXA_FLOWS_MAIL_BODY_MAX",
+      "class": "defaulted",
+      "description": "How much of an inbound body may enter an agent prompt, inside the untrusted block.",
+      "default": "4000",
+      "targets": [
+        "compose"
+      ]
+    },
+    {
+      "key": "VEXA_FLOWS_ATTENDEE_DOMAINS",
+      "class": "capability",
+      "description": "The OUTBOUND fan-out allow-list (PRD §16.2). Unset = the organizer's own domain.",
+      "capability": "outbound_policy",
+      "targets": [
+        "compose"
+      ]
+    },
+    {
+      "key": "VEXA_FLOWS_DATA_STATEMENT",
+      "class": "capability",
+      "description": "The deployment's own sentence about where the words live, carried in what it mails.",
+      "capability": "outbound_policy",
+      "targets": [
+        "compose"
+      ]
+    },
+    {
+      "key": "VEXA_BEHAVIOR_DIR",
+      "class": "capability",
+      "description": "The private behavior tree a deployment mounts (PRD decision 12). EMPTY IS THE OSS PRODUCT: the showcase baked into the image is what flows reads.",
+      "capability": "behavior_override",
+      "targets": [
+        "compose"
+      ]
+    },
+    {
+      "key": "VEXA_JITSI_HOSTS",
+      "class": "capability",
+      "description": "Extra Jitsi hosts a meeting link may live on, beyond meet.jit.si. The SAME setting meeting-api and the MCP service read — two parsers that disagree about what a link is accept different meetings.",
+      "capability": "jitsi_hosts",
+      "targets": [
+        "compose"
+      ]
+    },
+    {
+      "key": "VEXA_FLOWS_USER_KEY_TTL_S",
+      "class": "defaulted",
+      "description": "How long a minted gateway token lives AND how long this process reuses it. One 20-person meeting used to leave ~30 permanent full-scope tokens on the organiser's account (R-B13).",
+      "default": "900",
+      "targets": [
+        "compose"
+      ]
+    },
+    {
+      "key": "VEXA_TIMELINE_SCAN_ROWS",
+      "class": "defaulted",
+      "description": "How many reaction rows the timeline projection scans.",
+      "default": "2000",
+      "targets": [
+        "compose"
+      ]
+    },
+    {
+      "key": "VEXA_INTERNAL_SECRET",
+      "class": "capability",
+      "description": "DEPRECATED alias of INTERNAL_API_SECRET (F95) — honoured with a warning for one release, removed next. On no surface BY DESIGN: a surface that plumbed it would keep the second spelling alive. Declared so the removal is a deletion here rather than an archaeology.",
+      "capability": "deprecated_secret_aliases",
+      "secret": true,
+      "targets": []
+    },
+    {
+      "key": "VEXA_INTERNAL_API_SECRET",
+      "class": "capability",
+      "description": "The second DEPRECATED alias of INTERNAL_API_SECRET, on the same terms and the same clock.",
+      "capability": "deprecated_secret_aliases",
+      "secret": true,
+      "targets": []
+    },
+    {
+      "key": "VEXA_FLOWS_INSTANCE_GATE",
+      "class": "capability",
+      "description": "Forces the instance gate open or shut. A RIG DIAL: a deployment's gate state is a fact about the deployment, so no surface offers a way to lie about it.",
+      "capability": "rig_dials",
+      "targets": []
+    },
+    {
+      "key": "VEXA_FLOWS_FIXTURE_TRANSCRIPT",
+      "class": "capability",
+      "description": "`1` serves the declared fixture transcript instead of the gateway's. A HARNESS dial, on no surface for the same reason.",
+      "capability": "rig_dials",
+      "targets": []
+    }
+  ],
+  "capabilities": {
+    "own_database": {
+      "description": "The engine addressing its own Postgres by DSN rather than by looking up a container on the docker host.",
+      "when_unconfigured": "`common.db_url` falls back to the dogfood container lookup, which resolves on the rig box and nowhere else — so a deployment that leaves this unset fails at its first query, not at boot."
+    },
+    "timeline_read_key": {
+      "description": "A narrower credential for `GET /timeline` than the operator key.",
+      "when_unconfigured": "The timeline stays readable, by the operator key only."
+    },
+    "agent_domain": {
+      "description": "This deployment carries the agent domain (PRD decision 40.7: identity is the one shared dependency; meetings, agents and flows work independently and in any configuration).",
+      "when_unconfigured": "Every flow step that would dispatch an agent turn answers `not_present` instead of reaching for a door that is not there. THAT IS A PRODUCT — the no-agents MCP product — not a degraded state."
+    },
+    "terminal_link": {
+      "description": "A terminal adapter behind flows' link port (PRD decision 4). Flows owns the port; the terminal is one adapter; a deployment may have none.",
+      "when_unconfigured": "Nothing is mailed carrying a link, and any step that would compose one refuses naming VEXA_UI_URL at the moment the link would have gone out. It does not stop the process booting."
+    },
+    "mailbox": {
+      "description": "The inbound mail intake — the `flows-mailbox` lane, IMAP poll to `POST /events`.",
+      "mode": "all",
+      "when_unconfigured": "There is no mail intake. The `mailbox` compose profile is off by default for exactly this reason: a lane started without credentials restart-loops and reads as a broken deployment."
+    },
+    "mail_double": {
+      "description": "A plain SMTP host instead of Gmail over SSL — the development mail double.",
+      "when_unconfigured": "Outbound mail goes through Gmail SMTP over SSL."
+    },
+    "mail_intake_policy": {
+      "description": "Who the mailbox will act for, beyond known users (R-B12).",
+      "mode": "any",
+      "when_unconfigured": "The mailbox's own domain, and nobody else. Unset is the SAFE value here, never `everyone`."
+    },
+    "outbound_policy": {
+      "description": "Who a flow may fan out to, and what this deployment says about where the words live (PRD §16.2).",
+      "mode": "any",
+      "when_unconfigured": "Fan-out is the organizer's own domain and no data statement is carried."
+    },
+    "behavior_override": {
+      "description": "A private `behavior/` tree mounted over the showcase baked into the image (PRD decision 12).",
+      "when_unconfigured": "The in-repo showcase is what flows reads. THAT IS THE OSS PRODUCT, exactly — this repo never carries a tree shipped dark."
+    },
+    "jitsi_hosts": {
+      "description": "Self-hosted Jitsi origins this deployment recognises as meeting links.",
+      "when_unconfigured": "meet.jit.si only."
+    },
+    "deprecated_secret_aliases": {
+      "description": "The two pre-F95 spellings of INTERNAL_API_SECRET, honoured with a warning for one release.",
+      "mode": "any",
+      "when_unconfigured": "The canonical name is the only one read, which is the state this capability exists to arrive at."
+    },
+    "rig_dials": {
+      "description": "Harness overrides used by the dogfood rig and the offline suites.",
+      "mode": "any",
+      "when_unconfigured": "The real instance gate and the real transcript. This is the deployment state."
+    }
+  },
+  "surface_only": [
+    {
+      "key": "LOG_LEVEL",
+      "reason": "compose sets it uniformly on every service in the stack. The flows processes log through print and uvicorn's own level and read no LOG_LEVEL, so it is documented drift rather than a key this service consumes."
+    }
+  ]
+}

--- a/core/flows/src/config_preflight.py
+++ b/core/flows/src/config_preflight.py
@@ -1,0 +1,392 @@
+"""config.v1 preflight — the shared boot-time deployment-config validator (ADR-0026).
+
+CANONICAL COPY: ``deploy/contracts/config.v1/preflight.py``. Every adopted service vendors this
+file VERBATIM as ``config_preflight.py`` next to its ``config.v1.json`` declaration —
+``gate:config-contract`` enforces byte-equality — so the module is importable inside every image
+without a cross-domain package dependency (P2: the services stay isolated bricks; they share a
+contract, not a code distribution).
+
+The three declaration classes (see the contract README):
+
+* **required-explicit** — unset/empty at boot ⇒ :class:`ConfigError` (the deploy refuses to boot
+  with ONE message naming every missing key — fail loud, P18/ADR-0010);
+* **defaulted** — the documented code default applies; nothing to enforce at boot;
+* **capability** — the key belongs to a named capability whose tri-state is computed from the env:
+  ``configured`` / ``not_configured`` / ``misconfigured`` (mode=all: some-but-not-all keys set).
+  The service RUNS either way; capability-gated endpoints consult :func:`capability_state` and fail
+  loud with a typed, actionable error; ``/health`` exposes the rows via :func:`capability_health`
+  (ADDITIVE — existing health consumers keep working).
+
+A capability may also declare a **live probe** (contract ``$defs/Probe``): one cheap verification
+that the SET values actually work — an authenticated HTTP call (``http``: an unauthorized answer or
+a network failure ⇒ misconfigured; any other status ⇒ the credential was accepted) or a credentials
+FILE check (``file``: regular readable non-empty JSON ⇒ ok; a directory — docker's bind-mount of a
+MISSING host path — or unreadable/non-JSON ⇒ misconfigured). Probes run only when the env-level
+state is already ``configured``: once at boot (logged, never boot-blocking) and lazily on ``/health``
+when the cached result is older than the probe's ``ttl_s``. This is what turns the silent-401 STT
+token and the absent claude-credentials mount into a visible ``misconfigured`` row BEFORE any
+meeting/agent runs.
+
+Any declaration class may also carry **forbidden_values** — the placeholder literals a stock deploy
+surface once supplied. A boot whose env holds one raises :class:`ConfigError` beside the missing-key
+refusal, because an unconfigured secret that LOOKS configured is the worse of the two failures: the
+service comes up green and the value is in the public repository (F95).
+
+Env-level state is computed AT CALL TIME (no boot-time snapshot), so tests monkeypatching the
+environment and long-lived processes both observe the truth.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import time
+import urllib.error
+import urllib.request
+from functools import lru_cache
+from pathlib import Path
+from typing import List, Mapping, Optional
+
+log = logging.getLogger("config.v1.preflight")
+
+CONFIGURED = "configured"
+NOT_CONFIGURED = "not_configured"
+MISCONFIGURED = "misconfigured"
+
+
+class ConfigError(RuntimeError):
+    """A deployment-config violation the boot must not survive (fail loud + attributable, P18)."""
+
+
+@lru_cache(maxsize=1)
+def load_declaration() -> dict:
+    """This service's config.v1 declaration (``config.v1.json``, vendored next to this module).
+
+    Sanity-checks the declaration's internal references (a ``capability``-classed key must name a
+    declared capability) so a broken declaration fails at first use, not silently.
+    """
+    path = Path(__file__).resolve().parent / "config.v1.json"
+    decl = json.loads(path.read_text(encoding="utf-8"))
+    caps = decl.get("capabilities") or {}
+    for entry in decl.get("keys") or []:
+        if entry.get("class") == "capability" and entry.get("capability") not in caps:
+            raise ConfigError(
+                f"config.v1 declaration for {decl.get('service')!r} is inconsistent: key "
+                f"{entry.get('key')!r} names undeclared capability {entry.get('capability')!r}"
+            )
+    return decl
+
+
+def _is_set(env: Mapping[str, str], key: str) -> bool:
+    # Empty string counts as UNSET: the deploy surfaces default absent vars to "" (compose
+    # `${VAR:-}`, lite `export VAR="${VAR:-}"`), so "" and absent must mean the same thing.
+    return bool((env.get(key) or "").strip())
+
+
+def capability_states(env: Optional[Mapping[str, str]] = None) -> dict:
+    """The env-level tri-state of every declared capability — PURE (no probe I/O), computed from
+    the live env. This is the request-path oracle capability-gated endpoints use."""
+    env = os.environ if env is None else env
+    decl = load_declaration()
+    caps = decl.get("capabilities") or {}
+    keys_by_cap: dict = {name: [] for name in caps}
+    for entry in decl.get("keys") or []:
+        if entry.get("class") == "capability":
+            keys_by_cap[entry["capability"]].append(entry["key"])
+    states = {}
+    for name, cap in caps.items():
+        keys = keys_by_cap.get(name) or []
+        present = [k for k in keys if _is_set(env, k)]
+        if (cap.get("mode") or "all") == "any":
+            states[name] = CONFIGURED if present else NOT_CONFIGURED
+        elif keys and len(present) == len(keys):
+            states[name] = CONFIGURED
+        elif not present:
+            states[name] = NOT_CONFIGURED
+        else:
+            states[name] = MISCONFIGURED
+    return states
+
+
+def capability_state(name: str, env: Optional[Mapping[str, str]] = None) -> str:
+    """One capability's env-level tri-state. An UNDECLARED name raises — gating on a capability the
+    declaration does not carry is a bug, not a runtime condition."""
+    states = capability_states(env)
+    if name not in states:
+        raise ConfigError(
+            f"capability {name!r} is not declared in {load_declaration().get('service')!r}'s config.v1"
+        )
+    return states[name]
+
+
+def missing_capability_keys(name: str, env: Optional[Mapping[str, str]] = None) -> List[str]:
+    """The unset member keys behind a not_configured/misconfigured capability — so a gated
+    endpoint's error can name EXACTLY what to set (actionable, not just 'unavailable')."""
+    env = os.environ if env is None else env
+    decl = load_declaration()
+    keys = [
+        e["key"]
+        for e in decl.get("keys") or []
+        if e.get("class") == "capability" and e.get("capability") == name
+    ]
+    return [k for k in keys if not _is_set(env, k)]
+
+
+# ── live probes (contract $defs/Probe) — do the SET values actually work? ────────────────────────
+
+_probe_cache: dict = {}
+
+
+def _reset_probe_cache() -> None:
+    """Test seam: forget cached probe results (the cache is per-process, keyed by capability)."""
+    _probe_cache.clear()
+
+
+def probe_url(base: str, path: str) -> str:
+    """Join a configured base URL to the probe's declared path, accepting BOTH accepted shapes:
+    a bare base (``https://api.openai.com``) and a full endpoint URL that already carries the path
+    (``https://api.openai.com/v1/audio/transcriptions``). Appending blindly would double-path the
+    latter into a 404 — the same URL that works in a meeting. This is the ONE rule, shared with the
+    bot's client (``whisper/src/transcription-client.ts``) and the terminal's dictation route."""
+    base = (base or "").strip().rstrip("/")
+    if not path:
+        return base
+    return base if base.endswith(path) else base + path
+
+
+#: A ~1s 16 kHz mono WAV of a quiet tone — the smallest body that is unambiguously *audio*, so a
+#: metered backend must price it and answer 200 or 402 rather than rejecting it unparsed.
+_PROBE_WAV_SECONDS = 1
+_PROBE_WAV_RATE = 16000
+
+
+def _probe_wav() -> bytes:
+    """Build the probe's WAV in memory (stdlib only — this file is vendored into every service and
+    takes no dependencies)."""
+    import math
+    import struct
+
+    frames = b"".join(
+        struct.pack("<h", int(6000 * math.sin(i * 0.06)))
+        for i in range(_PROBE_WAV_RATE * _PROBE_WAV_SECONDS)
+    )
+    data_len = len(frames)
+    byte_rate = _PROBE_WAV_RATE * 2
+    return (
+        b"RIFF" + struct.pack("<I", 36 + data_len) + b"WAVEfmt "
+        + struct.pack("<IHHIIHH", 16, 1, 1, _PROBE_WAV_RATE, byte_rate, 2, 16)
+        + b"data" + struct.pack("<I", data_len) + frames
+    )
+
+
+def audio_probe_body(model: str = "whisper-1") -> tuple:
+    """The audio round-trip's (content_type, body) — the ONE definition of "ask the STT backend the
+    real question", shared with the terminal's Test button (``core/agent/control_plane/config_test``)
+    exactly as ``probe_url`` shares the URL rule. Both must ask identically, or the wizard greens
+    what the boot refuses."""
+    return _multipart({"model": model, "response_format": "json"}, "probe.wav", _probe_wav())
+
+
+def _multipart(fields: Mapping[str, str], filename: str, payload: bytes) -> tuple:
+    """Encode one file + simple fields as multipart/form-data (urllib has no encoder, and this file
+    takes no dependencies). Returns (content_type, body)."""
+    boundary = "----ConfigV1Probe0dcb1f7a"
+    out = bytearray()
+    for k, v in fields.items():
+        out += (f"--{boundary}\r\nContent-Disposition: form-data; name=\"{k}\"\r\n\r\n{v}\r\n").encode()
+    out += (f"--{boundary}\r\nContent-Disposition: form-data; name=\"file\"; "
+            f"filename=\"{filename}\"\r\nContent-Type: audio/wav\r\n\r\n").encode()
+    out += payload + b"\r\n"
+    out += f"--{boundary}--\r\n".encode()
+    return f"multipart/form-data; boundary={boundary}", bytes(out)
+
+
+def _http_probe(spec: dict, env: Mapping[str, str], timeout: float) -> dict:
+    """One authenticated request against the configured endpoint.
+
+    The oracle, in order: network failure ⇒ ``unreachable`` · declared ``unauthorized_statuses``
+    (401/403) ⇒ ``unauthorized``, the token was rejected · declared ``exhausted_statuses`` (402) ⇒
+    ``exhausted``, the token is authentic but cannot buy the work · declared ``invalid_statuses``
+    (404 for an OpenAI-compatible transcriptions path) ⇒ ``invalid_endpoint``, the URL shape is
+    wrong. Any OTHER status proves reachability + accepted auth ⇒ ok.
+
+    ``payload: "audio"`` makes the probe send the REAL thing — a ~1s WAV, the same request shape a
+    bot's first chunk makes — because an empty body cannot answer the question. A metered backend
+    answers an empty POST 400/422 whether the credential is funded or worthless, so the probe that
+    never sends audio greens a token that will 402 on every segment of every meeting. Sending audio
+    also makes the verdict independent of WHO the token belongs to: a billing-exempt account and a
+    funded one both answer 200, and neither has to be named anywhere. It costs a fraction of a
+    minute, so declare a long ``ttl_s`` — usability changes when an operator acts, not by the second.
+
+    A failure carries ``kind`` because the classes are NOT interchangeable to a consumer:
+    ``unauthorized``/``invalid_endpoint``/``exhausted`` are CONFIGURATION faults, true until an
+    operator edits a value or tops up, so a request path may refuse on them; ``unreachable`` is a
+    LIVENESS fault that a restart or a DNS blip produces, so refusing on it would couple this
+    service's availability to the endpoint's. All demote the /health row identically — only actors
+    that REFUSE need the distinction."""
+    base = (env.get(spec["url_key"]) or "").strip().rstrip("/")
+    url = probe_url(base, spec.get("path") or "")
+    body = b""
+    content_type = None
+    if (spec.get("payload") or "") == "audio":
+        content_type, body = audio_probe_body(spec.get("payload_model") or "whisper-1")
+    req = urllib.request.Request(url, data=body, method=(spec.get("method") or "POST"))
+    if content_type:
+        req.add_header("Content-Type", content_type)
+    token = (env.get(spec["auth_key"]) or "").strip() if spec.get("auth_key") else ""
+    if token:
+        req.add_header("Authorization", f"Bearer {token}")
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as r:  # noqa: S310 — declared endpoint
+            status = int(r.status)
+    except urllib.error.HTTPError as e:
+        status = int(e.code)
+    except Exception as e:  # noqa: BLE001 — a probe must never throw past here
+        return {"ok": False, "kind": "unreachable",
+                "reason": f"unreachable: {e.__class__.__name__}: {e}"}
+    if status in (spec.get("unauthorized_statuses") or [401, 403]):
+        return {"ok": False, "status": status, "kind": "unauthorized",
+                "reason": "unauthorized — the configured token was REJECTED by the endpoint"}
+    if status in (spec.get("exhausted_statuses") or []):
+        return {"ok": False, "status": status, "kind": "exhausted",
+                "reason": f"the token is VALID but cannot pay for the work (HTTP {status}) — every "
+                          f"transcription will fail and meetings will complete with no transcript; "
+                          f"top up the account or configure a token that can transcribe"}
+    if status in (spec.get("invalid_statuses") or []):
+        return {"ok": False, "status": status, "kind": "invalid_endpoint",
+                "reason": f"endpoint path not found ({url}) — check the URL shape; some gateways "
+                          f"also answer 404 for a rejected credential"}
+    return {"ok": True, "status": status}
+
+
+#: Probe-failure kinds that mean the CONFIGURATION is wrong (true until an operator changes a
+#: value), as opposed to the endpoint merely being down. A request path may refuse on these.
+CONFIG_FAULT_KINDS = frozenset({"unauthorized", "invalid_endpoint", "exhausted"})
+
+
+def _file_probe(spec: dict, env: Mapping[str, str], timeout: float) -> dict:
+    """Verify a credentials file AS VISIBLE TO THIS SERVICE (the key's own path, then any declared
+    in-container mirror mounts of a docker-HOST path). A directory here is the signature of docker
+    bind-mounting a MISSING host path — exactly the 'Not logged in' worker failure, caught early."""
+    raw = (env.get(spec["path_key"]) or "").strip()
+    if not raw:
+        return {"ok": True, "skipped": f"{spec['path_key']} unset — this credential path is not in use"}
+    tried = []
+    for p in [raw, *(spec.get("fallback_paths") or [])]:
+        path = Path(p)
+        if not path.exists():
+            tried.append(f"{p}: not found")
+            continue
+        if not path.is_file():
+            return {"ok": False, "path": p,
+                    "reason": f"{p} is not a regular file — docker bind-mounts a MISSING host path "
+                              f"as a DIRECTORY, so the host file behind {spec['path_key']} is absent"}
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except Exception as e:  # noqa: BLE001
+            return {"ok": False, "path": p, "reason": f"{p}: unreadable or not JSON ({e.__class__.__name__})"}
+        if not data:
+            return {"ok": False, "path": p, "reason": f"{p}: empty credentials JSON"}
+        return {"ok": True, "path": p}
+    return {"ok": False, "reason": "; ".join(tried)}
+
+
+def _run_probe(spec: dict, env: Mapping[str, str]) -> dict:
+    timeout = float(spec.get("timeout_s") or 2)
+    kind = spec.get("kind")
+    if kind == "http":
+        return _http_probe(spec["http"], env, timeout)
+    if kind == "file":
+        return _file_probe(spec["file"], env, timeout)
+    return {"ok": False, "reason": f"unknown probe kind {kind!r}"}
+
+
+def _cached_probe(name: str, spec: dict, env: Mapping[str, str], force: bool = False) -> dict:
+    ttl = float(spec.get("ttl_s") or 60)
+    now = time.monotonic()
+    hit = _probe_cache.get(name)
+    if not force and hit is not None and (now - hit["at"]) < ttl:
+        return hit["result"]
+    result = _run_probe(spec, env)
+    _probe_cache[name] = {"at": now, "result": result}
+    return result
+
+
+def cached_probe_verdict(name: str, max_age_s: Optional[float] = None) -> Optional[dict]:
+    """The last probe verdict for ``name``, or None when there is no opinion fresh enough to act on.
+
+    A pure cache READ — it never issues a request, so a REQUEST path may consult it (boot preflight
+    seeds the cache, ``/health`` refreshes it; probe I/O stays on those two paths). ``max_age_s``
+    bounds staleness: an older entry reads as None. None means "no verdict" and must never be
+    treated as a failure — an unprobed capability is not a broken one."""
+    hit = _probe_cache.get(name)
+    if hit is None:
+        return None
+    if max_age_s is not None and (time.monotonic() - hit["at"]) > max_age_s:
+        return None
+    return hit["result"]
+
+
+def capability_health(env: Optional[Mapping[str, str]] = None, force_probe: bool = False) -> dict:
+    """The /health rows: env-level tri-state per capability, PLUS the live-probe verdict for
+    capabilities that declare one (probe failure demotes the row to ``misconfigured`` with a
+    reason). Probe results are cached per the probe's ``ttl_s``; a row's shape is
+    ``{"state": ..., "probe"?: {"ok": ..., ...}}`` — additive next to the env-only state."""
+    env = os.environ if env is None else env
+    decl = load_declaration()
+    caps = decl.get("capabilities") or {}
+    rows = {}
+    for name, state in capability_states(env).items():
+        row: dict = {"state": state}
+        spec = (caps.get(name) or {}).get("probe")
+        if spec and state == CONFIGURED:
+            result = _cached_probe(name, spec, env, force=force_probe)
+            row["probe"] = result
+            if not result.get("ok"):
+                row["state"] = MISCONFIGURED
+        rows[name] = row
+    return rows
+
+
+def preflight(env: Optional[Mapping[str, str]] = None) -> dict:
+    """Boot-time validation of the declaration against the environment.
+
+    Raises :class:`ConfigError` naming EVERY missing required-explicit key (one actionable message,
+    not a peel-the-onion loop); runs each configured capability's live probe once; logs one line per
+    capability so a deploy's config completeness is visible in the boot log (a failed probe logs a
+    WARNING but never blocks boot — capabilities gate endpoints, not the process).
+    Returns ``{"service", "capabilities"}`` (the same row shape as :func:`capability_health`).
+    """
+    env = os.environ if env is None else env
+    decl = load_declaration()
+    required = [e for e in decl.get("keys") or [] if e.get("class") == "required-explicit"]
+    missing = [e for e in required if not _is_set(env, e["key"])]
+    if missing:
+        detail = "; ".join(f"{e['key']} ({e['description']})" for e in missing)
+        raise ConfigError(
+            f"{decl.get('service')} is misconfigured and refuses to boot — required environment "
+            f"variable(s) not set: {detail}. Each is declared required-explicit in this service's "
+            "config.v1 declaration (config.v1.json, gate:config-contract); set them and restart."
+        )
+    # A key sitting on a documented placeholder is UNCONFIGURED wearing a configured face — worse
+    # than unset, because nothing 503s and the value is published (F95). Never echo the value.
+    placeheld = [e["key"] for e in decl.get("keys") or []
+                 if e.get("forbidden_values")
+                 and (env.get(e["key"]) or "").strip() in set(e["forbidden_values"])]
+    if placeheld:
+        raise ConfigError(
+            f"{decl.get('service')} is misconfigured and refuses to boot — {', '.join(placeheld)} "
+            "still hold(s) a documented PLACEHOLDER value. That literal is published in this "
+            "repository, so it is not a secret: anyone can present it. Generate a real value "
+            "(`openssl rand -hex 32`), set it on every service that shares the tier, and restart. "
+            "The forbidden literals are declared per key in this service's config.v1 declaration "
+            "(config.v1.json, gate:config-contract)."
+        )
+    rows = capability_health(env, force_probe=True)
+    for name, row in sorted(rows.items()):
+        if row["state"] == MISCONFIGURED:
+            log.warning("config.v1 capability %s: MISCONFIGURED — %s", name,
+                        (row.get("probe") or {}).get("reason", "some-but-not-all keys set"))
+        else:
+            log.info("config.v1 capability %s: %s", name, row["state"])
+    return {"service": decl.get("service"), "capabilities": rows}

--- a/core/flows/src/flows_config.py
+++ b/core/flows/src/flows_config.py
@@ -76,9 +76,20 @@ DECLARED: dict[str, tuple[str, object, str]] = {
     # inside the deployment's own network) and lives in compose/helm, never here.
     "VEXA_FLOWS_GATEWAY_URL": ("required-explicit", None, "the meetings gateway."),
     "VEXA_FLOWS_ADMIN_API_URL": ("required-explicit", None, "admin-api's admin tier."),
-    "VEXA_UI_URL": ("required-explicit", None,
-                    "where a person's own terminal lives — it goes into every link we mail, so a "
-                    "localhost default is a dead button in every deployment that is not a laptop."),
+    # THE LINK PORT, and `capability` is what makes it one (PRD decision 4, founder 2026-09-03
+    # 09:56Z: *"fine as a port + adapter (P16): flows owns a link port, the terminal is one
+    # adapter, the no-agents product has none"*). It was `required-explicit`, which made a
+    # STEP-TIME link decide whether the process could BOOT: `preflight()` refused, so flows-api
+    # crash-looped on the compose network before it could serve /health or its tool manifest — and
+    # the no-agents product has no terminal to name. Unset is therefore a supported deployment,
+    # exactly as the agent door's absence is, and it is still not a silent one: `require` refuses
+    # at the moment a link would have been composed, naming this key (`ui_link`, `mint_scaffold`).
+    # There is still NO DEFAULT — a localhost default is a dead button in every deployment that is
+    # not a laptop, which is the reason the door rule exists at all.
+    "VEXA_UI_URL": ("capability", None,
+                    "where a person's own terminal lives — it goes into every link we mail. UNSET "
+                    "MEANS THIS DEPLOYMENT HAS NO TERMINAL ADAPTER: nothing is mailed with a link "
+                    "and any step that would compose one refuses, naming this key."),
     # THE AGENT DOMAIN'S PRESENCE SIGNAL (PRD decision 40.7: *"meetings, agents and flows work
     # independently and together in any configuration"*). `capability`, which is exactly what the
     # class means here — unset is not a misconfiguration, it is the `no-agents` profile, and every
@@ -93,13 +104,28 @@ DECLARED: dict[str, tuple[str, object, str]] = {
         "the engine's Postgres DSN. Unset falls back to the dogfood container lookup in "
         "`common.db_url`, which exists for the rig and never for a deployment."),
     "VEXA_FLOWS_API_PORT": ("defaulted", "18200", "the port flows-api binds."),
+    "VEXA_FLOWS_API_HOST": (
+        "defaulted", "127.0.0.1",
+        "the interface flows-api binds. Loopback by default because this process also runs as a "
+        "HOST LANE on the dogfood rig, where 0.0.0.0 would publish its port on every interface of "
+        "that box. The compose service sets 0.0.0.0 in its own environment — in a container "
+        "loopback is that container's own, so nothing else on the network can reach it, which is "
+        "why the interim wiring had to bind the lane to the docker bridge address by hand."),
 
     # ── the mailbox: which inbox, and what it will answer ───────────────────
     "VEXA_MAIL_INBOX": ("defaulted", "imap", "`imap` (real) or `mailpit` (the dev double)."),
+    # `capability`, not `required-explicit`, for the same reason as the agent door and the link
+    # port: a deployment may carry no mail intake at all (the no-agents MCP product does not), and
+    # the class that says so is the one that says a deployment is a product rather than a hole.
+    # Nothing changed operationally — flows' own `preflight` only ever enforced DOOR_KEYS, so this
+    # class was documentary — but the config.v1 declaration is read by the shared boot validator,
+    # where `required-explicit` means "refuse to boot" and would have refused the API lane over a
+    # key only the mailbox lane reads.
     "VEXA_MAIL_ADDR": (
-        "required-explicit", None,
-        "the address this deployment's mailbox answers as. It is also the identity every "
-        "allow-list is anchored on, so an unset value is not a cosmetic gap."),
+        "capability", None,
+        "the address this deployment's mailbox answers as, and the identity every allow-list is "
+        "anchored on. Unset = no mail intake; set without VEXA_MAIL_APP_PASSWORD is the "
+        "half-configured mailbox the capability's `all` mode calls misconfigured."),
     "VEXA_MAIL_APP_PASSWORD": ("capability", None, "the IMAP/SMTP credential paired with VEXA_MAIL_ADDR."),
     "VEXA_MAIL_SMTP_HOST": ("capability", None, "unset = Gmail SMTP over SSL; set = a plain host (the mail double)."),
     "VEXA_MAIL_SMTP_PORT": ("defaulted", "25", "the port for a set VEXA_MAIL_SMTP_HOST."),
@@ -164,7 +190,10 @@ class ConfigError(RuntimeError):
 
 
 #: The service endpoints flows reaches. `required-explicit` ones must be named by the deployment;
-#: the agent door is a capability, because its absence is a supported product configuration.
+#: the agent door and the link port are capabilities, because their absence is a supported product
+#: configuration — no agent domain (40.7) and no terminal adapter (decision 4) respectively.
+#: `missing_doors` filters on the CLASS, so a door moves between the two lists by reclassification
+#: in the table above and nowhere else.
 DOOR_KEYS = ("VEXA_FLOWS_GATEWAY_URL", "VEXA_FLOWS_ADMIN_API_URL", "VEXA_UI_URL",
              "VEXA_FLOWS_AGENT_API_URL")
 

--- a/core/flows/src/flows_defs/production.py
+++ b/core/flows/src/flows_defs/production.py
@@ -49,7 +49,15 @@ from flows_steps import agent as ag
 from flows_steps import emailx as mx          # thread bookkeeping + the iMIP calendar reply only
 from flows_steps import meeting as mt
 from flows_steps import mailtext
-from flows_steps.common import (UI_URL, ensure_platform_user, mint_scaffold, platform_user_id,
+# NOT `from … import UI_URL`. That name is a REQUIRED-EXPLICIT door served by `common`'s PEP-562
+# `__getattr__`, so importing it resolves the door AT IMPORT — the exact thing `_door` resolves at
+# access time to avoid ("a constant binds whatever the environment said at import"). One
+# `from … import` undid that for this whole module and made a step-time link URL decide whether
+# flows-api can BOOT: on the compose network it crash-looped with `VEXA_UI_URL is unset` before it
+# could serve /health or its tool manifest. Read through the module, at the use site, where the
+# refusal is still loud and is about the link it would have composed.
+from flows_steps import common as _common
+from flows_steps.common import (ensure_platform_user, mint_scaffold, platform_user_id,
                                 scaffolded, setting, ws_file)
 from flows_steps.notify import notify
 
@@ -796,7 +804,7 @@ def build(reg: Registry, db) -> None:
             if end != -1:
                 body = rest[end + 4:]
         body = re.sub(r"\[([^\]]+)\]\((/[^)]*)\)",
-                      lambda m: m.group(1) + ": " + UI_URL + m.group(2), body)
+                      lambda m: m.group(1) + ": " + _common.UI_URL + m.group(2), body)
         body = re.sub(r"\[\[([^\]]+)\]\]", r"\1", body)
         return body.strip()
 

--- a/core/flows/src/flows_integrations/flows_api.py
+++ b/core/flows/src/flows_integrations/flows_api.py
@@ -487,16 +487,30 @@ def timeline(subject: str = "", since: str = "", until: str = "", limit: int = 2
     return out
 
 
+def bind_host() -> str:
+    """Which interface to listen on — loopback unless the deployment says otherwise.
+
+    THE DEFAULT STAYS `127.0.0.1` ON PURPOSE. This process runs two ways: as a host lane out of
+    `flows-up.sh` on the dogfood rig, and (new) as a container on the compose network. In a
+    container, loopback is the loopback of that container, so nothing else on the network can reach
+    it — which is why the interim wiring had to bind the lane to the docker bridge address by hand
+    and write a host-specific address into a deployment.
+
+    Flipping the default to `0.0.0.0` would fix the container and, the same day, publish the host
+    lane's port on every interface of the rig box: a deployment change smuggled in as a container
+    fix. So the container says `VEXA_FLOWS_API_HOST=0.0.0.0` in its own environment, out loud,
+    where an operator reading the compose file can see the exposure and its port binding together.
+    """
+    return (os.environ.get("VEXA_FLOWS_API_HOST") or "127.0.0.1").strip()
+
+
 def main() -> int:  # pragma: no cover — process entrypoint
     import uvicorn
     port = int(os.environ.get("VEXA_FLOWS_API_PORT", "18200"))
-    print(f"flows-api up on :{port} · vocabulary of {len(vocab.steps)} steps", flush=True)
-    uvicorn.run(app, host="127.0.0.1", port=port, log_level="warning")
+    host = bind_host()
+    print(f"flows-api up on {host}:{port} · vocabulary of {len(vocab.steps)} steps", flush=True)
+    uvicorn.run(app, host=host, port=port, log_level="warning")
     return 0
-
-
-if __name__ == "__main__":
-    raise SystemExit(main())
 
 
 # ── the MCP tool manifest (PRD decision 40) ───────────────────────────────────────────────────
@@ -522,3 +536,18 @@ def mcp_tools_manifest():
     except Exception as e:  # noqa: BLE001
         raise HTTPException(status_code=503,
                             detail=f"this build carries no tool manifest: {e}") from e
+
+
+# THE ENTRYPOINT GUARD IS THE LAST THING IN THIS MODULE, and that is load-bearing rather than
+# tidy. It used to sit above the manifest route, and `python -m flows_integrations.flows_api` —
+# the compose command, the helm command, the rig's command — runs this file AS `__main__`: the
+# guard fires, `main()` blocks inside `uvicorn.run`, and NOTHING BELOW IT IS EVER EXECUTED. So the
+# process that every deployment actually runs served /flows, /events and /health and answered 404
+# on `/.well-known/mcp-tools.json`, while the offline suite — which IMPORTS the module, where
+# `__name__` is not `__main__` and the whole file runs — proved the route existed and served the
+# right four tools. Green offline, absent live, and only the first live boot of the compose service
+# could tell them apart.
+#
+# Anything added after this line is invisible to the running service. Add routes ABOVE it.
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/core/flows/tests/test_config_contract.py
+++ b/core/flows/tests/test_config_contract.py
@@ -1,0 +1,128 @@
+"""config.v1 (ADR-0026) — `core/flows` adopted, and the two declarations held together.
+
+Flows carried its OWN declaration long before this: `flows_config.DECLARED`, written to make the
+adoption "a transcription when it happens" (its own docstring), with both directions asserted by
+`test_config_declaration.py`. The adoption did not replace that table — the accessors
+(`get`/`get_int`/`get_bool`) still refuse an undeclared name at the read, which is a thing a JSON
+file cannot do — so the brick now has TWO declarations of the same fact, and two declarations of
+one fact drift. That is exactly the shape F95 was (one secret, three names, three refusal lists).
+
+So the file that would have been "the declaration conforms to the schema" is instead "the two
+declarations are the same declaration", plus the boot-behaviour assertions the contract's shared
+validator makes possible. Schema conformance itself is `gate:config-contract` check 1 and the
+contract's own `validate.mjs`; it is not restated here.
+
+WHAT THE SHARED PREFLIGHT IS AND IS NOT WIRED TO. `config_preflight.py` is vendored verbatim (the
+gate enforces byte-equality) and is what makes the declaration machine-readable — capability
+tri-states, forbidden-value refusals, `/health` rows. The flows entrypoints still call
+`flows_config.preflight()`, which is door-scoped and older; putting a second boot validator in
+front of a running deployment is a change to how it boots and belongs to whoever is changing that,
+not to the adoption. Offline, stdlib only.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+SRC = Path(__file__).resolve().parents[1] / "src"
+sys.path.insert(0, str(SRC))
+
+import config_preflight as cp        # noqa: E402  — the vendored canonical validator
+import flows_config as cfg           # noqa: E402  — the brick's own table
+
+
+def _decl():
+    return cp.load_declaration()
+
+
+def test_the_declaration_is_this_service_and_loads():
+    decl = _decl()
+    assert decl["contract"] == "config.v1"
+    assert decl["service"] == "flows-api"
+
+
+def test_the_two_declarations_name_exactly_the_same_keys():
+    """The drift check, and the reason this file exists. A key added to one table and not the
+    other is a key the gate checks against a deploy surface and the accessors refuse at the read,
+    or the reverse — both of which are found at 3am rather than in CI."""
+    contract = {k["key"] for k in _decl()["keys"]}
+    table = set(cfg.DECLARED)
+    assert contract == table, {
+        "in config.v1.json only": sorted(contract - table),
+        "in flows_config.DECLARED only": sorted(table - contract),
+    }
+
+
+def test_the_two_declarations_agree_on_every_class_and_default():
+    """Same key, same class, same default. The class is not decoration: it decides whether an
+    unset key refuses the boot, and the two files must not answer that differently."""
+    disagree = {}
+    for k in _decl()["keys"]:
+        cls, default, _why = cfg.DECLARED[k["key"]]
+        want_default = None if k["class"] != "defaulted" else k.get("default")
+        got_default = None if default is None else str(default)
+        if k["class"] != cls or (k["class"] == "defaulted" and want_default != got_default):
+            disagree[k["key"]] = {"config.v1.json": (k["class"], k.get("default")),
+                                  "flows_config": (cls, default)}
+    assert disagree == {}
+
+
+def test_every_capability_key_names_a_declared_capability():
+    decl = _decl()
+    named = set(decl.get("capabilities", {}))
+    for k in decl["keys"]:
+        if k["class"] == "capability":
+            assert k["capability"] in named, f"{k['key']} names capability {k['capability']!r}"
+
+
+def test_the_no_agents_profile_is_configured_not_broken():
+    """PRD 40.7 and decision 4 in one assertion. A deployment with no agent domain and no terminal
+    adapter must read as two capabilities that are OFF — never as a service that cannot boot."""
+    env = {"VEXA_FLOWS_API_KEY": "k", "VEXA_FLOWS_ADMIN_KEY": "a", "INTERNAL_API_SECRET": "s",
+           "VEXA_FLOWS_ADMIN_API_URL": "http://admin-api:8001",
+           "VEXA_FLOWS_GATEWAY_URL": "http://gateway:8000"}
+    cp.preflight(env)                                  # must not raise
+    assert cp.capability_state("agent_domain", env) == "not_configured"
+    assert cp.capability_state("terminal_link", env) == "not_configured"
+    assert cp.capability_state("mailbox", env) == "not_configured"
+
+
+def test_the_boot_refuses_a_deployment_that_named_no_credential_and_no_door():
+    with pytest.raises(cp.ConfigError) as refused:
+        cp.preflight({})
+    said = str(refused.value)
+    for key in ("VEXA_FLOWS_API_KEY", "VEXA_FLOWS_ADMIN_KEY", "INTERNAL_API_SECRET",
+                "VEXA_FLOWS_ADMIN_API_URL", "VEXA_FLOWS_GATEWAY_URL"):
+        assert key in said, f"the refusal does not name {key}"
+    for capability_key in ("VEXA_FLOWS_AGENT_API_URL", "VEXA_UI_URL", "VEXA_MAIL_ADDR"):
+        assert capability_key not in said, \
+            f"{capability_key} is a capability — its absence is a product, not a misconfiguration"
+
+
+#  and  are on the refusal list too, but the refusal PROSE contains both
+# words, so asserting they are not echoed cannot distinguish the value from the sentence. The three
+# here are literals no message would otherwise say.
+@pytest.mark.parametrize("placeholder", ["vexa-internal-secret", "lite-internal-secret", "changeme"])
+def test_the_published_placeholders_are_refused_by_name_never_by_value(placeholder):
+    """F95 — the failure `required-explicit` does NOT catch: the key was never unset, compose
+    supplied a literal from this public repository, and the deployment came up green sharing one
+    secret with every reader of the source. `flows_steps.common` already refuses these three
+    credentials at their use sites; the declaration is where the shared boot validator learns the
+    same list, so the two cannot drift apart."""
+    env = {"VEXA_FLOWS_API_KEY": "k", "VEXA_FLOWS_ADMIN_KEY": "a",
+           "INTERNAL_API_SECRET": placeholder,
+           "VEXA_FLOWS_ADMIN_API_URL": "http://admin-api:8001",
+           "VEXA_FLOWS_GATEWAY_URL": "http://gateway:8000"}
+    with pytest.raises(cp.ConfigError) as refused:
+        cp.preflight(env)
+    assert "INTERNAL_API_SECRET" in str(refused.value)
+    assert placeholder not in str(refused.value), "a refusal must never echo the value"
+
+
+def test_the_placeholder_list_is_the_same_list_the_use_sites_refuse():
+    from flows_steps import common
+    for k in _decl()["keys"]:
+        if k["key"] in ("INTERNAL_API_SECRET", "VEXA_FLOWS_ADMIN_KEY", "VEXA_FLOWS_API_KEY"):
+            assert set(k["forbidden_values"]) == set(common.PLACEHOLDER_SECRETS), k["key"]

--- a/core/flows/tests/test_flows_api_service.py
+++ b/core/flows/tests/test_flows_api_service.py
@@ -1,0 +1,179 @@
+"""flows-api as a COMPOSE SERVICE — the three things that stopped it being one.
+
+Today the flows lanes run on the host out of `~/.storm/flows-up.sh`, on loopback :18200/:18201, and
+the compose-network `mcp` service reaches them through an interim hack: the lane is bound to the
+docker bridge address so the assembler can fetch `/.well-known/mcp-tools.json`. That interim is a
+host-specific address written into a deployment, and it is what a real service replaces.
+
+Three gaps, and each is small enough to look like nothing:
+
+  * `main()` binds `127.0.0.1`. Inside a container that is the loopback of the container, so the
+    service is unreachable from every other service on the network — the single reason the bridge
+    address had to be hand-wired.
+  * there is no `/health`, so nothing can express a compose `healthcheck` or a `depends_on`
+    condition against it.
+  * the manifest route exists but nothing pins WHICH tools it serves, so an assembly that silently
+    lost a tool would still look assembled.
+
+Offline: the engine is stdlib-pure and `postgres_db` builds its engine lazily, so the app imports
+without a database.
+"""
+from __future__ import annotations
+
+import os
+
+import pytest
+
+# IMPORTING THIS APP HAS SIDE EFFECTS, so every one of them is undone before the module finishes.
+#
+# `flows_api` reads its credentials and composes its database AT IMPORT. Getting it in here means
+# setting environment, PROCESS-WIDE. Left in place it leaks into every other test file in the
+# session, which is not hypothetical: the first version of this module turned
+# `test_link_loop.py::test_mint_scaffold_posts_the_record_and_returns_the_url` red, and that test
+# passes on its own. `gate:test-isolation` exists for this shape.
+#
+# THE DATABASE IS CHOSEN BY THE URL, not by a monkeypatch. An earlier version of this file swapped
+# `flows.postgres_db` for an in-memory sqlite adapter; `flows_api` then moved to `db_from_url`,
+# which resolves `postgres_db` inside `flows.db` and never saw the swap, so the module tried to
+# open a real connection at import. `db_from_url`'s own docstring is the fix: "a `sqlite://` URL
+# gets the sqlite dialect, anything else gets Postgres. No flag, no test-only branch — the
+# deployment's own URL decides." So this suite is a deployment whose URL says sqlite.
+_PRIOR_ENV = {k: os.environ.get(k) for k in
+              ("VEXA_FLOWS_API_KEY", "INTERNAL_API_SECRET", "VEXA_FLOWS_DB_URL")}
+
+os.environ.setdefault("VEXA_FLOWS_API_KEY", "test-flows-key")
+os.environ.setdefault("INTERNAL_API_SECRET", "test-internal-secret")
+os.environ["VEXA_FLOWS_DB_URL"] = "sqlite://"
+try:
+    from flows_integrations import flows_api  # noqa: E402
+finally:
+    for _k, _v in _PRIOR_ENV.items():
+        if _v is None:
+            os.environ.pop(_k, None)
+        else:
+            os.environ[_k] = _v
+
+#: The domain's contribution to the one MCP surface. Named here so a tool cannot leave the manifest
+#: without a test saying so — an assembly that quietly lost one still looks assembled.
+FOUR_TOOLS = {"flows_list", "reactions_list", "reaction_signal", "timeline"}
+
+
+def _route(path: str):
+    return next((r for r in flows_api.app.routes if getattr(r, "path", None) == path), None)
+
+
+def test_health_exists_and_is_open():
+    """A compose healthcheck and a `depends_on: service_healthy` both need one unauthenticated
+    route that answers. Open like the manifest: a probe that had to authenticate could not run
+    before identity did, which is the moment you most want to know whether the process is up."""
+    r = _route("/health")
+    assert r is not None, "flows-api has no /health — nothing can express a healthcheck against it"
+    assert not getattr(r, "dependencies", []), "/health must not be behind auth"
+
+    body = flows_api.health()
+    assert body.get("status") == "ok", body
+    assert body.get("service") == "flows-api", body
+
+
+def test_no_path_is_registered_twice():
+    """This branch and #1431 both added a /health, and the collision is SILENT: FastAPI keeps both
+    registrations and the FIRST one answers, so the reader of the second body is reading dead code
+    that looks live. `_route` returns the first match, which is what the framework does too — this
+    is the assertion that makes a second one a failure instead of a shadow."""
+    bindings = [(m, r.path) for r in flows_api.app.routes if getattr(r, "path", None)
+                for m in sorted(getattr(r, "methods", None) or ["*"])]
+    duplicates = sorted({b for b in bindings if bindings.count(b) > 1})
+    assert duplicates == [], duplicates
+
+
+def test_nothing_is_registered_after_the_entrypoint_guard():
+    """FOUND BY THE FIRST LIVE BOOT, and invisible to every offline assertion above.
+
+    `if __name__ == "__main__": raise SystemExit(main())` sat in the MIDDLE of the module, above
+    the manifest route. Every deployment starts this file with `python -m`, so `__name__` IS
+    `__main__`: the guard fires, `main()` blocks inside `uvicorn.run`, and the lines below it never
+    execute. The running service answered 404 on `/.well-known/mcp-tools.json` — the one route the
+    MCP assembly needs — while this suite, which IMPORTS the module and therefore runs all of it,
+    proved the route existed and served exactly the right four tools.
+
+    A test that imports can never catch this, so this one reads the source instead."""
+    from pathlib import Path
+
+    src = Path(flows_api.__file__).read_text()
+    guard = src.index('if __name__ == "__main__":')
+    after = src[guard:]
+    assert "@app." not in after, \
+        "a route is declared after the entrypoint guard — `python -m` never reaches it"
+    assert after.count("\n") < 4, "the guard must be the LAST statement in the module"
+
+
+def test_the_manifest_is_open_and_carries_exactly_the_four_tools():
+    r = _route("/.well-known/mcp-tools.json")
+    assert r is not None
+    assert not getattr(r, "dependencies", []), "the manifest must stay open — the assembler is not a user"
+
+    manifest = flows_api.mcp_tools_manifest()
+    assert {t["name"] for t in manifest["tools"]} == FOUR_TOOLS, manifest["tools"]
+    assert manifest["domain"] == "flows"
+
+
+def test_the_bind_address_is_configurable_and_still_defaults_to_loopback():
+    """The container binds every interface; the HOST LANE must not change under the dogfood estate.
+
+    A default of 0.0.0.0 would silently expose the host lane's port on every interface of the rig
+    box the day this merges — a deployment change smuggled in as a container fix. So the default
+    stays loopback and the container says otherwise, out loud, in its own environment.
+    """
+    assert flows_api.bind_host() == "127.0.0.1"
+
+    os.environ["VEXA_FLOWS_API_HOST"] = "0.0.0.0"
+    try:
+        assert flows_api.bind_host() == "0.0.0.0"
+    finally:
+        del os.environ["VEXA_FLOWS_API_HOST"]
+
+
+def test_the_new_keys_are_declared():
+    """`flows_config.DECLARED` asserts both directions (read ⊆ declared and declared ⊆ read), so a
+    key added without a declaration fails there. This says it out loud where the key is introduced."""
+    import flows_config
+
+    for key in ("VEXA_FLOWS_API_HOST", "VEXA_FLOWS_API_PORT"):
+        assert key in flows_config.DECLARED, f"{key} is read and declared nowhere"
+
+
+def test_a_step_time_door_is_not_read_at_import(monkeypatch):
+    """A REQUIRED-EXPLICIT door that is only used to compose a mailed link must not decide whether
+    the process can BOOT. Found by the live proof on bbb: flows-api crash-looped with
+    `VEXA_UI_URL is unset` before serving anything, including /health and the tool manifest.
+
+    `_door` resolves at ACCESS time on purpose — its own docstring says a constant "binds whatever
+    the environment said at import" — and `common.__getattr__` (PEP 562) is what makes that work.
+    But `from flows_steps.common import UI_URL` fires that `__getattr__` AT IMPORT, which is the
+    one thing the design was built to avoid. One `from … import` undid it for the whole module.
+
+    So: a deployment that never mails a link boots; the refusal still fires, loudly, at the moment
+    the link would have been composed.
+    """
+    import importlib
+    import sys
+
+    monkeypatch.delenv("VEXA_UI_URL", raising=False)
+    monkeypatch.setenv("VEXA_FLOWS_GATEWAY_URL", "http://gateway:8000")
+    monkeypatch.setenv("VEXA_FLOWS_ADMIN_API_URL", "http://admin-api:8001")
+    for mod in [m for m in sys.modules if m.startswith(("flows_defs", "flows_steps"))]:
+        del sys.modules[mod]
+
+    importlib.import_module("flows_defs.production")      # must not raise
+
+    # AND THE OTHER HALF, which the first version of this test missed: `flows_api` calls
+    # `flows_config.preflight()` at import, and VEXA_UI_URL was a required-explicit DOOR, so the
+    # process still refused to boot with the import fixed. It is a link PORT now (PRD decision 4)
+    # and its adapter is optional, so a deployment with no terminal boots.
+    import flows_config
+    flows_config.preflight()                              # must not raise
+
+    from flows_steps import common
+    with pytest.raises(Exception) as refused:
+        _ = common.UI_URL
+    assert "VEXA_UI_URL" in str(refused.value), "the refusal must still name the key it needs"

--- a/core/flows/tests/test_flows_doors.py
+++ b/core/flows/tests/test_flows_doors.py
@@ -22,7 +22,13 @@ import pytest
 DOORS = {
     "VEXA_FLOWS_GATEWAY_URL": "required-explicit",
     "VEXA_FLOWS_ADMIN_API_URL": "required-explicit",
-    "VEXA_UI_URL": "required-explicit",
+    # THE LINK PORT, not a service flows calls (PRD decision 4). `required-explicit` made a
+    # step-time link decide whether the process could BOOT — flows-api crash-looped on the compose
+    # network with `VEXA_UI_URL is unset` before serving /health or its manifest, and the
+    # no-agents product has no terminal to name. Unset is a deployment with no link adapter; the
+    # refusal moved to the moment a link would have been composed, which is where it says
+    # something.
+    "VEXA_UI_URL": "capability",
     "VEXA_FLOWS_AGENT_API_URL": "capability",       # 40.7: unset = the domain is not deployed
 }
 
@@ -58,16 +64,17 @@ def test_the_preflight_names_every_door_the_deployment_did_not(monkeypatch):
     for key, cls in DOORS.items():
         if cls == "required-explicit":
             assert key in said, f"the refusal does not name {key}"
-    assert "VEXA_FLOWS_AGENT_API_URL" not in said, \
-        "the agent door is a capability — its absence is a product, not a misconfiguration"
+    for capability in ("VEXA_FLOWS_AGENT_API_URL", "VEXA_UI_URL"):
+        assert capability not in said, \
+            f"{capability} is a capability — its absence is a product, not a misconfiguration"
 
 
 def test_the_preflight_passes_once_the_doors_are_named(monkeypatch):
     monkeypatch.setenv("VEXA_FLOWS_GATEWAY_URL", "http://gateway:8000")
     monkeypatch.setenv("VEXA_FLOWS_ADMIN_API_URL", "http://admin-api:8001")
-    monkeypatch.setenv("VEXA_UI_URL", "http://terminal:3000")
+    monkeypatch.delenv("VEXA_UI_URL", raising=False)
     monkeypatch.delenv("VEXA_FLOWS_AGENT_API_URL", raising=False)
-    flows_config.preflight()                     # the no-agents profile boots
+    flows_config.preflight()      # no agent domain, no terminal adapter — and it boots
 
 
 def test_require_refuses_rather_than_returning_an_empty_base(monkeypatch):
@@ -96,3 +103,13 @@ def test_the_contract_smoke_takes_its_target_from_the_contract_only():
     src = (Path(__file__).resolve().parent / "test_contract_smokes.py").read_text()
     assert not _HOST_PORT.search(src), "the contract smoke hard-codes a local host-port"
     assert "flows_config" in src or "from flows_steps.common import" in src
+
+
+def test_the_link_port_still_refuses_at_the_moment_a_link_would_be_composed(monkeypatch):
+    """Reclassifying VEXA_UI_URL moved the refusal; it did not remove it. A deployment that has no
+    terminal boots and mails nothing with a link. One that HAS a terminal and forgot to name it
+    gets told so where the link would have gone, not three services away at boot."""
+    monkeypatch.delenv("VEXA_UI_URL", raising=False)
+    with pytest.raises(flows_config.ConfigError) as refused:
+        flows_config.require("VEXA_UI_URL")
+    assert "VEXA_UI_URL" in str(refused.value)

--- a/deploy/compose/.env.example
+++ b/deploy/compose/.env.example
@@ -335,3 +335,55 @@ VEXA_UI_URL=
 # they were invited to — unset, it simply does not mention meetings. Same DSN the meetings services
 # use.
 MEETINGS_DB_URL=
+
+# ── flows: the reaction engine (flows-api) and its mail lane (flows-mailbox, profile `mailbox`) ──
+# Every key below is declared in core/flows/src/config.v1.json and checked against docker-compose.yml
+# by gate:config-contract. Both flows lanes read the same set: they are one image under two commands.
+
+# The operator key gating POST /flows and POST /events. NO DEFAULT ON PURPOSE — flows refuses to
+# start without it, and refuses the published placeholders (`changeme`, `vexa-internal-secret`, …)
+# by name. `openssl rand -hex 32`.
+VEXA_FLOWS_API_KEY=
+# admin-api's admin key under the name flows reads it by. Defaults to ADMIN_TOKEN; set it only to
+# give flows a different credential from the one the rest of the stack uses.
+VEXA_FLOWS_ADMIN_KEY=
+# A read-only key that opens GET /timeline and nothing else. Unset, only the operator key does.
+VEXA_FLOWS_TIMELINE_KEY=
+# agent-api's internal tier. UNSET MEANS THIS DEPLOYMENT DOES NOT RUN THE AGENT DOMAIN (PRD 40.7):
+# flow steps that would dispatch an agent turn answer `not_present`. That is a product, not a fault.
+VEXA_FLOWS_AGENT_API_URL=
+# Where the assembler asks flows for its tool manifest. Defaults to the service; set it EMPTY to run
+# a deployment that does not carry the flows domain at all.
+VEXA_FLOWS_API_URL=
+FLOWS_API_HOST_PORT=18200
+
+# The mailbox. Empty = no mail intake, which is what the `mailbox` profile being off means.
+VEXA_MAIL_ADDR=
+VEXA_MAIL_APP_PASSWORD=
+VEXA_MAIL_INBOX=imap
+VEXA_MAIL_SMTP_HOST=
+VEXA_MAIL_SMTP_PORT=25
+VEXA_MAILPIT_URL=
+VEXA_MAILPIT_LOOKBACK_S=300
+VEXA_NOTIFY_CHANNEL=smtp
+# WHO THE MAILBOX WILL ACT FOR (R-B12). UNSET IS NOT `EVERYONE` — it means the mailbox's own
+# domain, so empty is the safe value here and not a hole. Comma-separated, with or without a `@`.
+VEXA_FLOWS_MAIL_DOMAINS=
+# `1` answers a quarantined stranger ONCE with a fixed one-liner. Off by default: any automatic
+# reply to an unverified sender is a reflector.
+VEXA_FLOWS_MAIL_QUARANTINE_REPLY=
+# The ceilings on what one inbox can cost, per sender and for the whole deployment, per window.
+VEXA_FLOWS_MAIL_RATE_PER_SENDER=12
+VEXA_FLOWS_MAIL_RATE_GLOBAL=120
+VEXA_FLOWS_MAIL_RATE_WINDOW_S=3600
+VEXA_FLOWS_MAIL_BODY_MAX=4000
+
+# The OUTBOUND fan-out allow-list; unset = the organizer's own domain. And this deployment's own
+# sentence about where the words live, carried in what it mails.
+VEXA_FLOWS_ATTENDEE_DOMAINS=
+VEXA_FLOWS_DATA_STATEMENT=
+# A private behavior tree mounted over the showcase baked into the image (PRD decision 12).
+# EMPTY IS THE OSS PRODUCT.
+VEXA_BEHAVIOR_DIR=
+VEXA_FLOWS_USER_KEY_TTL_S=900
+VEXA_TIMELINE_SCAN_ROWS=2000

--- a/deploy/compose/README.md
+++ b/deploy/compose/README.md
@@ -12,6 +12,39 @@ slim image from `<service>/Dockerfile`:
 | agent-api    | `core/agent/services/agent-api`        | 18100     | `uvicorn control_plane.api`        |
 | gateway      | `core/gateway/services/gateway`        | 18056     | `python -m gateway`                |
 | terminal     | `clients/terminal`                     | 13000     | Next.js custom server              |
+| mcp          | `core/meetings/services/mcp`           | 18010     | the MCP transport                  |
+| flows-api    | repo root, `core/flows/Dockerfile`     | 18200     | `python -m flows_integrations.flows_api` |
+| flows-mailbox| repo root, `core/flows/Dockerfile`     | —         | `python -m flows_integrations.mailbox` (profile `mailbox`) |
+
+### flows, and what it replaces
+
+`flows-api` is the reaction engine's HTTP surface and one of the domains the MCP assembly asks for
+a tool manifest (PRD decision 40): `mcp` fetches `/.well-known/mcp-tools.json` from it, so a stack
+that runs flows serves flows' tools on the one MCP surface, and one that does not simply serves
+fewer. Before this service existed the engine ran as HOST processes beside the stack and `mcp` was
+pointed at the docker BRIDGE ADDRESS of that host lane — a host-specific IP written into a
+deployment, for a service the deployment did not run. `FLOWS_API_URL` now defaults to
+`http://flows-api:8200`; set it to point at a flows elsewhere, or set it EMPTY to run a deployment
+that genuinely does not carry the domain.
+
+An existing deployment that reaches flows through such a bridge keeps working: its
+`VEXA_FLOWS_API_URL` override still wins over the new default, so the host lane and any listener
+in front of it retire on the operator's own schedule, after the stack is cut over — not on the day
+this merges.
+
+`flows-mailbox` is the inbound mail lane (IMAP poll → `POST /events`), the same image under a
+different command and with the same environment. It is behind the `mailbox` COMPOSE PROFILE and
+therefore off by default, because mail is an optional intake: a lane started without real IMAP
+credentials restart-loops and reads as a broken stack. Turn it on with `--profile mailbox` (or
+`COMPOSE_PROFILES=mailbox`) once `VEXA_MAIL_ADDR` and `VEXA_MAIL_APP_PASSWORD` are set. Do not
+scale it — the IMAP cursor is single-writer by design.
+
+Two things flows will refuse, and both are deliberate: it will not start without
+`VEXA_FLOWS_API_KEY`, `VEXA_FLOWS_ADMIN_KEY` and `INTERNAL_API_SECRET` (a weak default makes an
+unconfigured deployment look configured), and it will refuse to compose a mailed link when
+`VEXA_UI_URL` is unset — at the link, not at boot, because a deployment may legitimately have no
+terminal. Every key it reads is declared in `core/flows/src/config.v1.json` and checked against
+this file by `gate:config-contract`.
 
 Every service answers `GET /health` and carries a compose healthcheck; `depends_on` waits on
 `condition: service_healthy` so the bring-up is ordered. The `runtime` mounts

--- a/deploy/compose/docker-compose.yml
+++ b/deploy/compose/docker-compose.yml
@@ -511,6 +511,221 @@ services:
     networks: [vexa]
     restart: unless-stopped
 
+  # flows-api — the reaction engine's HTTP surface, and one of the domains the MCP assembly asks
+  # for a tool manifest (PRD decision 40).
+  #
+  # WHAT THIS REPLACES. The flows lanes run on the dogfood rig as HOST processes out of
+  # `flows-up.sh`, on loopback :18200/:18201, and the compose-network `mcp` service was pointed at
+  # the docker BRIDGE ADDRESS of that host lane so it could fetch /.well-known/mcp-tools.json — a
+  # host-specific IP written into a deployment, for a service the deployment did not run. This is
+  # the service. The host lane keeps working unchanged until the estate cuts over: the bind address
+  # defaults to loopback in code and is widened HERE, in the container's own environment, so the
+  # exposure is visible next to the port that publishes it.
+  #
+  # ONE IMAGE, THREE ENTRYPOINTS, ONE CONFIGURATION. `flows-api` and `flows-mailbox` differ by
+  # `command` and by nothing else, so they carry the SAME environment: the config.v1 declaration
+  # belongs to the flows domain, not to one of its processes, and a lane configured differently
+  # from its sibling is how a mail policy comes to hold in one place and not the other. The WORKER
+  # is the image's default command and is not started here yet — it is the next lane out of the
+  # rig, and it is not what the MCP assembly needs.
+  flows-api:
+    build:
+      # The repo ROOT: the image COPYs core/flows/src AND the behavior showcase at behavior/.
+      context: ../..
+      dockerfile: core/flows/Dockerfile
+    image: vexaai/v012-flows:${IMAGE_TAG:-dev}
+    command: ["python", "-m", "flows_integrations.flows_api"]
+    ports:
+      # Loopback-published for debugging, like every other service here; overridable so two stacks
+      # can share a host.
+      - "127.0.0.1:${FLOWS_API_HOST_PORT:-18200}:8200"
+    environment:
+      # ── the listener ────────────────────────────────────────────────────────────────────────
+      # In a container, loopback is THIS container's loopback — nothing else on the network can
+      # reach it. That is the whole reason the bridge-address hack existed. Said out loud here
+      # rather than flipped as a code default, which would have published the rig's host lane on
+      # every interface of that box the day it merged.
+      - VEXA_FLOWS_API_HOST=0.0.0.0
+      - VEXA_FLOWS_API_PORT=${VEXA_FLOWS_API_PORT:-8200}
+      - VEXA_FLOWS_DB_URL=postgresql+psycopg://${DB_USER:-postgres}:${DB_PASSWORD:-postgres}@postgres:5432/${DB_NAME:-vexa}
+      # ── the credentials, all fail-closed (#1453, F95) ───────────────────────────────────────
+      # NO DEFAULT AND NO `:?`. No default because a weak one makes an unconfigured deployment look
+      # configured — that is F95's whole lesson, and `flows_steps/common.py` refuses the published
+      # placeholder literals by name. No `:?` either, though it is tempting: compose evaluates it
+      # while PARSING THE FILE, so it fails `docker compose config` for the entire stack, including
+      # deployments that do not run flows at all. The refusal belongs to the process that needs the
+      # secret, where it names itself and stops only itself — and it is already there, and tested.
+      - VEXA_FLOWS_API_KEY=${VEXA_FLOWS_API_KEY:-}
+      # admin-api's OWN token, under the name flows reads it by. One credential, two spellings, is
+      # what F95 was; this is the second spelling of ADMIN_TOKEN and it is passed through, never
+      # re-defaulted to a literal of its own.
+      - VEXA_FLOWS_ADMIN_KEY=${VEXA_FLOWS_ADMIN_KEY:-${ADMIN_TOKEN:-}}
+      - INTERNAL_API_SECRET=${INTERNAL_API_SECRET:-}
+      - VEXA_FLOWS_TIMELINE_KEY=${VEXA_FLOWS_TIMELINE_KEY:-}
+      # ── the doors (#1453 made these required-explicit) ──────────────────────────────────────
+      # Service names on the compose network. An unnamed door is a loud refusal at the moment it
+      # would have been used, so naming them here is what makes the refusal never fire in a stack
+      # that does run these domains.
+      - VEXA_FLOWS_ADMIN_API_URL=http://admin-api:8001
+      - VEXA_FLOWS_GATEWAY_URL=http://gateway:8000
+      # OPTIONAL DOMAIN, and the reason it is a variable rather than a service name: decision 40
+      # says a deployment may not run the agent domain at all. Unset, steps that need it answer
+      # `not_present` instead of reaching for a door that is not there (#1453).
+      - VEXA_FLOWS_AGENT_API_URL=${VEXA_FLOWS_AGENT_API_URL:-}
+      # THE LINK PORT, not a door (PRD decision 4: flows owns a link port, the terminal is one
+      # adapter, the no-agents product has none). Unset, nothing is mailed with a link and any step
+      # that would compose one refuses naming this key — it no longer decides whether flows BOOTS.
+      - VEXA_UI_URL=${VEXA_UI_URL:-}
+      # ── the mailbox (read by the flows-mailbox lane below; one image, one declaration) ───────
+      - VEXA_MAIL_INBOX=${VEXA_MAIL_INBOX:-imap}
+      - VEXA_MAIL_ADDR=${VEXA_MAIL_ADDR:-}
+      - VEXA_MAIL_APP_PASSWORD=${VEXA_MAIL_APP_PASSWORD:-}
+      - VEXA_MAIL_SMTP_HOST=${VEXA_MAIL_SMTP_HOST:-}
+      - VEXA_MAIL_SMTP_PORT=${VEXA_MAIL_SMTP_PORT:-25}
+      - VEXA_MAILPIT_URL=${VEXA_MAILPIT_URL:-}
+      - VEXA_MAILPIT_LOOKBACK_S=${VEXA_MAILPIT_LOOKBACK_S:-300}
+      - VEXA_NOTIFY_CHANNEL=${VEXA_NOTIFY_CHANNEL:-smtp}
+      # ── who the mailbox will act for (R-B12) ────────────────────────────────────────────────
+      # UNSET IS NOT `EVERYONE`: unset means the mailbox's own domain. Empty here is therefore the
+      # safe value and not a hole.
+      - VEXA_FLOWS_MAIL_DOMAINS=${VEXA_FLOWS_MAIL_DOMAINS:-}
+      - VEXA_FLOWS_MAIL_QUARANTINE_REPLY=${VEXA_FLOWS_MAIL_QUARANTINE_REPLY:-}
+      - VEXA_FLOWS_MAIL_RATE_PER_SENDER=${VEXA_FLOWS_MAIL_RATE_PER_SENDER:-12}
+      - VEXA_FLOWS_MAIL_RATE_GLOBAL=${VEXA_FLOWS_MAIL_RATE_GLOBAL:-120}
+      - VEXA_FLOWS_MAIL_RATE_WINDOW_S=${VEXA_FLOWS_MAIL_RATE_WINDOW_S:-3600}
+      - VEXA_FLOWS_MAIL_BODY_MAX=${VEXA_FLOWS_MAIL_BODY_MAX:-4000}
+      # ── behaviour and content ───────────────────────────────────────────────────────────────
+      - VEXA_FLOWS_ATTENDEE_DOMAINS=${VEXA_FLOWS_ATTENDEE_DOMAINS:-}
+      - VEXA_FLOWS_DATA_STATEMENT=${VEXA_FLOWS_DATA_STATEMENT:-}
+      # The private behavior tree a deployment mounts (decision 12). EMPTY IS THE OSS PRODUCT: the
+      # showcase baked into the image at /behavior is what flows reads.
+      - VEXA_BEHAVIOR_DIR=${VEXA_BEHAVIOR_DIR:-}
+      - VEXA_JITSI_HOSTS=${VEXA_JITSI_HOSTS:-}
+      - VEXA_FLOWS_USER_KEY_TTL_S=${VEXA_FLOWS_USER_KEY_TTL_S:-900}
+      - VEXA_TIMELINE_SCAN_ROWS=${VEXA_TIMELINE_SCAN_ROWS:-2000}
+      # Set uniformly across this stack; the flows processes log through uvicorn's own level and do
+      # not read it. Carried in the declaration's `surface_only` list with that reason, so
+      # `gate:config-contract` records the drift instead of ignoring it.
+      - LOG_LEVEL=${LOG_LEVEL:-info}
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request,sys; sys.exit(0 if urllib.request.urlopen('http://localhost:8200/health').status==200 else 1)"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+    init: true
+    depends_on:
+      # WHAT IT CANNOT BOOT WITHOUT, and nothing else: its own database, and IDENTITY — the one
+      # domain decision 40.7 lets everybody depend on. Not meeting-api, not agent-api, not the
+      # terminal: flows reaches those at STEP time, and 40.7's whole point is that a deployment may
+      # not carry them. A depends_on there would turn an optional domain into a boot requirement.
+      postgres:
+        condition: service_healthy
+      admin-api:
+        condition: service_healthy
+    networks: [vexa]
+    restart: unless-stopped
+
+  # flows-mailbox — the inbound mail lane: IMAP poll → `POST /events` on the engine. Same image,
+  # same configuration, different command.
+  #
+  # UNDER A PROFILE, and that is the product statement: mail is an OPTIONAL INTAKE. The no-agents
+  # MCP product boots identity + meetings + flows + mcp + gateway and never touches a mailbox, so
+  # a lane that needs a real IMAP credential must not be in the default `docker compose up` — it
+  # would restart-loop on a stock stack and read as a broken deployment. `--profile mailbox`, or
+  # `COMPOSE_PROFILES=mailbox`, turns it on once the mail credentials are actually set.
+  #
+  # SINGLE WRITER: the IMAP cursor is single-writer by design (helm pins replicas: 1 for the same
+  # reason). Do not scale this service.
+  flows-mailbox:
+    profiles: ["mailbox"]
+    build:
+      context: ../..
+      dockerfile: core/flows/Dockerfile
+    image: vexaai/v012-flows:${IMAGE_TAG:-dev}
+    command: ["python", "-m", "flows_integrations.mailbox"]
+    environment:
+      # ── the listener ────────────────────────────────────────────────────────────────────────
+      # In a container, loopback is THIS container's loopback — nothing else on the network can
+      # reach it. That is the whole reason the bridge-address hack existed. Said out loud here
+      # rather than flipped as a code default, which would have published the rig's host lane on
+      # every interface of that box the day it merged.
+      - VEXA_FLOWS_API_HOST=0.0.0.0
+      - VEXA_FLOWS_API_PORT=${VEXA_FLOWS_API_PORT:-8200}
+      - VEXA_FLOWS_DB_URL=postgresql+psycopg://${DB_USER:-postgres}:${DB_PASSWORD:-postgres}@postgres:5432/${DB_NAME:-vexa}
+      # ── the credentials, all fail-closed (#1453, F95) ───────────────────────────────────────
+      # NO DEFAULT AND NO `:?`. No default because a weak one makes an unconfigured deployment look
+      # configured — that is F95's whole lesson, and `flows_steps/common.py` refuses the published
+      # placeholder literals by name. No `:?` either, though it is tempting: compose evaluates it
+      # while PARSING THE FILE, so it fails `docker compose config` for the entire stack, including
+      # deployments that do not run flows at all. The refusal belongs to the process that needs the
+      # secret, where it names itself and stops only itself — and it is already there, and tested.
+      - VEXA_FLOWS_API_KEY=${VEXA_FLOWS_API_KEY:-}
+      # admin-api's OWN token, under the name flows reads it by. One credential, two spellings, is
+      # what F95 was; this is the second spelling of ADMIN_TOKEN and it is passed through, never
+      # re-defaulted to a literal of its own.
+      - VEXA_FLOWS_ADMIN_KEY=${VEXA_FLOWS_ADMIN_KEY:-${ADMIN_TOKEN:-}}
+      - INTERNAL_API_SECRET=${INTERNAL_API_SECRET:-}
+      - VEXA_FLOWS_TIMELINE_KEY=${VEXA_FLOWS_TIMELINE_KEY:-}
+      # ── the doors (#1453 made these required-explicit) ──────────────────────────────────────
+      # Service names on the compose network. An unnamed door is a loud refusal at the moment it
+      # would have been used, so naming them here is what makes the refusal never fire in a stack
+      # that does run these domains.
+      - VEXA_FLOWS_ADMIN_API_URL=http://admin-api:8001
+      - VEXA_FLOWS_GATEWAY_URL=http://gateway:8000
+      # OPTIONAL DOMAIN, and the reason it is a variable rather than a service name: decision 40
+      # says a deployment may not run the agent domain at all. Unset, steps that need it answer
+      # `not_present` instead of reaching for a door that is not there (#1453).
+      - VEXA_FLOWS_AGENT_API_URL=${VEXA_FLOWS_AGENT_API_URL:-}
+      # THE LINK PORT, not a door (PRD decision 4: flows owns a link port, the terminal is one
+      # adapter, the no-agents product has none). Unset, nothing is mailed with a link and any step
+      # that would compose one refuses naming this key — it no longer decides whether flows BOOTS.
+      - VEXA_UI_URL=${VEXA_UI_URL:-}
+      # ── the mailbox (read by the flows-mailbox lane below; one image, one declaration) ───────
+      - VEXA_MAIL_INBOX=${VEXA_MAIL_INBOX:-imap}
+      - VEXA_MAIL_ADDR=${VEXA_MAIL_ADDR:-}
+      - VEXA_MAIL_APP_PASSWORD=${VEXA_MAIL_APP_PASSWORD:-}
+      - VEXA_MAIL_SMTP_HOST=${VEXA_MAIL_SMTP_HOST:-}
+      - VEXA_MAIL_SMTP_PORT=${VEXA_MAIL_SMTP_PORT:-25}
+      - VEXA_MAILPIT_URL=${VEXA_MAILPIT_URL:-}
+      - VEXA_MAILPIT_LOOKBACK_S=${VEXA_MAILPIT_LOOKBACK_S:-300}
+      - VEXA_NOTIFY_CHANNEL=${VEXA_NOTIFY_CHANNEL:-smtp}
+      # ── who the mailbox will act for (R-B12) ────────────────────────────────────────────────
+      # UNSET IS NOT `EVERYONE`: unset means the mailbox's own domain. Empty here is therefore the
+      # safe value and not a hole.
+      - VEXA_FLOWS_MAIL_DOMAINS=${VEXA_FLOWS_MAIL_DOMAINS:-}
+      - VEXA_FLOWS_MAIL_QUARANTINE_REPLY=${VEXA_FLOWS_MAIL_QUARANTINE_REPLY:-}
+      - VEXA_FLOWS_MAIL_RATE_PER_SENDER=${VEXA_FLOWS_MAIL_RATE_PER_SENDER:-12}
+      - VEXA_FLOWS_MAIL_RATE_GLOBAL=${VEXA_FLOWS_MAIL_RATE_GLOBAL:-120}
+      - VEXA_FLOWS_MAIL_RATE_WINDOW_S=${VEXA_FLOWS_MAIL_RATE_WINDOW_S:-3600}
+      - VEXA_FLOWS_MAIL_BODY_MAX=${VEXA_FLOWS_MAIL_BODY_MAX:-4000}
+      # ── behaviour and content ───────────────────────────────────────────────────────────────
+      - VEXA_FLOWS_ATTENDEE_DOMAINS=${VEXA_FLOWS_ATTENDEE_DOMAINS:-}
+      - VEXA_FLOWS_DATA_STATEMENT=${VEXA_FLOWS_DATA_STATEMENT:-}
+      # The private behavior tree a deployment mounts (decision 12). EMPTY IS THE OSS PRODUCT: the
+      # showcase baked into the image at /behavior is what flows reads.
+      - VEXA_BEHAVIOR_DIR=${VEXA_BEHAVIOR_DIR:-}
+      - VEXA_JITSI_HOSTS=${VEXA_JITSI_HOSTS:-}
+      - VEXA_FLOWS_USER_KEY_TTL_S=${VEXA_FLOWS_USER_KEY_TTL_S:-900}
+      - VEXA_TIMELINE_SCAN_ROWS=${VEXA_TIMELINE_SCAN_ROWS:-2000}
+      # Set uniformly across this stack; the flows processes log through uvicorn's own level and do
+      # not read it. Carried in the declaration's `surface_only` list with that reason, so
+      # `gate:config-contract` records the drift instead of ignoring it.
+      - LOG_LEVEL=${LOG_LEVEL:-info}
+    init: true
+    depends_on:
+      # The same two, and for the same reason — plus flows-api, because this lane's whole output is
+      # `POST /events` against it. That is not a domain dependency; it is this process talking to
+      # its own domain's API.
+      postgres:
+        condition: service_healthy
+      admin-api:
+        condition: service_healthy
+      flows-api:
+        condition: service_healthy
+    networks: [vexa]
+    restart: unless-stopped
+
   # MCP service — the Model Context Protocol front for the PUBLIC API (v0.12 port of 0.10.6
   # services/mcp). Stateless: every tool call forwards the caller's key to the gateway as
   # X-API-Key. Fronted at the gateway edge under /mcp (#795) — an MCP client points at the
@@ -536,7 +751,11 @@ services:
       - ADMIN_API_URL=http://admin-api:8001
       - MEETING_API_URL=http://meeting-api:8080
       - AGENT_API_URL=${AGENT_API_URL:-}
-      - FLOWS_API_URL=${VEXA_FLOWS_API_URL:-}
+      # DEFAULTS TO THE SERVICE. It used to default to empty, so a stack that ran flows still
+      # assembled without its tools unless somebody supplied a URL by hand — which is how a
+      # docker bridge address came to be the answer. Override to point at a flows elsewhere;
+      # set it empty to run a deployment that genuinely does not carry the domain.
+      - FLOWS_API_URL=${VEXA_FLOWS_API_URL:-http://flows-api:8200}
       # A private deployment mounts its own manifests here — billing, seats, entitlement — and they
       # are assembled exactly like the OSS ones, competing for names in the same space so a mount
       # can collide but never shadow. EMPTY IS THE OSS PRODUCT, exactly.

--- a/deploy/compose/tests/flows_wiring_test.py
+++ b/deploy/compose/tests/flows_wiring_test.py
@@ -1,0 +1,134 @@
+"""flows-api as a compose service, and the assembler wired to it (offline — no stack, no docker).
+
+The live proof is a real boot on bbb: bring up identity + meetings + flows + mcp + gateway with the
+agent domain ABSENT, and the MCP assembly at the gateway's `/mcp` must show flows' four tools
+beside the 14. These assertions pin the WIRING that proof depends on, so it cannot rot between runs
+of an expensive test — and so a reviewer can see, without a stack, that the interim was actually
+replaced.
+
+THE INTERIM THIS REPLACES: the flows lanes run on the host out of `~/.storm/flows-up.sh` on
+loopback :18200/:18201, and the compose-network `mcp` service was pointed at the docker BRIDGE
+ADDRESS of that host lane so it could fetch `/.well-known/mcp-tools.json`. A host-specific IP,
+written into a deployment, for a service the deployment does not run.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[3]
+COMPOSE = ROOT / "deploy" / "compose" / "docker-compose.yml"
+
+
+def _service(name: str) -> str:
+    """One service block, as text — the same line-wise read `gate:config-contract` uses."""
+    lines = COMPOSE.read_text().split("\n")
+    start = next(i for i, l in enumerate(lines) if l.rstrip() == f"  {name}:")
+    end = len(lines)
+    for i in range(start + 1, len(lines)):
+        if lines[i][:3].strip() and not lines[i].startswith("   ") and lines[i].strip():
+            end = i
+            break
+    return "\n".join(lines[start:end])
+
+
+def test_the_stack_defines_a_flows_api_service():
+    block = _service("flows-api")
+    assert "context: ../.." in block, "flows' image builds from the repo root (it COPYs behavior/)"
+    assert "core/flows/Dockerfile" in block
+    assert "flows_integrations.flows_api" in block, "the api entrypoint is a command override"
+
+
+def test_flows_api_listens_on_the_network_not_its_own_loopback():
+    """The single reason the bridge-address hack existed. Said out loud in the service's own
+    environment rather than flipped as a default, so the exposure is visible where the port is."""
+    block = _service("flows-api")
+    assert "VEXA_FLOWS_API_HOST=0.0.0.0" in block
+    assert re.search(r"VEXA_FLOWS_API_PORT=\$\{VEXA_FLOWS_API_PORT:-8200\}", block), block
+
+
+def test_flows_api_has_a_healthcheck_and_depends_on_identity_only():
+    """`depends_on` names what flows-api cannot start without: its database and the identity it
+    authenticates against. NOT meeting-api, NOT agent-api — flows reaches those at step time and
+    the whole point of decision 40's assembly is that a deployment may not run them at all. A
+    depends_on there would make an optional domain a boot requirement."""
+    block = _service("flows-api")
+    assert "healthcheck:" in block and "/health" in block
+
+    deps = block.split("depends_on:")[1]
+    assert "postgres:" in deps and "admin-api:" in deps, deps
+    for optional in ("meeting-api", "agent-api", "mcp", "gateway"):
+        assert f"{optional}:" not in deps, f"{optional} is not something flows-api needs to BOOT"
+
+
+def test_the_doors_are_service_names():
+    """#1453 made the doors required-explicit: unnamed is a loud refusal at the moment of use.
+    On the compose network they are service names — never a host IP, never a bridge address."""
+    block = _service("flows-api")
+    assert "VEXA_FLOWS_ADMIN_API_URL=http://admin-api:8001" in block
+    assert "VEXA_FLOWS_GATEWAY_URL=http://gateway:8000" in block
+
+    # The ENVIRONMENT only. A published port is `127.0.0.1:<port>` by design (loopback on the host,
+    # not the box's public interfaces) and the healthcheck's `localhost` is the container's own —
+    # both correct. What must never appear is a host address as a DOOR.
+    env = block.split("environment:")[1].split("healthcheck:")[0]
+    for banned in ("172.17.", "172.18.", "host.docker.internal", "127.0.0.1", "localhost"):
+        assert banned not in env, f"a host-specific address survives as a door: {banned}"
+
+
+def test_the_assembler_is_pointed_at_the_service():
+    """THE POINT OF THE BRANCH. `mcp` asked for flows' manifest at whatever `VEXA_FLOWS_API_URL`
+    said, which is how a bridge address ended up being the answer. It now defaults to the service."""
+    block = _service("mcp")
+    assert re.search(r"FLOWS_API_URL=\$\{VEXA_FLOWS_API_URL:-http://flows-api:8200\}", block), \
+        "mcp still has no default route to the flows service"
+
+
+def test_the_mailbox_is_a_lane_of_its_own_and_off_by_default():
+    """Mail is an OPTIONAL INTAKE, and a profile is how compose says so.
+
+    The no-agents MCP product boots identity + meetings + flows + mcp + gateway and never touches a
+    mailbox. A lane that needs a real IMAP credential must therefore not be in the default
+    `docker compose up`: it would restart-loop on a stock stack and read as a broken deployment,
+    which is the same defect as a capability shipped dark, pointing the other way."""
+    block = _service("flows-mailbox")
+    assert 'profiles: ["mailbox"]' in block, "the mail lane must not start on a stock stack"
+    assert "flows_integrations.mailbox" in block, "the mailbox entrypoint is a command override"
+    assert "core/flows/Dockerfile" in block, "same image as flows-api — one image, three entrypoints"
+
+
+def test_both_flows_lanes_carry_the_same_configuration():
+    """ONE DECLARATION, TWO LANES. `config.v1` is declared for the flows DOMAIN, and
+    `gate:config-contract` reads the flows-api block; a mail policy that held in one lane and not
+    the other would pass that gate and still be wrong. Same keys, both lanes."""
+    def keys(name):
+        lines = _service(name).split("\n")
+        start = lines.index("    environment:") + 1
+        out = set()
+        for line in lines[start:]:
+            if line.strip() and not line.startswith("      "):
+                break
+            m = re.match(r"\s*-\s*([A-Z][A-Z0-9_]*)=", line)
+            if m:
+                out.add(m.group(1))
+        return out
+
+    api, mailbox = keys("flows-api"), keys("flows-mailbox")
+    assert api == mailbox, {"only flows-api": sorted(api - mailbox),
+                            "only flows-mailbox": sorted(mailbox - api)}
+    assert "VEXA_FLOWS_MAIL_DOMAINS" in mailbox, "the intake allow-list must reach the intake"
+
+
+def test_the_link_port_is_declared_and_may_be_empty():
+    """PRD decision 4: flows owns a link port, the terminal is one adapter, and the no-agents
+    product has none. Empty is a deployment with no terminal — not a deployment that cannot boot,
+    which is what a required-explicit door made it."""
+    for lane in ("flows-api", "flows-mailbox"):
+        assert "VEXA_UI_URL=${VEXA_UI_URL:-}" in _service(lane), lane
+
+
+def test_the_host_port_is_overridable_and_bound_to_loopback():
+    """Published for debugging like every other service here, on 127.0.0.1 so it is not on the
+    box's public interfaces, and overridable so two stacks can share a host."""
+    block = _service("flows-api")
+    assert re.search(r'"127\.0\.0\.1:\$\{FLOWS_API_HOST_PORT:-\d+\}:8200"', block), block

--- a/scripts/gates.mjs
+++ b/scripts/gates.mjs
@@ -989,6 +989,24 @@ const CONFIG_ADOPTED = [
     compose: "mcp", helm: [], lite: null,
   },
   {
+    // #1453 + the compose-service branch: flows is a DEPLOYABLE DOMAIN now, not a pair of host
+    // lanes out of a rig script, and the seam backlog's B7 ("the config-contract gate is green
+    // over less than half the seam") named this brick by hand. `core/flows/src/flows_config.py`
+    // was written to make this adoption a transcription — one table, both directions asserted by
+    // its own test — and this entry is that transcription arriving.
+    // ONE DECLARATION, TWO COMPOSE LANES: `flows-api` and `flows-mailbox` are the same image under
+    // different commands and carry the same environment, so the declaration belongs to the domain
+    // and the entry binds it to the API lane.
+    // helm/lite are EMPTY: the flows helm chart plumbs its keys through a Secret's `stringData`,
+    // which the line-wise `- name:` scan cannot see, and there is no supervisord program at all.
+    // Naming a surface this check cannot actually read would be worse than saying it is not read.
+    service: "flows-api",
+    decl: "core/flows/src/config.v1.json",
+    preflight: "core/flows/src/config_preflight.py",
+    scan: ["core/flows/src"],
+    compose: "flows-api", helm: [], lite: null,
+  },
+  {
     service: "gateway",
     decl: "core/gateway/services/gateway/src/gateway/config.v1.json",
     preflight: "core/gateway/services/gateway/src/gateway/config_preflight.py",


### PR DESCRIPTION
**Delivers issue:** #1475

## Contribution rights
<!-- Select exactly ONE. This is a legal certification: an agent may explain the choices but
     must not select one for you. See CONTRIBUTOR_RIGHTS.md. -->

- [ ] **Independent:** I created this contribution, or otherwise have the right to submit it
  under Apache-2.0, and it is not owned or controlled by an employer, client, or other entity.
  <!-- rights:independent -->
- [ ] **Employer/client authorization required:** an employer, client, or other entity owns or
  may control this contribution. I am requesting Vexa's private corporate-authorization process.
  <!-- rights:corporate -->
- [ ] **Unsure:** I need a private rights review before merge.
  <!-- rights:uncertain -->

Every commit must also carry the contributor's own DCO `Signed-off-by` line. Selecting the
independent path means no individual CLA is required. Corporate and unsure paths do not stop
technical review, but they do block merge until resolved.

## Observation bundle (the record of your harnessed loop)

Ran on `bbb`, throwaway compose project `fcproof2`, torn down completely afterwards. Base
`a5ba8e952` (tip of `minutes-mcp-viewer`), head `510235a1a`.

- **C1 — flows-api serves, in a container, the routes it serves in a test.**
  Ran: built the flows image and booted `flows-api` on the compose network, then fetched
  `/health` and `/.well-known/mcp-tools.json` from the host and from inside the `mcp` container.
  Saw, on the first boot: `/health` 200, and **`/.well-known/mcp-tools.json` 404** — a route the
  offline suite proves exists and serves exactly the right four tools. Concluded: two defects the
  test lane structurally cannot see, and the reason this acceptance is a live boot.
  1. The image never carried `mcp.tools.v1.json`. `docker exec … ls /app` showed `schema.sql` and
     `src` and nothing else; the route reads the manifest beside `src/`, so it could only ever 503.
  2. The real one: `/openapi.json` listed 8 paths and the manifest route was **not registered at
     all**. `if __name__ == "__main__": raise SystemExit(main())` sat in the MIDDLE of the module,
     above the route. Every deployment starts this file with `python -m`, so `__name__` IS
     `__main__`: the guard fires, `main()` blocks inside `uvicorn.run`, and nothing below it
     executes. The offline suite IMPORTS the module — `__name__` is not `__main__`, the whole file
     runs, the route exists. Green offline, absent live.
  The guard is now the last statement in the file, and the new test reads the SOURCE for it, since
  a test that imports can never catch this. Also removed this branch's second `@app.get("/health")`
  — #1431 added one to the line while this was in flight, FastAPI keeps both with the first
  answering, so the second was dead code that reads as live.

- **C2 — a deployment with no terminal and no agent domain boots.**
  Ran: `flows_config.preflight()` against the base sha's own declaration with the doors named and
  no terminal, then the same at head. Saw: base **refuses** — `this flows deployment cannot name
  VEXA_UI_URL` — head boots. Then the live boot with `VEXA_UI_URL=""` and
  `VEXA_FLOWS_AGENT_API_URL=""` in the container's environment: healthy. Concluded: the WIP fix to
  the import was necessary and not sufficient — two mechanisms made a step-time link decide the
  boot, and only the container found the second.

- **C3 — flows is a compose service, and the assembler is pointed at it.**
  Ran: brought up identity + meetings + flows + mcp + gateway with the agent domain absent; MCP
  `initialize` + `tools/list` through the gateway's `/mcp`. Saw: 18 tools = 14 + flows' 4; then,
  with the assembler pointed at an unreachable flows URL, 14 and none of the four. Concluded: the
  four are served by the running service, not baked into the assembler — the assembly degrades to
  a smaller product rather than a broken one, which is what decision 40 asks for.

- **C4 — the mail lane is deployable and off by default.**
  Ran: `docker compose config --services`, with and without `--profile mailbox`. Saw the lane
  present only under the profile. Concluded: an operator with no IMAP credentials is not handed a
  restart-looping container, and one who wants mail starts it with a flag.

- **C5 — `gate:config-contract` covers flows.**
  Ran: the gate, and the new declaration through the contract's own validator. Saw: 6 → **7
  adopted services**, 309 declared keys, 23 capabilities. Concluded: the seam backlog's B7 is
  closed for this brick. `flows_config.DECLARED` stays (its accessors refuse an undeclared name at
  the READ, which JSON cannot), so a test holds the two declarations to the same keys, classes and
  defaults — two declarations of one fact is the shape F95 was.

## Acceptance floor

| Row | Evidence |
|---|---|
| **A1** | Head `510235a1a`, project `fcproof2`, 2026-09-03T10:38Z. `docker compose ps`: `admin-api`, `meeting-api`, `gateway`, `mcp`, `flows-api`, `postgres`, `redis`, `minio`, `runtime` — **all healthy**; `docker ps -a --filter name=fcproof2-agent` = **0**; container env `VEXA_UI_URL=[]`, `VEXA_FLOWS_AGENT_API_URL=[]`. flows-api boot line: `flows-api up on 0.0.0.0:8200 · vocabulary of 21 steps`. **RED at base `a5ba8e952`**: same preflight, doors named, no terminal → `ConfigError: this flows deployment cannot name VEXA_UI_URL` (base class of the key: `required-explicit`; head: `capability`). |
| **A2** | `curl http://127.0.0.1:28200/.well-known/mcp-tools.json` → **HTTP 200**, `domain=flows`, `['flows_list','reactions_list','reaction_signal','timeline']`. Over the compose network from inside the assembler: `docker exec fcproof2-mcp-1 … urlopen('http://flows-api:8200/.well-known/mcp-tools.json')` → **HTTP 200 · domain flows · 4 tools**. **RED, same branch, before the image + guard fix**: the identical request returned `HTTP/1.1 404 Not Found` `{"detail":"Not Found"}` from the running container, and `/openapi.json` listed the route nowhere. |
| **A3** | Through the gateway edge, `POST http://127.0.0.1:28056/mcp`: `initialize` 200 (`mcp-session-id: fa981b40…`), `tools/list` 200 → **18 tools = 14 + 4**. Full list: `annotate_meeting, flows_list, get_bot_status, get_meeting_chat, get_meeting_transcript, get_recording, list_meetings, list_recordings, parse_meeting_link, reaction_signal, reactions_list, report_issue, request_meeting_bot, search_transcripts, speak_in_meeting, stop_bot, timeline, update_bot_config`. Agent-domain tools present: **none**. **RED**: same stack, `VEXA_FLOWS_API_URL=http://flows-api-absent:8200`, `mcp` recreated → **14 tools**, flows' four absent. |
| **A4** | `whats_waiting` is **not** in the A3 list, and that is the scope line, not a gap: it becomes a flows tool in **slice 4**, which is a separate PR. Nothing in this diff serves it or should. |
| **A5** | `docker compose config --services` → `admin-api agent-api flows-api gateway mcp meeting-api minio minio-init postgres redis runtime terminal` (**no** `flows-mailbox`). With `--profile mailbox` → the same list **plus `flows-mailbox`**. |
| **A6** | Head: `✓ gate:config-contract — 7 adopted service(s) · 309 declared keys · 23 capabilities · declarations ≡ deploy surfaces ≡ code reads`. Base `a5ba8e952`: **6** adopted services (`CONFIG_ADOPTED` carries meeting-api, runtime, agent-api, admin-api, mcp, gateway). |
| **A7** | Control on A1 — the boot check moved, it was not disabled. Head, with `VEXA_FLOWS_GATEWAY_URL` unset: `ConfigError: this flows deployment cannot name VEXA_FLOWS_GATEWAY_URL — set each to the service it should reach…`. And the link port still refuses at its use site: `flows_config.require("VEXA_UI_URL")` raises naming the key (pinned by `test_the_link_port_still_refuses_at_the_moment_a_link_would_be_composed`). |
| **A-** | At head `510235a1a`: `core/flows` **415 passed, 5 skipped**; `core/meetings/services/mcp` **192 passed**; `deploy/compose/tests` static lanes **13 passed, 15 skipped** (`stack_test.py` needs a default-project stack and is CI's); the 14-gate pre-push set green (`readme dataflow isolation isolation-py exports graph graph-py schema contract-version config-contract licenses execution-env test-isolation contract-conformance`), which the hook re-ran on push. Full suite is CI's at head. |

## Docs diff (D6c)

| page | altitude | change |
|---|---|---|
| `deploy/compose/README.md` | reference | The service table gains `flows-api`, `flows-mailbox` and `mcp` (the last was already missing). A new section says what the flows service replaces, that `FLOWS_API_URL` now defaults to the service and empty still means "this deployment does not carry the domain", how the `mailbox` profile is turned on and why it is off, and the two things flows refuses and where each refusal fires. |
| `deploy/compose/.env.example` | reference | A flows block: every key an operator sets, with the ones that are SAFE empty said out loud — the inbound allow-list unset means *the mailbox's own domain*, never *everyone*, and an empty behavior dir *is* the OSS product. |
| `core/flows/src/config.v1.json` | reference (machine-readable) | The same truth in the form the gate reads: 35 keys with class, default, capability and why; 12 capabilities each with its `when_unconfigured` behaviour. |
| quickstart / concept pages | — | **No change, argued:** this makes an existing domain deployable. It does not change what a person does with Vexa, and the no-agents product's own story is #1465's. |

## Security checks (required on the diff)

- **Dependency + licence scan (architecture P17):** `gate:licenses` at head — `514 deps OSS-clean
  (Cat A; 2 Cat-B by exception: LGPL-3.0-or-later @img/sharp-libvips-linux-x64; MPL-2.0
  lightningcss)`. **This diff adds no dependency**: no `requirements`, `pyproject`, `package.json`
  or lockfile is touched.
- **Secrets scan:** the base..head diff carries no assigned credential-shaped literal. The changes
  move in the opposite direction — `VEXA_FLOWS_API_KEY`, `VEXA_FLOWS_ADMIN_KEY` and
  `INTERNAL_API_SECRET` are plumbed with **no default and no `:?`**, and the declaration carries
  each one's `forbidden_values` (the published placeholders `vexa-internal-secret`,
  `lite-internal-secret`, `changeme`, …), asserted equal to the list `flows_steps.common` refuses
  at the use sites. A refusal names the KEY, never the value — pinned by a test.
- **Exposure review of the one new surface:** `VEXA_FLOWS_API_HOST` defaults to loopback in code
  and is widened only in the container's own environment, beside the port that publishes it, so
  merging this cannot change the exposure of the host lanes that run the same process today. The
  published host port is `127.0.0.1:…`, like every other service here. `/health` and the manifest
  are the only unauthenticated routes and neither names data or a credential.
- **SAST:** not applicable to this diff (no new parsing, no new user-supplied input path); the
  maintainer's closing security bundle stands.

## Validation request

Any competent non-author with docker on a host. What to watch, in order:

1. `cp deploy/compose/.env.example .env`, set `ADMIN_TOKEN`, `INTERNAL_API_SECRET`,
   `VEXA_FLOWS_API_KEY`; leave `VEXA_UI_URL` and `VEXA_FLOWS_AGENT_API_URL` **empty**.
2. `docker compose up -d admin-api meeting-api gateway mcp flows-api` — flows-api reaches healthy
   with no terminal and no agent domain. That is the value.
3. Mint a token, `initialize` + `tools/list` against the gateway's `/mcp`: **18 tools**, the four
   flows ones among them, no agent tool. Then point `VEXA_FLOWS_API_URL` at something unreachable,
   recreate `mcp`, and see **14** — the four are the service's, not the assembler's.
4. Read `deploy/compose/README.md`'s flows section and `.env.example`'s flows block first, and say
   whether steps 1–3 were runnable from them alone. The docs story is part of what you are signing.

**Deployment validated by the author:** full compose on `bbb`, throwaway project `fcproof2`, built
fresh from repo sha `510235a1a` with `deploy/compose/docker-compose.yml`; env deltas from stock:
distinct host ports, `ADMIN_TOKEN`/`INTERNAL_API_SECRET`/`VEXA_FLOWS_API_KEY` set,
`VEXA_UI_URL` and `VEXA_FLOWS_AGENT_API_URL` empty, agent-api and terminal not started. The stack
was destroyed after the run (containers, volumes, network).

**Deployments this issue names and nobody ran:** Lite and k8s-helm are out of scope in #1475 and
stay honestly unclaimed. The helm chart's own flows gaps (the `flows-api` pod names no doors and
binds loopback) were found while writing the config.v1 adoption and are NOT fixed here — they are a
separate issue on the same seam.

**Migration notes for an operator (PRD decision 2 — operator-visible boot changes, stated):**
- `VEXA_FLOWS_ADMIN_KEY` is now plumbed to flows in compose, defaulting to `ADMIN_TOKEN`. A stack
  that sets neither will see flows refuse to act — deliberately, and with the key named.
- A deployment that reaches flows through a host lane keeps working unchanged: its
  `VEXA_FLOWS_API_URL` override still wins over the new default, so the lane and any listener in
  front of it retire when that deployment is cut over to the service, not when this merges. For
  the dogfood estate specifically, that cut-over is `FLOWS_API_URL` → `http://flows-api:8200` and
  the retirement of the nginx bridge listener on `172.20.0.1:18200`; **this PR does not perform
  it.**
- `VEXA_UI_URL` unset no longer refuses the boot. If your deployment HAS a terminal, keep setting
  it: the refusal now fires where a link would have been mailed.

## Authorship
Sole author: the human submitting this. No agent co-author trailers (D13).
Tooling disclosure (optional, welcome, never an attribution): prepared with a coding agent on `bbb`.

<!-- vexa-agent -->
