### PR TITLE
The gate script tests give the same verdict on the same tree every run: fixtures edit a private shadow, never the checkout

### DIFF
--- a/scripts/gates.test.mjs
+++ b/scripts/gates.test.mjs
@@ -9,10 +9,11 @@
 // stay green through exactly the bug it was written to catch. The planted file IS the input
 // population: `git grep --untracked` reads the working tree, so a file on disk is a real input.
 
-import test from "node:test";
+import test, { after } from "node:test";
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { writeFileSync, readFileSync, rmSync, mkdirSync, existsSync } from "node:fs";
+import { writeFileSync, readFileSync, rmSync, mkdirSync, mkdtempSync, existsSync, copyFileSync, lstatSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -117,30 +118,86 @@ test("a test-only create_async_engine does not invent a service in the budget", 
 
 // ════════════════════════════════════════════════════════════════════════════════════════════════
 // #653 — gate:image-licenses and gate:runtime-parity. Same plant-and-run-the-real-gate discipline: a
-// gate that never reds on the input it was written to catch is theatre. These edit a tracked deploy
-// file in place, run the real gate as a subprocess, and restore — so each RED is the actual pipeline
-// firing, not a stubbed parse. Every fixture is paired with the vacuity control that the clean tree
-// is green (a red there would invalidate the fixture below it).
+// gate that never reds on the input it was written to catch is theatre. Each fixture edits a deploy
+// file, runs the real gate as a subprocess, and restores — so each RED is the actual pipeline firing,
+// not a stubbed parse. Every fixture is paired with the vacuity control that the clean tree is green
+// (a red there would invalidate the fixture below it).
+//
+// The edit lands in a PRIVATE SHADOW of the working tree, never in the checkout (#1106). `node --test`
+// runs every test file concurrently, and the checkout is read by the others: sbom.test.mjs reads
+// deploy/lite/Dockerfile.lite and asserts the very marker the runtime-parity fixture below replaces,
+// so an in-place edit here was a ~50 ms window in which a sibling file read a fixture as the tree —
+// one red run in three on a 4-core runner, on PRs that touched nothing near it. One writer per
+// surface: this file owns its shadow; the checkout has no writer. gates.mjs resolves every path it
+// reads from process.cwd(), so pointing the subprocess at the shadow is the whole redirection —
+// the script under test is still the working tree's scripts/gates.mjs, its inputs are the mirror.
 // ════════════════════════════════════════════════════════════════════════════════════════════════
 
+// The shadow mirrors the working tree as git sees it — tracked + untracked-unignored, so an
+// uncommitted deploy edit is part of the fixture exactly as it would be for the gate itself — and
+// nothing git ignores (no node_modules, no build output). Built once per file, on first use, torn
+// down when the file's tests finish.
+let shadowRoot = null;
+function shadowTree() {
+  if (shadowRoot) return shadowRoot;
+  const dir = mkdtempSync(join(tmpdir(), "vexa-gates-test-"));
+  const listing = execFileSync("git", ["ls-files", "-z", "--cached", "--others", "--exclude-standard"], { cwd: ROOT });
+  for (const relPath of listing.toString().split("\0")) {
+    if (!relPath) continue;
+    const src = join(ROOT, relPath);
+    let st; try { st = lstatSync(src); } catch { continue; }   // listed but gone: a sibling's planted fixture, already removed
+    if (!st.isFile()) continue;
+    const dst = join(dir, relPath);
+    mkdirSync(dirname(dst), { recursive: true });
+    copyFileSync(src, dst);
+  }
+  shadowRoot = dir;
+  return dir;
+}
+after(() => { if (shadowRoot) rmSync(shadowRoot, { recursive: true, force: true }); });
+
+// Runs the working tree's gates.mjs against the checkout by default, against the shadow under withEdited.
+let fixtureRoot = ROOT;
 function runGate(name) {
-  try { return { green: true, out: execFileSync("node", ["scripts/gates.mjs", name], { cwd: ROOT, encoding: "utf8" }) }; }
+  try { return { green: true, out: execFileSync("node", [join(ROOT, "scripts", "gates.mjs"), name], { cwd: fixtureRoot, encoding: "utf8" }) }; }
   catch (e) { return { green: false, out: `${e.stdout || ""}${e.stderr || ""}` }; }
 }
-// Temporarily replace `find`→`repl` in a tracked file, run fn, always restore the exact original bytes.
+// Temporarily replace `find`→`repl` in the SHADOW's copy of a tracked file, run fn with the gates
+// pointed at the shadow, always restore the exact original bytes. The checkout is never written.
 function withEdited(relPath, find, repl, fn) {
-  const abs = join(ROOT, relPath);
+  const abs = join(shadowTree(), relPath);
   const orig = readFileSync(abs, "utf8");
   const edited = orig.replace(find, repl);
   assert.notEqual(edited, orig, `fixture setup: pattern not found in ${relPath} — the test would prove nothing`);
   writeFileSync(abs, edited);
-  try { return fn(); } finally { writeFileSync(abs, orig); }
+  fixtureRoot = shadowTree();
+  try { return fn(); } finally { fixtureRoot = ROOT; writeFileSync(abs, orig); }
 }
 
 const COMPOSE = "deploy/compose/docker-compose.yml";
 const VALUES = "deploy/helm/charts/vexa/values.yaml";
 const LITE = "deploy/lite/Dockerfile.lite";
 const IMG_MANIFEST = "image-licenses.json";
+
+// ── the fixture harness itself ──────────────────────────────────────────────────────────────────
+
+test("withEdited (#1106): the checkout is untouched while a fixture runs — the edit lives in the shadow only", () => {
+  // The invariant the flake violated. A concurrent reader of the tracked file (sbom.test.mjs) must
+  // see the committed bytes at every instant of this file's run; only the shadow carries the edit.
+  const marker = "supervisor postgresql-client";
+  const tracked = join(ROOT, LITE);
+  const committed = readFileSync(tracked, "utf8");
+  let seenInside;
+  const r = withEdited(LITE, marker, `${marker} review-apt-probe`, () => {
+    seenInside = { checkout: readFileSync(tracked, "utf8"), shadow: readFileSync(join(shadowTree(), LITE), "utf8") };
+    return runGate("runtime-parity");
+  });
+  assert.equal(seenInside.checkout, committed, "the tracked Dockerfile.lite changed under a running fixture — a sibling test file can read the fixture as the tree");
+  assert.match(seenInside.shadow, /review-apt-probe/, "the shadow copy did not carry the edit — the gate under test never saw the fixture");
+  assert.equal(r.green, true, `runtime-parity ran against the shadow (an apt probe is not a cache engine) but redded:\n${r.out}`);
+  assert.equal(readFileSync(join(shadowTree(), LITE), "utf8"), committed, "the shadow was not restored after the fixture");
+  assert.equal(readFileSync(tracked, "utf8"), committed);
+});
 
 // ── gate:runtime-parity ─────────────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
**Delivers issue:** #1478 (diagnoses the report #1106)

## Contribution rights
<!-- Select exactly ONE. This is a legal certification: an agent may explain the choices but
     must not select one for you. See CONTRIBUTOR_RIGHTS.md. -->

- [ ] **Independent:** I created this contribution, or otherwise have the right to submit it
  under Apache-2.0, and it is not owned or controlled by an employer, client, or other entity.
  <!-- rights:independent -->
- [ ] **Employer/client authorization required:** an employer, client, or other entity owns or
  may control this contribution. I am requesting Vexa's private corporate-authorization process.
  <!-- rights:corporate -->
- [ ] **Unsure:** I need a private rights review before merge.
  <!-- rights:uncertain -->

## Observation bundle

- **C1 · locate the writer —** ran: `grep -n writeFileSync scripts/*.test.mjs release/*.test.mjs` at base `f94c8fa74` · saw: `scripts/gates.test.mjs:136` writes `join(ROOT, relPath)` for five tracked deploy surfaces; `scripts/sbom.test.mjs:51` reads `deploy/lite/Dockerfile.lite` and asserts the literal three of those fixtures replace; every other writer targets a `mkdtemp` dir · concluded: two test files on one tracked file, one writing, one reading, run concurrently by `node --test`.
- **C1 · measure the window —** ran: a 5 ms poller on the tracked file during `node --test scripts/gates.test.mjs` at base · saw: `MUTATED +1330ms / restored +1392ms`, `+1509/+1553`, `+1659/+1741` — `windows=3` · concluded: 45–80 ms per run in which any sibling read sees a fixture as the tree. The pass/fail rate on this 128-core host was 0/23 at base (3 default, 10 pinned to 4 cores, 10 to 2), so the poller, not the rate, is the instrument here.
- **C1 · confirm the redirection is sufficient —** ran: read `gate:image-licenses` and `gate:runtime-parity` in `scripts/gates.mjs` · saw: every input resolved from `ROOT = process.cwd()` (`:465,480-482,530,557,594-596,602`), no `.git` dependency · concluded: pointing the subprocess `cwd` at a shadow copy covers all five surfaces without a per-file override.
- **C1 · fix —** `withEdited` edits a per-file shadow (`git ls-files -z --cached --others --exclude-standard` copy, built once, removed in `after()`); `runGate` runs the working tree's `scripts/gates.mjs` with `cwd` = shadow. Call sites untouched. Rejected on the way: env overrides (five surfaces + a templates dir), `--test-concurrency=1` (hides the race, keeps the class), a throwaway `git worktree` (HEAD, not the working tree — an uncommitted deploy edit would be invisible to its own fixture).
- **C1 · prove —** ran: poller at head · saw: `windows=0`, `leftover shadows: 0` · ran: `node --test scripts/gates.test.mjs` · saw: 20/20 (every RED fixture still reds through the shadow; file time 1.46 s → 1.82 s) · ran: the new harness test appended to the base `withEdited` in a throwaway worktree · saw: `not ok … the tracked Dockerfile.lite changed under a running fixture` (19 pass / 1 fail) · ran: `taskset -c 0-3 node --test scripts/*.test.mjs release/*.test.mjs` ×10 at head · saw: 10/10 `pass=134 fail=0`.

## Acceptance floor

| Row | Evidence |
|---|---|
| A1 | poller: base `f94c8fa74` → `windows=3` (45–80 ms each); head → `windows=0` |
| A2 | `withEdited (#1106): the checkout is untouched while a fixture runs — the edit lives in the shadow only`: RED against base `withEdited` (`not ok 20 … changed under a running fixture`), GREEN at head |
| A3 | `node --test scripts/*.test.mjs release/*.test.mjs`, 4-core pin, 10 consecutive runs at head: 10/10 green, 134 tests each |
| A- | `scripts/gates.test.mjs` 20/20 at head; full script-test lane green ×10; `gates` CI on this PR |

## Docs diff (D6c)
None. The lane is described only by the comment at `.github/workflows/gates.yml:47-51` and the one line in `scripts/README.md`; neither states fixture mechanics, and `docs/` does not reference the test files. The gates' documented behaviour is unchanged — only their tests' inputs move. The mechanism is explained in the file header where the next reader of `withEdited` will look.

## Security checks
- Diff confined to `scripts/gates.test.mjs`; no dependency, lockfile or runtime change — dependency/licence scan not applicable, `pnpm gate:licenses` runs in CI regardless.
- Secrets: `git diff -U0 | grep -Ei '(api[_-]?key|secret|token|password|BEGIN (RSA|OPENSSH)|AKIA…)'` → no matches. `gitleaks` is not installed on the measuring host.
- SAST: not applicable to a node:test harness; `node --check` clean.
- The shadow is a `mkdtemp` dir of tracked + untracked-unignored files only; nothing git-ignored (secrets files are ignored) is copied, and it is removed when the file's tests finish.

## Validation request
Any non-author maintainer; the reporter of #1106, on the laptop where the flake reproduced ~1 in 3, is the preferred signer. Watch: A1 (the poller from the bundle, or any 5 ms read loop on `deploy/lite/Dockerfile.lite` during `node --test scripts/gates.test.mjs`) and A3 (10 consecutive full-lane runs).
D12b: no deployment applies — CI tooling only. Provenance of the measurements: fresh `git worktree` of `Vexa-ai/vexa` at base `f94c8fa74` on a 128-core Linux host, Node v22.14.0, no env deltas; a second throwaway worktree at the same base for the A2 negative control.

## Authorship
Submitted by the maintainer. Tooling disclosure: diagnosed, measured and drafted with an agent; no co-author trailers.

<!-- vexa-agent -->
