### PR TITLE
Your own Claude Code can list and cancel the meeting joins you scheduled — and only yours

### DIFF
--- a/core/agent/shared/timeline.py
+++ b/core/agent/shared/timeline.py
@@ -71,7 +71,7 @@ def fetch(uid: str, *, back: int = BACK, ahead: int = AHEAD, timeout: float = TI
         return ""
     # The window is the route's default (14 back, 30 forward); `limit` is what the block can hold.
     url = f"{api}/timeline?subject={urllib.parse.quote(str(uid))}&format=preamble&limit={back + ahead}"
-    req = urllib.request.Request(url, method="GET", headers={"X-Flows-Admin-Key": key})
+    req = urllib.request.Request(url, method="GET", headers={"X-Flows-Operator-Key": key})
     try:
         with urllib.request.urlopen(req, timeout=timeout) as r:
             body = json.loads(r.read().decode() or "{}")

--- a/core/flows/Makefile
+++ b/core/flows/Makefile
@@ -46,10 +46,10 @@ stop: ## stop all three
 	@echo stopped
 
 status: ## the operator projection (reactions, newest first)
-	@curl -s -H "X-Flows-Admin-Key: $(KEY)" "$(API)/reactions" | $(PY) -m json.tool | head -60
+	@curl -s -H "X-Flows-Operator-Key: $(KEY)" "$(API)/reactions" | $(PY) -m json.tool | head -60
 
 flows: ## list every flow version + the step vocabulary
-	@curl -s -H "X-Flows-Admin-Key: $(KEY)" "$(API)/flows" | $(PY) -m json.tool | head -80
+	@curl -s -H "X-Flows-Operator-Key: $(KEY)" "$(API)/flows" | $(PY) -m json.tool | head -80
 
 check: ## validate a Python flow file: make check FILE=my_flow.py
 	cd $(SRC) && $(PY) flows_authoring.py check $(FILE)

--- a/core/flows/README.md
+++ b/core/flows/README.md
@@ -76,6 +76,25 @@ correct behaviour and not a gap in the queue.
 resolved private-mount-first and read hot, and a pending reaction behavior says nothing about is
 counted rather than spoken. `behavior/queue/README.md` is the contract.
 
+## Two tiers at the door
+
+`flows-api` answers to two kinds of caller and the difference is who the answer is about.
+
+The **operator key** (`X-Flows-Admin-Key`, `VEXA_FLOWS_API_KEY`) is the instance: it opens every
+route, reads every reaction and steers any of them. It is what configures the machine, and there is
+no per-person version of `POST /flows` or `POST /events`.
+
+A **person's own Vexa credential** opens the four routes that are about a person — `GET /flows`,
+`GET /reactions`, `POST /reactions/{id}/{verb}`, `GET /timeline` — and the subject is derived from
+that credential by asking identity's `/internal/validate`, the same resolver the gateway asks. Not
+a second resolver: flows is a second caller of the one that already exists. This is what the MCP
+edge needs, because that edge forwards the caller's own credential and holds none of its own — so
+without it the only way to make flows' four tools answer was to hand the edge the operator key, and
+the operator key is not a person.
+
+An unreachable identity answers **503**, never 401: not being able to ask who somebody is has not
+established that their credential is bad.
+
 ## Configuration
 
 Every environment key this brick reads is declared once in `src/flows_config.py`, with its class

--- a/core/flows/README.md
+++ b/core/flows/README.md
@@ -84,8 +84,9 @@ The **operator key** (`X-Flows-Operator-Key`, `VEXA_FLOWS_API_KEY`) is the insta
 route, reads every reaction and steers any of them. It is what configures the machine, and there is
 no per-person version of `POST /flows` or `POST /events`.
 
-A **person's own Vexa credential** opens the four routes that are about a person — `GET /flows`,
-`GET /reactions`, `POST /reactions/{id}/{verb}`, `GET /timeline` — and the subject is derived from
+A **person's own Vexa credential** opens the five routes that are about a person — `GET /flows`,
+`GET /reactions`, `POST /reactions/{id}/{verb}`, `GET /queue/waiting`, `GET /timeline` — and the
+subject is derived from
 that credential by asking identity's `/internal/validate`, the same resolver the gateway asks. Not
 a second resolver: flows is a second caller of the one that already exists. This is what the MCP
 edge needs, because that edge forwards the caller's own credential and holds none of its own — so

--- a/core/flows/README.md
+++ b/core/flows/README.md
@@ -80,7 +80,7 @@ counted rather than spoken. `behavior/queue/README.md` is the contract.
 
 `flows-api` answers to two kinds of caller and the difference is who the answer is about.
 
-The **operator key** (`X-Flows-Admin-Key`, `VEXA_FLOWS_API_KEY`) is the instance: it opens every
+The **operator key** (`X-Flows-Operator-Key`, `VEXA_FLOWS_API_KEY`) is the instance: it opens every
 route, reads every reaction and steers any of them. It is what configures the machine, and there is
 no per-person version of `POST /flows` or `POST /events`.
 
@@ -91,6 +91,11 @@ a second resolver: flows is a second caller of the one that already exists. This
 edge needs, because that edge forwards the caller's own credential and holds none of its own — so
 without it the only way to make flows' four tools answer was to hand the edge the operator key, and
 the operator key is not a person.
+
+The header used to be `X-Flows-Admin-Key`, which reads as admin-api's token and is not one — a lane
+start script carried a `changeme` for it because whoever wrote it exported admin-api's key under
+this service's name. The old header is accepted for one release, with a deprecation line printed
+once per process; a caller sending both is answered on the new one.
 
 An unreachable identity answers **503**, never 401: not being able to ask who somebody is has not
 established that their credential is bad.

--- a/core/flows/eval/adoption/simlane.py
+++ b/core/flows/eval/adoption/simlane.py
@@ -39,7 +39,7 @@ def _req(method: str, path: str, body=None, timeout=30):
     req = urllib.request.Request(API + path, method=method,
                                  data=json.dumps(body).encode() if body is not None else None)
     req.add_header("content-type", "application/json")
-    req.add_header("X-Flows-Admin-Key", KEY)
+    req.add_header("X-Flows-Operator-Key", KEY)
     try:
         with urllib.request.urlopen(req, timeout=timeout) as r:
             raw = r.read().decode()

--- a/core/flows/mcp.tools.v1.json
+++ b/core/flows/mcp.tools.v1.json
@@ -5,53 +5,31 @@
   "owner": "core/flows",
   "base_url_env": "FLOWS_API_URL",
   "served_at": "/.well-known/mcp-tools.json",
-  "depends_on": [
-    "identity"
-  ],
+  "depends_on": ["identity"],
   "tools": [
     {
       "name": "flows_list",
       "identity": "operator",
-      "requires": [
-        "identity",
-        "flows"
-      ],
-      "route": {
-        "method": "GET",
-        "path": "/flows"
-      },
-      "auth": "subject"
+      "auth": "subject",
+      "requires": ["identity", "flows"],
+      "route": { "method": "GET", "path": "/flows" }
     },
     {
       "name": "reactions_list",
       "identity": "user",
-      "requires": [
-        "identity",
-        "flows"
-      ],
-      "route": {
-        "method": "GET",
-        "path": "/reactions"
-      },
-      "arguments": [
-        "status",
-        "subject"
-      ],
-      "auth": "subject"
+      "auth": "subject",
+      "requires": ["identity", "flows"],
+      "route": { "method": "GET", "path": "/reactions" },
+      "arguments": ["status", "subject"],
+      "note": "A person's own queue: the subject is taken from their credential, so `subject` is optional and may only name themselves."
     },
     {
       "name": "reaction_signal",
       "identity": "user",
-      "requires": [
-        "identity",
-        "flows"
-      ],
-      "route": {
-        "method": "POST",
-        "path": "/reactions/{reaction_id}/{verb}"
-      },
-      "note": "resume | retry | cancel | wake. The path parameters are arguments without being declared \u2014 the route cannot be called without them.",
-      "auth": "subject"
+      "auth": "subject",
+      "requires": ["identity", "flows"],
+      "route": { "method": "POST", "path": "/reactions/{reaction_id}/{verb}" },
+      "note": "resume | retry | cancel | wake. The path parameters are arguments without being declared — the route cannot be called without them."
     },
     {
       "name": "whats_waiting",
@@ -59,26 +37,15 @@
       "auth": "subject",
       "requires": ["identity", "flows"],
       "route": { "method": "GET", "path": "/queue/waiting" },
-      "note": "PRD decision 42.2 — what is waiting IS flows: this subject's pending reactions, each naming the flow that produced it and its typed reason (human | failed | not_present | pending). Nothing is unioned at the edge. `auth: subject` means the person is the authenticated caller — the edge stamps X-User-Id and the tool takes no subject argument. The `auth` field itself arrives with decision 15; declared here so the merge order, not this manifest, resolves it."
+      "note": "PRD decision 42.2 — what is waiting IS flows: this subject's pending reactions, each naming the flow that produced it and its typed reason (human | failed | not_present | pending). Nothing is unioned at the edge. `auth: subject` means the person is the authenticated caller: flows resolves them from their own credential, and the tool takes no subject argument."
     },
     {
       "name": "timeline",
       "identity": "user",
-      "requires": [
-        "identity",
-        "flows"
-      ],
-      "route": {
-        "method": "GET",
-        "path": "/timeline"
-      },
-      "arguments": [
-        "subject",
-        "since",
-        "until",
-        "limit"
-      ],
-      "auth": "subject"
+      "auth": "subject",
+      "requires": ["identity", "flows"],
+      "route": { "method": "GET", "path": "/timeline" },
+      "arguments": ["subject", "since", "until", "limit"]
     }
   ],
   "publishes_events": [

--- a/core/flows/mcp.tools.v1.json
+++ b/core/flows/mcp.tools.v1.json
@@ -5,27 +5,53 @@
   "owner": "core/flows",
   "base_url_env": "FLOWS_API_URL",
   "served_at": "/.well-known/mcp-tools.json",
-  "depends_on": ["identity"],
+  "depends_on": [
+    "identity"
+  ],
   "tools": [
     {
       "name": "flows_list",
       "identity": "operator",
-      "requires": ["identity", "flows"],
-      "route": { "method": "GET", "path": "/flows" }
+      "requires": [
+        "identity",
+        "flows"
+      ],
+      "route": {
+        "method": "GET",
+        "path": "/flows"
+      },
+      "auth": "subject"
     },
     {
       "name": "reactions_list",
-      "identity": "operator",
-      "requires": ["identity", "flows"],
-      "route": { "method": "GET", "path": "/reactions" },
-      "arguments": ["status", "subject"]
+      "identity": "user",
+      "requires": [
+        "identity",
+        "flows"
+      ],
+      "route": {
+        "method": "GET",
+        "path": "/reactions"
+      },
+      "arguments": [
+        "status",
+        "subject"
+      ],
+      "auth": "subject"
     },
     {
       "name": "reaction_signal",
       "identity": "user",
-      "requires": ["identity", "flows"],
-      "route": { "method": "POST", "path": "/reactions/{reaction_id}/{verb}" },
-      "note": "resume | retry | cancel | wake. The path parameters are arguments without being declared — the route cannot be called without them."
+      "requires": [
+        "identity",
+        "flows"
+      ],
+      "route": {
+        "method": "POST",
+        "path": "/reactions/{reaction_id}/{verb}"
+      },
+      "note": "resume | retry | cancel | wake. The path parameters are arguments without being declared \u2014 the route cannot be called without them.",
+      "auth": "subject"
     },
     {
       "name": "whats_waiting",
@@ -38,9 +64,21 @@
     {
       "name": "timeline",
       "identity": "user",
-      "requires": ["identity", "flows"],
-      "route": { "method": "GET", "path": "/timeline" },
-      "arguments": ["subject", "since", "until", "limit"]
+      "requires": [
+        "identity",
+        "flows"
+      ],
+      "route": {
+        "method": "GET",
+        "path": "/timeline"
+      },
+      "arguments": [
+        "subject",
+        "since",
+        "until",
+        "limit"
+      ],
+      "auth": "subject"
     }
   ],
   "publishes_events": [

--- a/core/flows/src/flows_authoring.py
+++ b/core/flows/src/flows_authoring.py
@@ -51,7 +51,7 @@ def _extract(path: str) -> list[dict]:
 
 def _export(api: str, key: str, only: str | None) -> int:
     req = urllib.request.Request(f"{api}/flows")
-    req.add_header("X-Flows-Admin-Key", key)
+    req.add_header("X-Flows-Operator-Key", key)
     with urllib.request.urlopen(req, timeout=10) as r:
         data = json.loads(r.read())
     newest: dict[str, dict] = {}
@@ -92,7 +92,7 @@ def main() -> int:
         req = urllib.request.Request(f"{api}/flows", method="POST",
                                      data=json.dumps(d).encode())
         req.add_header("content-type", "application/json")
-        req.add_header("X-Flows-Admin-Key", key)
+        req.add_header("X-Flows-Operator-Key", key)
         try:
             with urllib.request.urlopen(req, timeout=10) as r:
                 print("   →", r.read().decode().replace("\n", " ")[:120])

--- a/core/flows/src/flows_integrations/flows_api.py
+++ b/core/flows/src/flows_integrations/flows_api.py
@@ -23,14 +23,14 @@ AUTH, TWO TIERS — because two different callers reach this surface and only on
 operator (issue #1468):
 
   * THE SUBJECT-SCOPED ROUTES (`GET /flows`, `GET /reactions`, `POST /reactions/{id}/{verb}`,
-    `GET /timeline`) take EITHER the operator key OR a person's own Vexa credential, as a bearer
-    or `X-API-Key`. With a person's credential the subject is DERIVED from it, through identity's
-    `/internal/validate` — the one resolver, the same one the gateway asks (P23) — and a `subject`
-    argument naming anyone else is refused rather than honoured. The MCP edge forwards the
-    caller's own credential and holds none of its own, so this is what makes those four tools
-    usable by a person at all: before it, the only way to make them answer was to hand the edge
-    the operator key, and the operator key is not a person — it reads every reaction in the
-    instance and cancels any of them.
+    `GET /queue/waiting`, `GET /timeline`) take EITHER the operator key OR a person's own Vexa
+    credential, as a bearer or `X-API-Key`. With a person's credential the subject is DERIVED from
+    it, through identity's `/internal/validate` — the one resolver, the same one the gateway asks
+    (P23) — and a `subject` argument naming anyone else is refused rather than honoured. The MCP
+    edge forwards the caller's own credential and holds none of its own, so this is what makes
+    those five tools usable by a person at all: before it, the only way to make them answer was to
+    hand the edge the operator key, and the operator key is not a person — it reads every reaction
+    in the instance and cancels any of them.
   * THE OPERATOR ROUTES (`POST /flows`, `POST /events`, `POST /events/batch`,
     `POST /flows/{name}/{version}/{action}`) take the operator key and nothing else. They
     configure the machine or admit facts on the instance's behalf; there is no per-person version
@@ -705,31 +705,45 @@ def mcp_tools_manifest():
 import flows_queue as _flows_queue  # noqa: E402
 
 
-@app.get("/queue/waiting", dependencies=[Depends(auth)])
+@app.get("/queue/waiting")
 def queue_waiting(subject: str = "", limit: int = 50,
-                  x_user_id: str = Header(default="")):
+                  x_user_id: str = Header(default=""),
+                  caller: Caller = Depends(subject_or_operator)):
     """WHAT IS WAITING FOR THIS PERSON — pending reactions, with the flow that produced each.
 
-    THE SUBJECT IS THE AUTHENTICATED CALLER'S. `X-User-Id` is what the MCP assembler stamps after
-    it has resolved identity once at the edge, and it WINS over `?subject=`: a caller who names
-    somebody else in a query argument while carrying their own bearer must read their own queue and
-    nobody else's. `?subject=` survives for the unstamped operator read that `GET /reactions`
-    already has, behind the same operator key — and that key is a SERVICE identity, not a person's,
-    which is exactly why the person's identity has to arrive separately.
+    THE SUBJECT IS THE AUTHENTICATED CALLER'S, and there are two ways to be one.
 
-    Behind `auth`, not `timeline_auth`: `VEXA_FLOWS_TIMELINE_KEY` is documented as opening the
-    timeline and nothing else, and quietly widening a key's reach is how a narrow credential stops
-    being narrow.
+    A PERSON authenticates with their own Vexa credential and their subject is resolved from it
+    (issue #1468). Nothing they send can move it: a `subject` argument naming anyone else is 403,
+    and an `X-User-Id` header is ignored outright. That header is a string a caller can type, and
+    it is only ever evidence because the OPERATOR key gates it — a service vouching for a person it
+    resolved. A verified credential is stronger evidence than any header, so it wins.
+
+    THE OPERATOR reads one person's queue on their behalf, and keeps exactly the behaviour this
+    route shipped with: `X-User-Id` is the gateway's answer and outranks `?subject=`, and
+    `?subject=` is the unstamped console read. Neither ever answers with the instance — no subject
+    at all is a 400, because this route answers for ONE person or for nobody.
+
+    The distinction matters because this route is NOT always behind the gateway: reached through
+    the MCP edge it is addressed directly, and that edge stamps no `X-User-Id` at all — it forwards
+    the caller's own credential, which is the whole reason a person's credential has to open the
+    door here.
+
+    Not opened by `VEXA_FLOWS_TIMELINE_KEY`: that key is documented as opening the timeline and
+    nothing else, and quietly widening a key's reach is how a narrow credential stops being narrow.
 
     The answer is DATA plus behavior's words: every sentence a person hears is resolved from
     `behavior/queue/`, read hot, never from this body. See `flows_queue` for why silence there is
     the filter rather than a keyword list here.
     """
-    who = (x_user_id or "").strip() or (subject or "").strip()
+    who = scoped_subject(caller, subject)
+    if caller.is_admin:
+        who = (x_user_id or "").strip() or who
     if not who:
         raise HTTPException(status_code=400, detail=(
-            "no subject — this route answers for ONE person. The edge stamps X-User-Id; an "
-            "operator calling it directly passes ?subject=<uid|email>."))
+            "no subject — this route answers for ONE person. A person is resolved from their own "
+            "credential; an operator passes ?subject=<uid|email>, or the gateway stamps "
+            "X-User-Id."))
     flows = [{"name": f.name, "version": f.version, "on": f.on.name}
              for f in vocab.flows.values()]
     return _flows_queue.waiting(db, subject=who, flows=flows,

--- a/core/flows/src/flows_integrations/flows_api.py
+++ b/core/flows/src/flows_integrations/flows_api.py
@@ -31,10 +31,16 @@ operator (issue #1468):
     usable by a person at all: before it, the only way to make them answer was to hand the edge
     the operator key, and the operator key is not a person — it reads every reaction in the
     instance and cancels any of them.
-  * THE ADMIN ROUTES (`POST /flows`, `POST /events`, `POST /events/batch`,
+  * THE OPERATOR ROUTES (`POST /flows`, `POST /events`, `POST /events/batch`,
     `POST /flows/{name}/{version}/{action}`) take the operator key and nothing else. They
     configure the machine or admit facts on the instance's behalf; there is no per-person version
     of either.
+
+The operator key travels as `X-Flows-Operator-Key`. It used to be `X-Flows-Admin-Key`, which reads
+as ADMIN-API's token and is not one — that confusion is on the record: a lane start script carried
+a `changeme` for it because whoever wrote the script exported the admin-api key under the name this
+service reads. The old header is still accepted for one release, with a deprecation line printed
+once per process; a caller sending both is answered on the new one.
 
 NEVER accepts code — steps are reviewed Python in the image; this API composes them (the n8n line
 we do not cross).
@@ -157,9 +163,37 @@ def _same_key(presented: str, expected: str) -> bool:
     return hmac.compare_digest(str(presented or ""), str(expected))
 
 
-def auth(x_flows_admin_key: str = Header(default="")) -> None:
-    if not _same_key(x_flows_admin_key, API_KEY):
-        raise HTTPException(status_code=401, detail="X-Flows-Admin-Key required")
+#: The header the operator key travels in, and the one it used to.
+OPERATOR_HEADER = "X-Flows-Operator-Key"
+DEPRECATED_OPERATOR_HEADER = "X-Flows-Admin-Key"
+#: Which deprecated spellings this process has already complained about. A deprecation printed per
+#: REQUEST is a flood nobody reads and a cost on the hot path; printed once it is a message.
+_DEPRECATED_HEADER_SAID: set = set()
+
+
+def _operator_key(x_flows_operator_key: str = "", x_flows_admin_key: str = "") -> str:
+    """The operator key the caller presented, under either name. "" when they presented none.
+
+    The new name wins when both are sent: a caller mid-migration sends the new one deliberately and
+    the old one because something else still adds it, and answering on the old one would make the
+    migration invisible to them.
+    """
+    key = (x_flows_operator_key or "").strip()
+    if key:
+        return key
+    key = (x_flows_admin_key or "").strip()
+    if key and DEPRECATED_OPERATOR_HEADER not in _DEPRECATED_HEADER_SAID:
+        _DEPRECATED_HEADER_SAID.add(DEPRECATED_OPERATOR_HEADER)
+        print(f"WARNING: {DEPRECATED_OPERATOR_HEADER} is DEPRECATED — send the same value as "
+              f"{OPERATOR_HEADER}. It is flows-api's OWN operator key (VEXA_FLOWS_API_KEY), never "
+              "admin-api's token; the old name said otherwise and was believed.", flush=True)
+    return key
+
+
+def auth(x_flows_operator_key: str = Header(default=""),
+         x_flows_admin_key: str = Header(default="")) -> None:
+    if not _same_key(_operator_key(x_flows_operator_key, x_flows_admin_key), API_KEY):
+        raise HTTPException(status_code=401, detail=f"{OPERATOR_HEADER} required")
 
 
 def _bearer(authorization: str, x_api_key: str) -> str:
@@ -179,7 +213,8 @@ def _bearer(authorization: str, x_api_key: str) -> str:
     return token.strip() if scheme.lower() == "bearer" else ""
 
 
-def subject_or_operator(x_flows_admin_key: str = Header(default=""),
+def subject_or_operator(x_flows_operator_key: str = Header(default=""),
+                        x_flows_admin_key: str = Header(default=""),
                         authorization: str = Header(default=""),
                         x_api_key: str = Header(default="")) -> Caller:
     """WHO IS CALLING — the operator, or one person. The dependency of every subject-scoped route.
@@ -187,13 +222,13 @@ def subject_or_operator(x_flows_admin_key: str = Header(default=""),
     The operator key is checked first and short-circuits: it is a local constant-time comparison,
     it is what every existing caller sends, and it must keep working while identity is down.
     """
-    if _same_key(x_flows_admin_key, API_KEY):
+    if _same_key(_operator_key(x_flows_operator_key, x_flows_admin_key), API_KEY):
         return Caller(kind="admin")
     token = _bearer(authorization, x_api_key)
     if not token:
         raise HTTPException(status_code=401, detail=(
             "this route needs your Vexa credential (Authorization: Bearer …, or X-API-Key), "
-            "or the operator key in X-Flows-Admin-Key"))
+            f"or the operator key in {OPERATOR_HEADER}"))
     try:
         return resolve(token, secret=INTERNAL_SECRET)
     except SubjectUnknown:
@@ -204,13 +239,15 @@ def subject_or_operator(x_flows_admin_key: str = Header(default=""),
             f"identity could not answer who you are ({e}) — this is our side, not your key"))
 
 
-def timeline_reader(x_flows_admin_key: str = Header(default=""),
+def timeline_reader(x_flows_operator_key: str = Header(default=""),
+                    x_flows_admin_key: str = Header(default=""),
                     authorization: str = Header(default=""),
                     x_api_key: str = Header(default="")) -> Caller:
     """`GET /timeline` alone: the narrow read-only key opens it, as well as the two tiers above."""
-    if TIMELINE_KEY and _same_key(x_flows_admin_key, TIMELINE_KEY):
+    if TIMELINE_KEY and _same_key(_operator_key(x_flows_operator_key, x_flows_admin_key),
+                                  TIMELINE_KEY):
         return Caller(kind="admin")
-    return subject_or_operator(x_flows_admin_key, authorization, x_api_key)
+    return subject_or_operator(x_flows_operator_key, x_flows_admin_key, authorization, x_api_key)
 
 
 def scoped_subject(caller: Caller, requested: str) -> str:

--- a/core/flows/src/flows_integrations/flows_api.py
+++ b/core/flows/src/flows_integrations/flows_api.py
@@ -19,8 +19,25 @@
                                     Read-only, and it takes the operator key OR the narrower
                                     VEXA_FLOWS_TIMELINE_KEY (see `_timeline_key`).
 
-Auth: X-Flows-Admin-Key (env VEXA_FLOWS_API_KEY). NEVER accepts code — steps are reviewed Python
-in the image; this API composes them (the n8n line we do not cross).
+AUTH, TWO TIERS — because two different callers reach this surface and only one of them is an
+operator (issue #1468):
+
+  * THE SUBJECT-SCOPED ROUTES (`GET /flows`, `GET /reactions`, `POST /reactions/{id}/{verb}`,
+    `GET /timeline`) take EITHER the operator key OR a person's own Vexa credential, as a bearer
+    or `X-API-Key`. With a person's credential the subject is DERIVED from it, through identity's
+    `/internal/validate` — the one resolver, the same one the gateway asks (P23) — and a `subject`
+    argument naming anyone else is refused rather than honoured. The MCP edge forwards the
+    caller's own credential and holds none of its own, so this is what makes those four tools
+    usable by a person at all: before it, the only way to make them answer was to hand the edge
+    the operator key, and the operator key is not a person — it reads every reaction in the
+    instance and cancels any of them.
+  * THE ADMIN ROUTES (`POST /flows`, `POST /events`, `POST /events/batch`,
+    `POST /flows/{name}/{version}/{action}`) take the operator key and nothing else. They
+    configure the machine or admit facts on the instance's behalf; there is no per-person version
+    of either.
+
+NEVER accepts code — steps are reviewed Python in the image; this API composes them (the n8n line
+we do not cross).
 
 THE INSTANCE GATE cuts across this surface in three different ways, and the difference is the
 point (see `flows_integrations/instance_gate.py`):
@@ -53,9 +70,16 @@ import flows_config  # noqa: E402
 from flows_defs import production  # noqa: E402
 from flows_integrations import instance_gate  # noqa: E402
 from flows_steps.common import db_url, require_internal_secret, setting  # noqa: E402
+from flows_integrations.subject_auth import (Caller, IdentityUnavailable,  # noqa: E402
+                                              SubjectUnknown, resolve)
+# ALIASED, and it is not style. The route below is also called `list_reactions`, and `def` rebinds
+# the module global — so the route was calling ITSELF, and every authenticated `GET /reactions`
+# answered 500 (`TypeError: list_reactions() got multiple values for argument 'status'`). The 401
+# in front of it hid that for as long as the route was operator-only. One name, one thing.
 from flows_timeline import (REACTION_FOUND, REACTION_MISSING,  # noqa: E402
-                            build_timeline, fetch_meetings, list_reactions, reaction_concerns,
+                            build_timeline, fetch_meetings, reaction_concerns,
                             render_preamble, render_text)
+from flows_timeline import list_reactions as reactions_for  # noqa: E402
 
 def _require_api_key() -> str:
     """The operator key, or the process refuses to start.
@@ -138,11 +162,91 @@ def auth(x_flows_admin_key: str = Header(default="")) -> None:
         raise HTTPException(status_code=401, detail="X-Flows-Admin-Key required")
 
 
-def timeline_auth(x_flows_admin_key: str = Header(default="")) -> None:
-    """The operator key opens everything, including this. The timeline key opens only this."""
-    if _same_key(x_flows_admin_key, API_KEY) or _same_key(x_flows_admin_key, TIMELINE_KEY):
-        return
-    raise HTTPException(status_code=401, detail="X-Flows-Admin-Key required")
+def _bearer(authorization: str, x_api_key: str) -> str:
+    """The caller's own Vexa credential, in either spelling of the ONE authentication path.
+
+    `X-API-Key` is what the MCP edge forwards (`vexa_mcp/register.py`) and what the gateway
+    resolves; `Authorization: Bearer` is what an MCP client sets. Same credential, two headers on
+    the way here, and no third path: nothing is read from a query string or an argument (PRD 40.8).
+    """
+    key = (x_api_key or "").strip()
+    if key:
+        return key
+    auth = (authorization or "").strip()
+    if not auth:
+        return ""
+    scheme, _, token = auth.partition(" ")
+    return token.strip() if scheme.lower() == "bearer" else ""
+
+
+def subject_or_operator(x_flows_admin_key: str = Header(default=""),
+                        authorization: str = Header(default=""),
+                        x_api_key: str = Header(default="")) -> Caller:
+    """WHO IS CALLING — the operator, or one person. The dependency of every subject-scoped route.
+
+    The operator key is checked first and short-circuits: it is a local constant-time comparison,
+    it is what every existing caller sends, and it must keep working while identity is down.
+    """
+    if _same_key(x_flows_admin_key, API_KEY):
+        return Caller(kind="admin")
+    token = _bearer(authorization, x_api_key)
+    if not token:
+        raise HTTPException(status_code=401, detail=(
+            "this route needs your Vexa credential (Authorization: Bearer …, or X-API-Key), "
+            "or the operator key in X-Flows-Admin-Key"))
+    try:
+        return resolve(token, secret=INTERNAL_SECRET)
+    except SubjectUnknown:
+        raise HTTPException(status_code=401, detail="that credential does not identify anyone")
+    except IdentityUnavailable as e:
+        # 503, NEVER 401. We did not reach a verdict on the credential — see subject_auth.
+        raise HTTPException(status_code=503, detail=(
+            f"identity could not answer who you are ({e}) — this is our side, not your key"))
+
+
+def timeline_reader(x_flows_admin_key: str = Header(default=""),
+                    authorization: str = Header(default=""),
+                    x_api_key: str = Header(default="")) -> Caller:
+    """`GET /timeline` alone: the narrow read-only key opens it, as well as the two tiers above."""
+    if TIMELINE_KEY and _same_key(x_flows_admin_key, TIMELINE_KEY):
+        return Caller(kind="admin")
+    return subject_or_operator(x_flows_admin_key, authorization, x_api_key)
+
+
+def scoped_subject(caller: Caller, requested: str) -> str:
+    """The subject these rows are about — derived, never asserted.
+
+    For the OPERATOR nothing changes: `subject` is whatever they asked for, including nothing,
+    which is the unscoped console read this surface has always served.
+
+    For a PERSON the subject is who their credential says they are. A `subject` argument is still
+    accepted, because the tool schema advertises one and a client that holds its own uid or address
+    will send it — but only as a spelling of themselves. Anything else is 403 rather than silently
+    overridden: an argument quietly ignored is the same defect as one quietly dropped, and here it
+    would be the difference between "here is your queue" and "here is someone else's".
+    """
+    asked = str(requested or "").strip()
+    if caller.is_admin:
+        return asked
+    if asked and asked.lower() not in caller.names:
+        raise HTTPException(status_code=403, detail={
+            "not_your_subject": asked,
+            "you_are": caller.uid,
+            "note": ("the subject is derived from your credential — send no subject, or your own "
+                     "platform id or address")})
+    return caller.uid
+
+
+def _as_me(caller: Caller):
+    """The identity resolver to hand the model for a subject caller: the pair we already hold.
+
+    `flows_timeline` otherwise asks admin-api to turn a uid into an address, which for this caller
+    is a second hop for a fact `/internal/validate` already returned — and one more thing that can
+    be down in the middle of a read.
+    """
+    if caller.is_admin:
+        return None
+    return lambda _subject: (caller.uid, caller.email)
 
 
 @app.get("/health")
@@ -199,8 +303,8 @@ class FlowSubmission(BaseModel):
     activate: bool = True
 
 
-@app.get("/flows", dependencies=[Depends(auth)])
-def list_flows():
+@app.get("/flows")
+def list_flows(caller: Caller = Depends(subject_or_operator)):
     code_flows = [{"name": f.name, "version": f.version, "on": f.on.name,
                    "steps": list(f.steps), "source": "image", "status": "active"}
                   for f in vocab.flows.values()]
@@ -373,51 +477,56 @@ def set_flow_status(name: str, version: int, action: str):
     return {"name": name, "version": version, "status": st}
 
 
-@app.get("/reactions", dependencies=[Depends(auth)])
-def list_reactions(status: Optional[str] = None, subject: str = ""):
-    """The operator projection — and, with ``subject``, ONE PERSON'S share of it.
+@app.get("/reactions")
+def list_reactions(status: Optional[str] = None, subject: str = "",
+                   caller: Caller = Depends(subject_or_operator)):
+    """ONE PERSON'S share of the reaction queue — or, for the operator, the whole projection.
 
-    ``subject`` (a platform uid or an email address) is what makes this route usable by a
-    per-person surface. Without it the control MCP was fanning the whole instance's reactions into
-    every signed-in user's queue: `whats_waiting` reported other tenants' flow names, step names
-    and failure reasons as this person's work, and `reactions_list` handed out every reaction id
-    instance-wide — which is also how `reaction_signal` could cancel a stranger's pending join
-    (R-D07, R-D12).
+    Unscoped, this route was fanning the entire instance's reactions into every signed-in user's
+    queue: `whats_waiting` reported other tenants' flow names, step names and failure reasons as
+    this person's work, and `reactions_list` handed out every reaction id instance-wide — which is
+    also how `reaction_signal` could cancel a stranger's pending join (R-D07, R-D12).
+
+    The subject is now DERIVED from the caller's own credential rather than asserted as an
+    argument (issue #1468). An operator still reads any subject, or none.
 
     Scoping reuses `flows_timeline`'s pair — the uid AND the email — for the reason that module
     documents: the invite lineage carries an organizer address and no uid, the completed lineage
     carries a uid and no address, and matching on one of them silently returns half the rows.
     """
-    subj = (subject or "").strip()
-    rows = list_reactions(db, subject=subj, status=status or "")
+    subj = scoped_subject(caller, subject)
+    rows = reactions_for(db, subject=subj, status=status or "", identity=_as_me(caller))
     if rows is None:
         return {"reactions": [], "subject": subj, "unresolved": True}
-    return {"reactions": [
+    return {"subject": subj, "reactions": [
         {"id": r["reaction_id"], "flow": f"{r['flow']}@{r['flow_version']}", "step": r["step"],
          "status": r["status"], "attempt": r["attempt"], "reason": r["reason"],
          "next_run_at": r["next_run_at"]}
         for r in rows]}
 
 
-@app.post("/reactions/{reaction_id}/{verb}", dependencies=[Depends(auth)])
+@app.post("/reactions/{reaction_id}/{verb}")
 def signal_reaction(reaction_id: str, verb: str, subject: str = "",
-                    x_actor: str = Header(default="api"), body: dict = Body(default={})):
-    """Steer one reaction — and, with `subject`, only if it is THAT PERSON'S (R-D07).
+                    x_actor: str = Header(default="api"), body: dict = Body(default={}),
+                    caller: Caller = Depends(subject_or_operator)):
+    """Steer one reaction — and, for a person, only if it is THEIRS (R-D07).
 
-    The verbs post with the lane's admin key, so before `subject` existed the caller's identity
-    never reached this decision: the control MCP handed every signed-in user every reaction id and
-    then let them `cancel` any of it. Ownership is the right question here rather than operator
-    authority — a person stopping the join they scheduled with `bot_schedule` is the ordinary path,
-    and an admin-only gate would close it to fix an unusual one.
+    Ownership is the right question here rather than operator authority: a person stopping the join
+    THEY scheduled with `bot_schedule` is the ordinary path, and an admin-only gate would close it
+    to fix an unusual one.
 
-    Omitting `subject` keeps the unscoped operator behaviour this route has always had: it is
-    already behind the operator key, and the admin console steers reactions it does not own.
+    The check used to run only when the CALLER passed `subject`, which meant a caller who simply
+    omitted it got the unscoped behaviour — and every caller reached this route holding the same
+    operator key, so nobody's identity ever reached this decision. Now a person's subject comes
+    from their credential and the check always runs; an operator with no subject keeps the unscoped
+    console behaviour, because the admin console steers reactions it does not own.
     """
     fns = {"retry": retry, "resume": resume, "cancel": cancel, "wake": wake}
     if verb not in fns:
         raise HTTPException(status_code=404, detail="retry | resume | cancel | wake")
-    if str(subject or "").strip():
-        owns = reaction_concerns(db, reaction_id, subject=subject.strip())
+    subj = scoped_subject(caller, subject)
+    if subj:
+        owns = reaction_concerns(db, reaction_id, subject=subj, identity=_as_me(caller))
         if owns == REACTION_MISSING:
             raise HTTPException(status_code=404, detail="no such reaction")
         if owns != REACTION_FOUND:
@@ -430,9 +539,10 @@ def signal_reaction(reaction_id: str, verb: str, subject: str = "",
     return {verb: True}
 
 
-@app.get("/timeline", dependencies=[Depends(timeline_auth)])
+@app.get("/timeline")
 def timeline(subject: str = "", since: str = "", until: str = "", limit: int = 20,
-             meetings: bool = True, format: str = "json"):
+             meetings: bool = True, format: str = "json",
+             caller: Caller = Depends(timeline_reader)):
     """ONE PERSON'S DAY, IN ORDER — PRD decision 31.
 
     Founder, 2026-09-02: *"does the agent have temporal awareness of the last events and future
@@ -445,6 +555,9 @@ def timeline(subject: str = "", since: str = "", until: str = "", limit: int = 2
     scopes, because the invite lineage carries an organizer and no uid while the completed lineage
     carries a uid and, without the resolution, nothing to match an address on. Scoping on one of
     them silently returns half a day — see `flows_timeline.model.concerns`.
+
+    A PERSON does not send it: their subject is derived from their own credential, and one naming
+    anyone else is refused (issue #1468). An operator still asks about whoever they name.
 
     `since` / `until` take epoch seconds or ISO-8601; the default window straddles NOW (14 days
     back, 30 forward) because half of what decision 31 asks for is in the future. `limit` keeps the
@@ -464,7 +577,7 @@ def timeline(subject: str = "", since: str = "", until: str = "", limit: int = 2
     about one meeting, and the zone is a fact about the person, which this service can read and a
     worker container cannot.
     """
-    subj = (subject or "").strip()
+    subj = scoped_subject(caller, subject)
     if not subj:
         raise HTTPException(status_code=400,
                             detail="subject is required: a platform uid, or an email address")
@@ -474,7 +587,8 @@ def timeline(subject: str = "", since: str = "", until: str = "", limit: int = 2
             "expected": "a platform uid (digits) or an email address"})
     out = build_timeline(db, subj, since=since or None, until=until or None,
                          limit=max(1, min(int(limit or 20), 200)),
-                         meetings=fetch_meetings if meetings else None)
+                         meetings=fetch_meetings if meetings else None,
+                         identity=_as_me(caller))
     if out.get("unresolved"):
         raise HTTPException(status_code=404, detail=f"nobody answers to {subj!r}")
     shape = (format or "json").strip().lower()

--- a/core/flows/src/flows_integrations/subject_auth.py
+++ b/core/flows/src/flows_integrations/subject_auth.py
@@ -1,0 +1,117 @@
+"""WHO IS CALLING — resolved from the caller's own credential, by the service that owns the answer.
+
+Flows' whole surface used to sit behind one deployment-wide operator key. That key is not a person:
+with it `GET /reactions` returns every reaction in the instance and `POST /reactions/{id}/cancel`
+cancels any of them. So the MCP edge — which forwards the CALLER's credential and holds none of its
+own — could be wired two ways and both were wrong: refuse the person, or hand them the instance.
+
+This module is the third way, and it is deliberately NOT a new answer to "who is this". Identity
+owns that answer and publishes it at `/internal/validate`; the gateway is the caller everyone knows
+about (`core/gateway/services/gateway/src/gateway/adapters.py:85`). Flows is now a SECOND CALLER of
+that ONE resolver, not a second resolver — the distinction P23 is about. Nothing here parses a
+token, reads a users table, or decides what a scope means.
+
+THREE ANSWERS, AND THE THIRD IS THE ONE THAT GETS CONFUSED:
+
+    identity says user 126        ->  Caller(kind="subject", uid="126", email=…)
+    identity says "invalid token" ->  SubjectUnknown            -> 401, the caller's problem
+    identity does not answer,     ->  IdentityUnavailable       -> 503, OUR problem
+      or refuses OUR secret
+
+The third is the whole reason this is a module and not four lines in the route. An oracle that
+cannot be reached has NOT reached a verdict on the credential, and reporting one is how #495/#483
+turned a gateway hiccup into "your API key is invalid" for every user at once. `adapters.py:99-101`
+records that lesson at the gateway; this is the same rule at flows' door, including the case the
+gateway does not have: identity answering 403 because OUR internal secret is wrong is a deployment
+fault, and telling the person their key is invalid sends them to rotate a key that works.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import flows_config
+
+#: identity's authz oracle — the route, not a route. Same path the gateway posts to.
+VALIDATE_PATH = "/internal/validate"
+#: how long we wait for it. The gateway waits 5s for the same hop; a door check that takes longer
+#: than the call it guards is its own outage.
+TIMEOUT_S = 5.0
+
+
+class IdentityUnavailable(Exception):
+    """Identity could not be reached, or refused US. NOT a verdict on the caller's credential."""
+
+
+class SubjectUnknown(Exception):
+    """Identity answered, and nobody answers to this credential."""
+
+
+@dataclass(frozen=True)
+class Caller:
+    """Who is on the other end of this request, and in which of the two tiers.
+
+    ``admin`` is the operator key: unscoped, every route, the behaviour this service has always
+    had. ``subject`` is one person, and every subject-scoped route derives its subject from
+    ``uid`` — never from an argument the caller sent.
+    """
+    kind: str
+    uid: str = ""
+    email: str = ""
+
+    @property
+    def is_admin(self) -> bool:
+        return self.kind == "admin"
+
+    @property
+    def names(self) -> set:
+        """Every spelling of this caller, lower-cased — the uid and the address.
+
+        Both, because a client that already holds one of them will send whichever it has, and the
+        two lineages this service scopes on carry different ones (`flows_timeline.model.concerns`).
+        """
+        return {s for s in (self.uid.strip().lower(), self.email.strip().lower()) if s}
+
+
+def _validate(base: str, token: str, secret: str):
+    """The one HTTP hop, alone in a function so a test can replace exactly it.
+
+    `flows_steps.common.http` rather than httpx: flows has no httpx at runtime and reaches every
+    service over urllib — declaring a wheel for one POST would make this module the reason the
+    image grows.
+    """
+    from flows_steps.common import http
+    return http("POST", f"{base}{VALIDATE_PATH}", {"X-Internal-Secret": secret}, {"token": token},
+                timeout=TIMEOUT_S)
+
+
+def resolve(token: str, *, secret: str = "") -> Caller:
+    """The person this credential belongs to. Raises :class:`SubjectUnknown` or
+    :class:`IdentityUnavailable` — never returns a caller it is not sure about.
+
+    `secret` is the internal-tier credential the CALLER already read at boot — flows-api holds it
+    as a module constant precisely so an unconfigured deployment stops at import rather than at the
+    first request. Passed in rather than re-read here so there is one read of it in the process,
+    and so a missing one is a boot refusal and never a per-request 503.
+    """
+    token = str(token or "").strip()
+    if not token:
+        raise SubjectUnknown("no credential")
+    if not secret:
+        from flows_steps.common import require_internal_secret
+        secret = require_internal_secret()
+    base = flows_config.require("VEXA_FLOWS_ADMIN_API_URL").rstrip("/")
+    try:
+        code, body = _validate(base, token, secret)
+    except Exception as e:  # noqa: BLE001 — transport, DNS, a refused connection: all one answer
+        raise IdentityUnavailable(f"{type(e).__name__}: {e}"[:200]) from e
+
+    code = int(code or 0)
+    if code == 401:
+        raise SubjectUnknown("identity does not recognise this credential")
+    if code != 200 or not isinstance(body, dict):
+        # 403 = our internal secret; 503 = identity unconfigured; anything else = not a verdict.
+        raise IdentityUnavailable(f"identity answered {code} to the token check")
+    uid = body.get("user_id")
+    if uid in (None, ""):
+        raise IdentityUnavailable("identity answered 200 with no user_id")
+    return Caller(kind="subject", uid=str(uid), email=str(body.get("email") or ""))

--- a/core/flows/tests/test_health.py
+++ b/core/flows/tests/test_health.py
@@ -57,9 +57,9 @@ def test_health_ok():
 
 
 def test_health_takes_no_credential():
-    """The probe must not sit behind X-Flows-Admin-Key.
+    """The probe must not sit behind X-Flows-Operator-Key.
 
-    Every other route on this surface carries `Depends(auth)`. If this one ever acquires it, an
+    Every other route on this surface takes a credential. If this one ever acquires one, an
     orchestrator without the operator key reads 401 — indistinguishable from a dead process to a
     restart policy, and one more place the key has to reach.
     """

--- a/core/flows/tests/test_subject_bearer.py
+++ b/core/flows/tests/test_subject_bearer.py
@@ -127,6 +127,10 @@ def bearer(token):
 
 
 def admin():
+    return {"X-Flows-Operator-Key": OPERATOR}
+
+
+def admin_old_name():
     return {"X-Flows-Admin-Key": OPERATOR}
 
 
@@ -306,3 +310,40 @@ def test_the_timeline_refuses_a_subject_that_is_not_yours(client, identity):
 def test_the_flow_listing_takes_a_persons_bearer(client, identity):
     r = client.get("/flows", headers=bearer("anna-key"))
     assert r.status_code == 200 and "steps_vocabulary" in r.json()
+
+
+# ── the operator header says what it holds ──────────────────────────────────────────────────────
+
+def test_the_operator_key_travels_under_a_name_that_says_what_it_is(client, identity):
+    """`X-Flows-Admin-Key` reads as admin-api's token and is not: it is flows-api's own operator
+    key. The two have been confused on a live deployment, which is how a lane came to run on the
+    string `changeme`. Splitting this surface into two tiers is the moment the name has to stop
+    lying."""
+    assert client.get("/reactions", headers=admin()).status_code == 200
+
+
+def test_the_old_name_still_opens_the_door_for_one_release(client, identity):
+    assert client.get("/reactions", headers=admin_old_name()).status_code == 200
+    assert client.post("/events", headers=admin_old_name(), json={
+        "event_type": "meeting.completed", "source_event_id": "s-old", "refs": {}}
+    ).status_code != 401
+
+
+def test_the_old_name_says_once_that_it_is_deprecated(client, identity, capsys):
+    fa._DEPRECATED_HEADER_SAID.clear()
+    client.get("/reactions", headers=admin_old_name())
+    first = capsys.readouterr().out
+    assert "X-Flows-Admin-Key" in first and "X-Flows-Operator-Key" in first
+    client.get("/reactions", headers=admin_old_name())
+    assert capsys.readouterr().out == "", "once per process, not once per request"
+
+
+def test_the_new_name_wins_when_both_are_sent(client, identity):
+    r = client.get("/reactions", headers={"X-Flows-Operator-Key": OPERATOR,
+                                          "X-Flows-Admin-Key": "not-the-key"})
+    assert r.status_code == 200
+
+
+def test_a_wrong_operator_key_under_either_name_is_refused(client, identity):
+    assert client.get("/reactions", headers={"X-Flows-Operator-Key": "wrong"}).status_code == 401
+    assert client.get("/reactions", headers={"X-Flows-Admin-Key": "wrong"}).status_code == 401

--- a/core/flows/tests/test_subject_bearer.py
+++ b/core/flows/tests/test_subject_bearer.py
@@ -347,3 +347,56 @@ def test_the_new_name_wins_when_both_are_sent(client, identity):
 def test_a_wrong_operator_key_under_either_name_is_refused(client, identity):
     assert client.get("/reactions", headers={"X-Flows-Operator-Key": "wrong"}).status_code == 401
     assert client.get("/reactions", headers={"X-Flows-Admin-Key": "wrong"}).status_code == 401
+
+
+# ── `GET /queue/waiting` — the fifth subject-scoped route (#1482 landed it operator-keyed) ──────
+
+@pytest.fixture
+def queue_subject(monkeypatch):
+    """Records WHICH subject the queue projection was asked about. The door is what is under test
+    here; `tests/test_queue_waiting.py` owns what the projection answers."""
+    asked = []
+
+    def waiting(_db, *, subject, flows, limit):
+        asked.append(subject)
+        return {"items": [], "flows": []}
+
+    monkeypatch.setattr(fa._flows_queue, "waiting", waiting)
+    return asked
+
+
+def test_the_queue_takes_a_persons_bearer_and_answers_about_them(client, identity, queue_subject):
+    r = client.get("/queue/waiting", headers=bearer("anna-key"))
+    assert r.status_code == 200, r.text
+    assert queue_subject == ["126"]
+
+
+def test_the_queue_refuses_a_subject_that_is_not_yours(client, identity, queue_subject):
+    r = client.get("/queue/waiting", params={"subject": "512"}, headers=bearer("anna-key"))
+    assert r.status_code == 403, r.text
+    assert queue_subject == [], "nothing was read"
+
+
+def test_a_stamped_user_id_does_not_beat_an_authenticated_person(client, identity, queue_subject):
+    """`X-User-Id` is a header a caller can type. It is trustworthy on this route only because the
+    OPERATOR key gates it — a service identity vouching for a person it resolved. A person's own
+    credential is stronger evidence than any header, so when one is present it wins.
+
+    This route is not always behind the gateway: reached through the MCP edge it is addressed
+    directly, and the edge stamps no `X-User-Id` at all."""
+    r = client.get("/queue/waiting", headers={**bearer("anna-key"), "X-User-Id": "512"})
+    assert r.status_code == 200
+    assert queue_subject == ["126"], "a header overrode a verified credential"
+
+
+def test_the_operator_read_still_honours_the_stamped_identity(client, identity, queue_subject):
+    """Unchanged: with the operator key, `X-User-Id` is the gateway's answer and still wins over
+    `?subject=` — `tests/test_queue_waiting.py` owns that row and it must keep passing."""
+    r = client.get("/queue/waiting", params={"subject": "999"},
+                   headers={**admin(), "X-User-Id": "126"})
+    assert r.status_code == 200 and queue_subject == ["126"]
+
+
+def test_the_queue_needs_a_credential(client, identity, queue_subject):
+    assert client.get("/queue/waiting", params={"subject": "126"}).status_code == 401
+    assert queue_subject == []

--- a/core/flows/tests/test_subject_bearer.py
+++ b/core/flows/tests/test_subject_bearer.py
@@ -1,0 +1,308 @@
+"""A PERSON'S OWN CREDENTIAL, on the routes that are about that person — issue #1468.
+
+Every route on this service used to take one deployment-wide operator key, and that key is not a
+person: with it `GET /reactions` returns every reaction in the instance and
+`POST /reactions/{id}/cancel` cancels any of them. So the MCP edge, which forwards the CALLER's own
+credential and holds none of its own, could be wired two ways and both were wrong — refuse the
+person (what it did: a 401 arriving inside a JSON-RPC envelope), or hand them the instance.
+
+This is the third way. The subject-scoped routes accept the person's own Vexa credential, resolve
+who that is through identity's `/internal/validate` — the one resolver, the same one the gateway
+asks — and scope on the answer. The admin routes are untouched.
+
+OFFLINE. `flows_api` builds its app at import and refuses to start without its credentials, so they
+are supplied here before the import exactly as `test_health.py` does, with the SAME literals: the
+module captures them as constants at import, and whichever test module imports first wins.
+
+The identity hop is stubbed at its lowest seam — `subject_auth._validate`, the one HTTP call — so
+the mapping from what identity answers to what this service answers is what is under test, and not
+a mock of the answer we wanted.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+_ENV = {"VEXA_FLOWS_API_KEY": "test-flows-key",
+        "INTERNAL_API_SECRET": "test-internal-secret",
+        "VEXA_FLOWS_DB_URL": "sqlite://"}
+_saved = {k: os.environ.get(k) for k in _ENV}
+os.environ.update(_ENV)
+try:
+    from flows_integrations import flows_api as fa  # noqa: E402
+    from flows_integrations import subject_auth  # noqa: E402
+finally:
+    for _k, _v in _saved.items():
+        if _v is None:
+            os.environ.pop(_k, None)
+        else:
+            os.environ[_k] = _v
+
+OPERATOR = fa.API_KEY
+
+#: Two people and one stranger's reaction. The two lineages `flows_timeline.model.concerns`
+#: documents are both here on purpose: `meeting.completed` carries a uid and no address,
+#: `invite.received` carries an organizer address and no uid.
+ANNA = {"uid": "126", "email": "anna@vexa.test"}
+BEN = {"uid": "512", "email": "ben@vexa.test"}
+
+ROWS = {
+    "r-anna-uid": {"uid": "126", "meeting_id": 104, "title": "Anna's standup"},
+    "r-anna-email": {"organizer": "anna@vexa.test", "ics_uid": "a@b", "title": "Anna's invite"},
+    "r-ben": {"uid": "512", "organizer": "ben@vexa.test", "meeting_id": 7, "title": "Ben's review"},
+}
+T0 = 1_788_000_000.0
+
+
+@pytest.fixture(autouse=True)
+def rows():
+    """The reaction table, rebuilt for each test — two of Anna's, one of Ben's."""
+    fa.db.execute("DELETE FROM reaction")
+    for rid, refs in ROWS.items():
+        fa.db.execute(
+            """INSERT INTO reaction (reaction_id, source_event_id, event_type, subject_refs,
+                                     flow, flow_version, step, status, attempt, next_run_at,
+                                     reason, created_at, updated_at)
+               VALUES (:rid,:sid,'meeting.completed',:refs,'post_meeting',1,'email_minutes',
+                       'waiting',0,0,NULL,:c,:c)""",
+            {"rid": rid, "sid": f"{rid}::post_meeting", "refs": json.dumps(refs), "c": T0})
+    yield
+    fa.db.execute("DELETE FROM reaction")
+
+
+@pytest.fixture
+def identity(monkeypatch):
+    """Identity, stubbed at the ONE http hop `subject_auth` makes.
+
+    `set(...)` installs a table of token -> what `/internal/validate` answers; `down(...)` makes the
+    hop fail the way an unreachable service fails. Both are the real shapes: a 200 body with
+    `user_id` and `email`, a 401 for a token nobody answers to, a 403 when OUR internal secret is
+    wrong, and a transport error."""
+    class Identity:
+        def __init__(self):
+            self.calls = []
+
+        def set(self, table):
+            def _validate(base, token, secret):
+                self.calls.append((base, token, secret))
+                return table.get(token, (401, {"detail": "Invalid token"}))
+            monkeypatch.setattr(subject_auth, "_validate", _validate)
+
+        def answers(self, code, body):
+            def _validate(base, token, secret):
+                self.calls.append((base, token, secret))
+                return code, body
+            monkeypatch.setattr(subject_auth, "_validate", _validate)
+
+        def down(self):
+            def _validate(base, token, secret):
+                self.calls.append((base, token, secret))
+                from flows import StepError
+                raise StepError("http POST .../internal/validate: URLError: connection refused")
+            monkeypatch.setattr(subject_auth, "_validate", _validate)
+
+    ident = Identity()
+    ident.set({
+        "anna-key": (200, {"user_id": 126, "email": "anna@vexa.test", "scopes": ["legacy"]}),
+        "ben-key": (200, {"user_id": 512, "email": "ben@vexa.test", "scopes": ["legacy"]}),
+    })
+    return ident
+
+
+@pytest.fixture
+def client():
+    return TestClient(fa.app, raise_server_exceptions=False)
+
+
+def bearer(token):
+    return {"Authorization": f"Bearer {token}"}
+
+
+def admin():
+    return {"X-Flows-Admin-Key": OPERATOR}
+
+
+# ── A1 · a person's own credential lists their own reactions ─────────────────────────────────────
+
+def test_a_persons_own_bearer_lists_their_own_reactions(client, identity):
+    r = client.get("/reactions", headers=bearer("anna-key"))
+    assert r.status_code == 200, r.text
+    assert {x["id"] for x in r.json()["reactions"]} == {"r-anna-uid", "r-anna-email"}
+
+
+def test_the_operator_key_still_lists_every_reaction(client, identity):
+    """The unscoped operator read this route has always had — and the reason A1 could never have
+    been observed before: the route function shadowed the model function it calls, so every
+    authenticated call raised `TypeError: list_reactions() got multiple values for argument
+    'status'` and answered 500. The 401 in front of it is what hid that for as long as it did."""
+    r = client.get("/reactions", headers=admin())
+    assert r.status_code == 200, r.text
+    assert {x["id"] for x in r.json()["reactions"]} == set(ROWS)
+
+
+def test_the_api_key_header_carries_a_bearer_too(client, identity):
+    """The MCP edge forwards the caller's credential as `X-API-Key` (register.py) and the gateway
+    resolves the same header, so both spellings of ONE credential reach this door."""
+    r = client.get("/reactions", headers={"X-API-Key": "anna-key"})
+    assert r.status_code == 200 and {x["id"] for x in r.json()["reactions"]} == {
+        "r-anna-uid", "r-anna-email"}
+
+
+# ── A2 · and nobody else's ───────────────────────────────────────────────────────────────────────
+
+def test_another_persons_bearer_sees_none_of_the_first_persons_rows(client, identity):
+    r = client.get("/reactions", headers=bearer("ben-key"))
+    assert r.status_code == 200
+    assert {x["id"] for x in r.json()["reactions"]} == {"r-ben"}
+
+
+def test_cancelling_a_reaction_that_is_not_yours_is_refused(client, identity):
+    r = client.post("/reactions/r-ben/cancel", headers=bearer("anna-key"), json={})
+    assert r.status_code == 403, r.text
+    assert fa.db.execute("SELECT status FROM reaction WHERE reaction_id='r-ben'")[0][0] == "waiting"
+
+
+def test_cancelling_your_own_reaction_works(client, identity):
+    r = client.post("/reactions/r-anna-uid/cancel", headers=bearer("anna-key"), json={})
+    assert r.status_code == 200, r.text
+    assert fa.db.execute(
+        "SELECT status FROM reaction WHERE reaction_id='r-anna-uid'")[0][0] == "cancelled"
+
+
+def test_ownership_is_checked_even_when_no_subject_argument_is_sent(client, identity):
+    """Before this, ownership was checked only when the CALLER passed `subject=` — an argument the
+    caller asserts. A person who simply omitted it got the unscoped operator behaviour."""
+    r = client.post("/reactions/r-ben/retry", headers=bearer("anna-key"), json={})
+    assert r.status_code == 403
+
+
+# ── A3 · no credential opens nothing ─────────────────────────────────────────────────────────────
+
+SUBJECT_SCOPED = [("GET", "/flows"), ("GET", "/reactions"),
+                  ("POST", "/reactions/r-anna-uid/cancel"), ("GET", "/timeline?subject=126")]
+
+
+@pytest.mark.parametrize("method,path", SUBJECT_SCOPED)
+def test_no_credential_at_all_is_refused(client, identity, method, path):
+    r = client.request(method, path, json={} if method == "POST" else None)
+    assert r.status_code == 401, f"{method} {path} -> {r.status_code}"
+
+
+@pytest.mark.parametrize("method,path", SUBJECT_SCOPED)
+def test_the_operator_key_still_opens_every_one_of_them(client, identity, method, path):
+    r = client.request(method, path, headers=admin(), json={} if method == "POST" else None)
+    assert r.status_code != 401, f"{method} {path} -> {r.status_code}: {r.text[:200]}"
+
+
+# ── A4 · the admin routes are still admin-keyed ──────────────────────────────────────────────────
+
+ADMIN_ONLY = [
+    ("POST", "/flows", {"name": "x", "on_event": "e", "steps": ["email_minutes"]}),
+    ("POST", "/events", {"event_type": "meeting.completed", "source_event_id": "s1", "refs": {}}),
+    ("POST", "/events/batch", {"meetings": [{"url": "https://m.test/a", "organizer": "a@b.test",
+                                             "start": T0}]}),
+    ("POST", "/flows/post_meeting/1/retire", {}),
+]
+
+
+@pytest.mark.parametrize("method,path,body", ADMIN_ONLY)
+def test_a_persons_bearer_does_not_open_an_admin_route(client, identity, method, path, body):
+    r = client.request(method, path, headers=bearer("anna-key"), json=body)
+    assert r.status_code == 401, f"{method} {path} -> {r.status_code}: {r.text[:200]}"
+
+
+@pytest.mark.parametrize("method,path,body", ADMIN_ONLY)
+def test_the_operator_key_still_opens_the_admin_routes(client, identity, method, path, body):
+    """`!= 401` rather than a status: past the door each of these has its own answer — the instance
+    gate's 409, an unknown flow version's 404 — and this row is about the door."""
+    r = client.request(method, path, headers=admin(), json=body)
+    assert r.status_code != 401, f"{method} {path} -> {r.status_code}: {r.text[:200]}"
+
+
+# ── A5 · the subject is derived, and a subject that is not yours is refused ──────────────────────
+
+def test_a_subject_argument_naming_someone_else_is_refused(client, identity):
+    r = client.get("/reactions", params={"subject": "512"}, headers=bearer("anna-key"))
+    assert r.status_code == 403, r.text
+    assert "512" in json.dumps(r.json())
+
+
+def test_naming_yourself_by_uid_is_accepted(client, identity):
+    r = client.get("/reactions", params={"subject": "126"}, headers=bearer("anna-key"))
+    assert r.status_code == 200
+    assert {x["id"] for x in r.json()["reactions"]} == {"r-anna-uid", "r-anna-email"}
+
+
+def test_naming_yourself_by_email_is_accepted(client, identity):
+    r = client.get("/reactions", params={"subject": "ANNA@vexa.test"}, headers=bearer("anna-key"))
+    assert r.status_code == 200
+    assert {x["id"] for x in r.json()["reactions"]} == {"r-anna-uid", "r-anna-email"}
+
+
+def test_the_answer_states_which_subject_it_is_about(client, identity):
+    """An argument silently overridden is the same defect as one silently dropped: the caller has
+    to be able to see whose rows came back."""
+    assert client.get("/reactions", headers=bearer("anna-key")).json()["subject"] == "126"
+    assert client.get("/reactions", headers=admin()).json()["subject"] == ""
+
+
+def test_an_operator_may_still_read_any_subject(client, identity):
+    r = client.get("/reactions", params={"subject": "512"}, headers=admin())
+    assert r.status_code == 200
+    assert {x["id"] for x in r.json()["reactions"]} == {"r-ben"}
+
+
+# ── A6 · an unreachable resolver is not a verdict on the credential ──────────────────────────────
+
+def test_identity_unreachable_is_503_not_401(client, identity):
+    identity.down()
+    r = client.get("/reactions", headers=bearer("anna-key"))
+    assert r.status_code == 503, r.text
+
+
+def test_identity_saying_the_token_is_unknown_is_401(client, identity):
+    r = client.get("/reactions", headers=bearer("no-such-key"))
+    assert r.status_code == 401, r.text
+
+
+def test_our_own_internal_secret_being_wrong_is_not_the_callers_fault(client, identity):
+    """identity answers 403 when the INTERNAL secret is wrong. That is a deployment fault; telling
+    the person their credential is invalid would send them to rotate a working key."""
+    identity.answers(403, {"detail": "Invalid internal secret"})
+    r = client.get("/reactions", headers=bearer("anna-key"))
+    assert r.status_code == 503, r.text
+
+
+def test_the_resolver_is_the_one_the_gateway_asks(client, identity):
+    """P23 — one resolver of who the caller is. Not a second lookup of our own: the same
+    `/internal/validate`, over the internal secret, that `gateway/adapters.py` posts to."""
+    client.get("/reactions", headers=bearer("anna-key"))
+    base, token, secret = identity.calls[-1]
+    assert token == "anna-key" and secret == "test-internal-secret"
+
+
+# ── the other two subject-scoped routes ──────────────────────────────────────────────────────────
+
+def test_the_timeline_takes_a_persons_bearer_and_answers_about_them(client, identity):
+    r = client.get("/timeline", params={"meetings": "false"}, headers=bearer("anna-key"))
+    assert r.status_code == 200, r.text
+    assert r.json()["uid"] == "126"
+
+
+def test_the_timeline_refuses_a_subject_that_is_not_yours(client, identity):
+    r = client.get("/timeline", params={"subject": "512", "meetings": "false"},
+                   headers=bearer("anna-key"))
+    assert r.status_code == 403, r.text
+
+
+def test_the_flow_listing_takes_a_persons_bearer(client, identity):
+    r = client.get("/flows", headers=bearer("anna-key"))
+    assert r.status_code == 200 and "steps_vocabulary" in r.json()

--- a/core/flows/tests/test_subject_bearer.py
+++ b/core/flows/tests/test_subject_bearer.py
@@ -72,7 +72,7 @@ def rows():
                                      flow, flow_version, step, status, attempt, next_run_at,
                                      reason, created_at, updated_at)
                VALUES (:rid,:sid,'meeting.completed',:refs,'post_meeting',1,'email_minutes',
-                       'waiting',0,0,NULL,:c,:c)""",
+                       'admitted',0,0,NULL,:c,:c)""",
             {"rid": rid, "sid": f"{rid}::post_meeting", "refs": json.dumps(refs), "c": T0})
     yield
     fa.db.execute("DELETE FROM reaction")
@@ -167,7 +167,7 @@ def test_another_persons_bearer_sees_none_of_the_first_persons_rows(client, iden
 def test_cancelling_a_reaction_that_is_not_yours_is_refused(client, identity):
     r = client.post("/reactions/r-ben/cancel", headers=bearer("anna-key"), json={})
     assert r.status_code == 403, r.text
-    assert fa.db.execute("SELECT status FROM reaction WHERE reaction_id='r-ben'")[0][0] == "waiting"
+    assert fa.db.execute("SELECT status FROM reaction WHERE reaction_id='r-ben'")[0][0] == "admitted"
 
 
 def test_cancelling_your_own_reaction_works(client, identity):

--- a/core/identity/services/admin-api/src/admin_api/app/events.py
+++ b/core/identity/services/admin-api/src/admin_api/app/events.py
@@ -71,7 +71,11 @@ def publish(event_type: str, source_event_id: str, subject_refs: dict,
     headers = {"content-type": "application/json"}
     key = _flows_key()
     if key:
-        headers["X-Flows-Admin-Key"] = key
+        # X-Flows-OPERATOR-Key: this is flows-api's own operator key (VEXA_FLOWS_API_KEY, read
+        # above), never admin-api's token. The header used to be spelled `X-Flows-Admin-Key`, and
+        # naming this service's own token in another service's header is precisely how a lane came
+        # to run on `changeme`. flows accepts the old name for one release.
+        headers["X-Flows-Operator-Key"] = key
     req = urllib.request.Request(f"{base}/events", data=body, headers=headers, method="POST")
     try:
         with urllib.request.urlopen(req, timeout=timeout or TIMEOUT_S) as r:  # noqa: S310

--- a/core/meetings/services/mcp/README.md
+++ b/core/meetings/services/mcp/README.md
@@ -40,6 +40,12 @@ Each tool answers two different questions, and conflating them is what issue #14
   by its own door is worse than one that is absent: an agent that cannot see a tool recovers.
 - **`none`** — nothing travels.
 
+A tool's **arguments** are its `arguments` list plus the path parameters of its route, and both are
+published in the tool's input schema with the owning route's own types and descriptions — the
+manifest never restates a route, and an argument an agent cannot see is an argument that does not
+exist. Path parameters are required; declared arguments are optional. An argument the tool does not
+declare is refused rather than dropped.
+
 **Migration note (operator-visible):** `auth` is **required**. A manifest written against the
 previous shape — including one supplied through `VEXA_MCP_MANIFEST_DIR` — refuses the boot, naming
 the tool and the field. That is deliberate: a default is a guess applied silently to every tool, and

--- a/core/meetings/services/mcp/README.md
+++ b/core/meetings/services/mcp/README.md
@@ -18,6 +18,33 @@ redis, never reaches into meeting-api or admin-api directly.
 | calls | ticket sink (`VEXA_TICKET_SINK_URL`) | `POST <sink>` | `report_issue` tickets: the agent's words + a server timestamp + a dedupe fingerprint + a **salted fingerprint of the caller's key** (never the key). Unset → `report_issue` returns 503 and nothing else is affected. |
 | calls | gateway (`GATEWAY_URL`) | `POST /bots` · `GET /bots/status` · `PUT/DELETE /bots/{platform}/{native}` · `GET /meetings` · `GET /transcripts/{platform}/{native}` · `GET /recordings[/{id}]` | each tool forwards verbatim with the caller's `X-API-Key` |
 
+## The manifest contract — `mcp.tools.v1`
+
+A domain that owns a door publishes its tools at `/.well-known/mcp-tools.json`; this service unions
+what the deployed domains declare and refuses the combinations that cannot be right
+(`src/vexa_mcp/manifest.py` is the contract — there is no separate schema file, so that validator
+and this section are the two places it is written).
+
+Each tool answers two different questions, and conflating them is what issue #1468 was:
+
+| field | question | values |
+|---|---|---|
+| `identity` | who the CALLER must be | `user` · `admin` · `operator` · `none` |
+| `auth` | which credential THIS EDGE presents to the door on their behalf | `subject` · `admin` · `none` |
+
+- **`subject`** — the caller's own credential travels, as `X-API-Key`. Always satisfiable: the
+  caller brought it. This is what the edge used to do for every tool, whether or not it was right.
+- **`admin`** — a key the *deployment* holds travels instead, and the caller's does not. The domain
+  must also declare `admin_auth: {"header": …, "key_env": …}`, and this deployment must actually
+  hold that key, or **the boot is refused, naming the tool**. A tool that is listed and then refused
+  by its own door is worse than one that is absent: an agent that cannot see a tool recovers.
+- **`none`** — nothing travels.
+
+**Migration note (operator-visible):** `auth` is **required**. A manifest written against the
+previous shape — including one supplied through `VEXA_MCP_MANIFEST_DIR` — refuses the boot, naming
+the tool and the field. That is deliberate: a default is a guess applied silently to every tool, and
+the guess was wrong for the four it was applied to.
+
 ## Tools (10)
 
 | Tool | Wraps |

--- a/core/meetings/services/mcp/src/vexa_mcp/app.py
+++ b/core/meetings/services/mcp/src/vexa_mcp/app.py
@@ -1251,7 +1251,7 @@ def create_app(
         with httpx.Client(transport=assembly_transport) as _boot:
             _assembly, _openapi, _bases = discover_mod.discover(_boot, env=_assembly_env)
         _bound = bind_mod.verify(_assembly, _openapi)
-        register_mod.register(app, _bound, _bases, transport=transport)
+        register_mod.register(app, _bound, _bases, transport=transport, env=_assembly_env)
         app.state.assembly = _assembly
 
     # ---------------------------

--- a/core/meetings/services/mcp/src/vexa_mcp/bind.py
+++ b/core/meetings/services/mcp/src/vexa_mcp/bind.py
@@ -66,8 +66,17 @@ def verify(assembly: Assembly, openapi_by_domain: Dict[str, dict]) -> List[Bound
             raise ManifestError(
                 f"{tool.domain}/{tool.name}: {tool.domain} does not serve {method} {path} — the "
                 "manifest names a route its own service does not have")
-        params = {p.get("name"): (p.get("schema") or {})
-                  for p in (op.get("parameters") or []) if p.get("name")}
+        # The DESCRIPTION travels with the schema. It is the owning route's own words about that
+        # argument, and it is the only thing an agent reads before deciding what to put there —
+        # dropping it publishes a typed blank.
+        params = {}
+        for spec in (op.get("parameters") or []):
+            if not spec.get("name"):
+                continue
+            schema = dict(spec.get("schema") or {})
+            if spec.get("description") and "description" not in schema:
+                schema["description"] = spec["description"]
+            params[spec["name"]] = schema
         path_params = tuple(_PATH_PARAM.findall(path))
         declared = {}
         for arg in tool_arguments(tool):

--- a/core/meetings/services/mcp/src/vexa_mcp/discover.py
+++ b/core/meetings/services/mcp/src/vexa_mcp/discover.py
@@ -98,4 +98,6 @@ def discover(client: httpx.Client, *, env: Optional[dict] = None
         openapi[domain] = spec
 
     deployed: Set[str] = set(bases)
-    return assemble(manifests, deployed=deployed), openapi, bases
+    # `env` reaches the assembler because "can this edge authenticate that tool" is a DEPLOYMENT
+    # question, and the assembler is where every other boot refusal already lives.
+    return assemble(manifests, deployed=deployed, env=env), openapi, bases

--- a/core/meetings/services/mcp/src/vexa_mcp/manifest.py
+++ b/core/meetings/services/mcp/src/vexa_mcp/manifest.py
@@ -20,6 +20,7 @@ that is not there:
     one name claimed twice                   ->  last-one-wins, and nobody knows which won
     a route the domain does not serve        ->  the manifest lying about its own service
     two entitlement hooks                    ->  "may this person act" answered twice
+    a door this edge cannot authenticate     ->  a listed tool that 401s on first use
 
 The one thing that is NOT a failure is a domain that is simply not deployed. Its tools are ABSENT
 from `tools/list` — an agent that cannot see a tool recovers; an agent told a tool exists and then
@@ -28,6 +29,7 @@ handed a 502 tells the person the product is broken.
 from __future__ import annotations
 
 import json
+import os
 import pathlib
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional, Set
@@ -50,6 +52,27 @@ DOMAINS = {"meetings", "identity", "flows", "agent", "gateway", "rehearse", "bil
 IDENTITIES = {"user", "admin", "operator", "none"}
 METHODS = {"GET", "POST", "PUT", "PATCH", "DELETE"}
 
+# WHICH CREDENTIAL THE DOOR BEHIND A TOOL READS — issue #1468. `identity` above says who the CALLER
+# must be; this says what THIS EDGE has to present on their behalf, and they are different
+# questions. Without it the edge had one move — forward the caller's own credential to everything —
+# and found out at call time whether the door read that. Flows' four tools sat behind a
+# deployment-wide operator key this edge does not hold and must never hold, so the answer reached
+# the agent as a JSON-RPC result with a 401 inside it: a tool in `tools/list` that cannot work.
+#
+#   subject   the caller's own credential travels. ALWAYS satisfiable — the caller brought it.
+#   admin     a key the DEPLOYMENT holds travels instead, and the caller's does not. Satisfiable
+#             only where that key is actually configured, which is why it fails the boot.
+#   none      nothing travels.
+#
+# REQUIRED, not defaulted. A default is what the edge already had — a guess, applied silently to
+# every tool, and wrong for four of them. A field that may be omitted reproduces this hole for the
+# next manifest, and the next manifest is the one nobody is watching.
+AUTHS = {"subject", "admin", "none"}
+#: Published literals a stock deploy surface once supplied — the same refusal list flows-api and the
+#: services' `config.v1` keep. A key that is in this repository authenticates nobody and everybody.
+PLACEHOLDER_KEYS = {"changeme", "change-me", "default", "secret", "vexa-internal-secret",
+                    "lite-internal-secret"}
+
 
 class ManifestError(Exception):
     """A manifest, or a combination of them, that this deployment must not boot with."""
@@ -66,6 +89,10 @@ class Tool:
     base_url_env: Optional[str]
     arguments: tuple = ()
     note: str = ""
+    #: which credential this edge presents to the door — see AUTHS.
+    auth: str = "subject"
+    #: for `auth: admin`, the domain's `{"header": …, "key_env": …}`. None for every other value.
+    admin_auth: Optional[dict] = None
 
 
 @dataclass(frozen=True)
@@ -110,6 +137,17 @@ def validate(doc: dict) -> dict:
             raise ManifestError(f"{domain}: a tool with no name")
         if t.get("identity") not in IDENTITIES:
             raise ManifestError(f"{domain}/{name}: identity must be one of {sorted(IDENTITIES)}")
+        auth = t.get("auth")
+        if auth not in AUTHS:
+            raise ManifestError(
+                f"{domain}/{name}: auth must be one of {sorted(AUTHS)} (got {auth!r}) — every tool "
+                "states which credential its door reads. There is no default: the default is what "
+                "this edge used to guess, and it guessed wrong for every operator-keyed route.")
+        if auth == "admin" and not _admin_auth(doc):
+            raise ManifestError(
+                f"{domain}/{name}: auth is admin, so {domain} must declare admin_auth "
+                '{"header": …, "key_env": …} — a deployment cannot hold a key it cannot spell, '
+                "and this edge will not invent the header the door reads.")
         requires = t.get("requires")
         if not isinstance(requires, list) or not requires:
             raise ManifestError(f"{domain}/{name}: requires must name at least one domain")
@@ -144,6 +182,15 @@ def validate(doc: dict) -> dict:
     return doc
 
 
+def _admin_auth(doc: dict) -> Optional[dict]:
+    """A domain's `{"header", "key_env"}`, or None when it did not declare a usable one."""
+    aa = doc.get("admin_auth")
+    if not isinstance(aa, dict):
+        return None
+    header, key_env = str(aa.get("header") or "").strip(), str(aa.get("key_env") or "").strip()
+    return {"header": header, "key_env": key_env} if header and key_env else None
+
+
 def load_mounted(directory: Optional[str]) -> List[dict]:
     """Every manifest a private deployment supplied. EMPTY IS THE OSS PRODUCT, exactly.
 
@@ -170,8 +217,16 @@ def load_mounted(directory: Optional[str]) -> List[dict]:
 
 
 def assemble(manifests: List[dict], *, deployed: Set[str],
-             required_domains: Optional[Set[str]] = None) -> Assembly:
-    """The union, with every combination rule applied. Raises :class:`ManifestError`."""
+             required_domains: Optional[Set[str]] = None,
+             env: Optional[dict] = None) -> Assembly:
+    """The union, with every combination rule applied. Raises :class:`ManifestError`.
+
+    `env` is the DEPLOYMENT, and it is here for one question: can this edge actually authenticate
+    each tool it is about to publish? A tool it cannot is refused now, by name, rather than served
+    and refused later by the door — the same fail-direction as every other rule in this module, and
+    the one the contract could not express until `auth` existed.
+    """
+    env = os.environ if env is None else env
     answered = {d.get("domain") for d in manifests}
     for missing in sorted((required_domains or set()) - answered):
         raise ManifestError(
@@ -202,11 +257,22 @@ def assemble(manifests: List[dict], *, deployed: Set[str],
             claimed[name] = (domain, source)
             if not set(t["requires"]) <= deployed:
                 continue
+            admin_auth = _admin_auth(doc) if t["auth"] == "admin" else None
+            if admin_auth:
+                held = str(env.get(admin_auth["key_env"]) or "").strip()
+                if not held or held in PLACEHOLDER_KEYS:
+                    raise ManifestError(
+                        f"{domain}/{name} needs the operator credential this deployment does not "
+                        f"hold: {admin_auth['key_env']} is "
+                        f"{'a published placeholder' if held else 'unset'}. Refusing to serve a "
+                        "tool that would be listed and then refused by its own door — set it, or "
+                        "take the tool out of this deployment's manifest.")
             out.tools.append(Tool(
                 name=name, domain=domain, source=source, identity=t["identity"],
                 requires=frozenset(t["requires"]), route=t.get("route"),
                 base_url_env=doc.get("base_url_env"),
-                arguments=tuple(t.get("arguments") or ()), note=t.get("note", "")))
+                arguments=tuple(t.get("arguments") or ()), note=t.get("note", ""),
+                auth=t["auth"], admin_auth=admin_auth))
     for doc in manifests:
         if doc["domain"] not in deployed:
             out.absent_domains.add(doc["domain"])

--- a/core/meetings/services/mcp/src/vexa_mcp/register.py
+++ b/core/meetings/services/mcp/src/vexa_mcp/register.py
@@ -6,10 +6,17 @@ mechanism makes an assembled tool and a built-in one indistinguishable to a clie
 whole point of assembling rather than proxying, and the reason there is no second code path to keep
 in step.
 
-WHAT TRAVELS: the caller's own credential, as `X-API-Key`, exactly as the fourteen send it. Nothing
-else. There is one authentication path into this edge (PRD 40.8) — a bearer in the header, the
-session bound by `Mcp-Session-Id` — so a tool cannot take a credential as an argument and this
-forward cannot invent one.
+WHAT TRAVELS: whichever credential the tool's `auth` names, and nothing else (issue #1468).
+`subject` sends the caller's own, as `X-API-Key`, exactly as the fourteen do — the case this edge
+was built for. `admin` sends the key the DEPLOYMENT holds, in the header the owning domain named,
+and the caller's own credential does NOT travel with it: a door that reads an operator key has no
+use for a person's, and forwarding both would let the weaker one look like it was checked.
+`none` sends neither.
+
+There is one authentication path INTO this edge (PRD 40.8) — a bearer in the header, the session
+bound by `Mcp-Session-Id` — so a tool cannot take a credential as an argument and this forward
+cannot invent one. What goes out of the edge is a different question, and it is the manifest that
+answers it; whether the deployment can answer it at all was already settled at assembly.
 
 WHAT DOES NOT TRAVEL: anything the manifest did not declare. An argument the owning route ignores is
 the worst reply available to an agent — it reports success for something that did not happen — so an
@@ -17,6 +24,7 @@ undeclared parameter is dropped here rather than forwarded and silently discarde
 """
 from __future__ import annotations
 
+import os
 from typing import Dict, List, Optional
 
 import httpx
@@ -41,16 +49,32 @@ def _caller_key(request: Request) -> str:
 
 
 def register(app: FastAPI, bound: List[BoundTool], base_urls: Dict[str, str], *,
-             transport: Optional[httpx.AsyncBaseTransport] = None) -> List[str]:
+             transport: Optional[httpx.AsyncBaseTransport] = None,
+             env: Optional[dict] = None) -> List[str]:
     """Add one route per bound tool. Returns the names registered, in order."""
+    env = os.environ if env is None else env
     names: List[str] = []
     for bt in bound:
-        names.append(_add(app, bt, base_urls[bt.tool.domain], transport))
+        names.append(_add(app, bt, base_urls[bt.tool.domain], transport, env))
     return names
 
 
+def _outbound(bt: BoundTool, caller_key: str, env: dict) -> Dict[str, str]:
+    """The credential headers this hop carries — decided by the manifest, not by what is available.
+
+    Read at request time rather than captured at boot so a rotated operator key takes effect on a
+    restart of the service that HOLDS it, not only of this one; assembly already proved it is set.
+    """
+    headers = {"Content-Type": "application/json"}
+    if bt.tool.auth == "subject":
+        headers["X-API-Key"] = caller_key
+    elif bt.tool.auth == "admin" and bt.tool.admin_auth:
+        headers[bt.tool.admin_auth["header"]] = str(env.get(bt.tool.admin_auth["key_env"]) or "")
+    return headers
+
+
 def _add(app: FastAPI, bt: BoundTool, base: str,
-         transport: Optional[httpx.AsyncBaseTransport]) -> str:
+         transport: Optional[httpx.AsyncBaseTransport], env: dict) -> str:
     method = bt.tool.route["method"]
     template = bt.tool.route["path"]
     declared = tuple(bt.parameters)
@@ -87,7 +111,7 @@ def _add(app: FastAPI, bt: BoundTool, base: str,
             async with httpx.AsyncClient(timeout=10, transport=transport) as client:
                 r = await client.request(
                     method, f"{base}{path}",
-                    headers={"X-API-Key": key, "Content-Type": "application/json"},
+                    headers=_outbound(bt, key, env),
                     params=params or None,
                     json=body if method in ("POST", "PUT", "PATCH") else None)
         except httpx.TimeoutException:

--- a/core/meetings/services/mcp/src/vexa_mcp/register.py
+++ b/core/meetings/services/mcp/src/vexa_mcp/register.py
@@ -21,17 +21,36 @@ answers it; whether the deployment can answer it at all was already settled at a
 WHAT DOES NOT TRAVEL: anything the manifest did not declare. An argument the owning route ignores is
 the worst reply available to an agent — it reports success for something that did not happen — so an
 undeclared parameter is dropped here rather than forwarded and silently discarded there.
+
+AND THE ROUTE IS BUILT WITH A REAL SIGNATURE, which is not a detail (issue #1468). The MCP tool's
+input schema is derived from THIS app's OpenAPI, and FastAPI derives that from the endpoint's
+parameters — so an endpoint taking only `request` published a tool with NO arguments at all. Every
+declared argument disappeared between `bind`, which had just verified each one against the owning
+route, and the surface. With the schema closed (`additionalProperties: false`, correctly) the effect
+was not a silent drop but a refusal: `reactions_list` could not filter, and `reaction_signal` could
+not be called at all, because `/reactions/{reaction_id}/{verb}` cannot be addressed without its two
+path parameters and an agent could not see that they existed.
+
+So the signature is BUILT — one query parameter per path parameter (required: the route cannot be
+addressed without them) and one per declared argument (optional, carrying the owning route's own
+type and description). It also re-arms the app-wide unknown-argument guard, which reads a route's
+declared query parameters and would otherwise refuse every argument to every assembled tool.
 """
 from __future__ import annotations
 
+import inspect
 import os
 from typing import Dict, List, Optional
 
 import httpx
-from fastapi import FastAPI, HTTPException, Request
+from fastapi import FastAPI, HTTPException, Query, Request
 from fastapi.responses import JSONResponse
 
 from .bind import BoundTool
+
+#: JSON Schema type -> the Python annotation FastAPI needs to publish it again. Anything else is a
+#: string: a wrong-but-honest type is recoverable, a guessed structure is not.
+_PY_TYPE = {"integer": int, "number": float, "boolean": bool, "string": str}
 
 
 def _caller_key(request: Request) -> str:
@@ -73,14 +92,36 @@ def _outbound(bt: BoundTool, caller_key: str, env: dict) -> Dict[str, str]:
     return headers
 
 
+def _signature(bt: BoundTool) -> inspect.Signature:
+    """The endpoint's parameters, as FastAPI has to see them to publish them again.
+
+    Path parameters are REQUIRED and declared arguments are optional, which is what the owning route
+    already says: `/reactions/{reaction_id}/{verb}` cannot be addressed without both, and every
+    declared argument is a query parameter with a default.
+    """
+    params = [inspect.Parameter("request", inspect.Parameter.KEYWORD_ONLY, annotation=Request)]
+    for name in bt.path_params:
+        params.append(inspect.Parameter(
+            name, inspect.Parameter.KEYWORD_ONLY, annotation=str,
+            default=Query(..., description=f"part of this tool's address: {bt.tool.route['path']}")))
+    for name, schema in bt.parameters.items():
+        if name in bt.path_params:
+            continue
+        params.append(inspect.Parameter(
+            name, inspect.Parameter.KEYWORD_ONLY,
+            annotation=Optional[_PY_TYPE.get(str(schema.get("type")), str)],
+            default=Query(None, description=schema.get("description") or None)))
+    return inspect.Signature(params)
+
+
 def _add(app: FastAPI, bt: BoundTool, base: str,
          transport: Optional[httpx.AsyncBaseTransport], env: dict) -> str:
     method = bt.tool.route["method"]
     template = bt.tool.route["path"]
-    declared = tuple(bt.parameters)
+    declared = tuple(n for n in bt.parameters if n not in bt.path_params)
     path_params = tuple(bt.path_params)
 
-    async def endpoint(request: Request):
+    async def endpoint(*, request: Request, **argument):
         key = _caller_key(request)
         if key == "" and bt.tool.identity != "none":
             raise HTTPException(status_code=401, detail="this tool needs your Vexa credential")
@@ -94,15 +135,14 @@ def _add(app: FastAPI, bt: BoundTool, base: str,
 
         path = template
         for name in path_params:
-            value = body.pop(name, None)
-            if value is None:
-                value = request.query_params.get(name)
+            # Declared REQUIRED in the signature, so FastAPI has already refused a call without it;
+            # empty-but-present is the one thing that reaches here, and it addresses nothing.
+            value = argument.get(name)
             if value in (None, ""):
-                raise HTTPException(status_code=422,
-                                    detail=f"{bt.name} needs {name}")
+                raise HTTPException(status_code=422, detail=f"{bt.name} needs {name}")
             path = path.replace("{" + name + "}", str(value))
 
-        params = {n: request.query_params[n] for n in declared if n in request.query_params}
+        params = {n: argument[n] for n in declared if argument.get(n) is not None}
         for n in declared:
             if n not in params and n in body:
                 params[n] = body.pop(n)
@@ -128,6 +168,7 @@ def _add(app: FastAPI, bt: BoundTool, base: str,
 
     endpoint.__name__ = bt.name
     endpoint.__doc__ = bt.description or f"{bt.tool.domain}: {method} {template}"
+    endpoint.__signature__ = _signature(bt)
     app.add_api_route(f"/tools/{bt.name}", endpoint, methods=[method],
                       operation_id=bt.name, name=bt.name,
                       summary=bt.description or None,

--- a/core/meetings/services/mcp/tests/test_assembled_call_path.py
+++ b/core/meetings/services/mcp/tests/test_assembled_call_path.py
@@ -38,6 +38,9 @@ FLOWS_OPENAPI = {"paths": {
         {"name": "subject", "in": "query", "schema": {"type": "string"}}]}},
     "/reactions/{reaction_id}/{verb}": {"post": {"summary": "Steer one reaction",
                                                  "parameters": []}},
+    "/queue/waiting": {"get": {"summary": "What is waiting for this person", "parameters": [
+        {"name": "subject", "in": "query", "schema": {"type": "string"}},
+        {"name": "limit", "in": "query", "schema": {"type": "integer"}}]}},
     "/timeline": {"get": {"summary": "One person's day, in order", "parameters": [
         {"name": "subject", "in": "query", "schema": {"type": "string"}},
         {"name": "since", "in": "query", "schema": {"type": "string"}},

--- a/core/meetings/services/mcp/tests/test_assembled_call_path.py
+++ b/core/meetings/services/mcp/tests/test_assembled_call_path.py
@@ -1,0 +1,172 @@
+"""WHAT AN AGENT ACTUALLY GETS when it calls an assembled tool — issue #1468 C3.
+
+Two questions, both asked at the mounted `/mcp` transport rather than at the forwarding route,
+because the transport is what an agent sees and the two can disagree:
+
+  1. **A refusal must arrive as a refusal.** The finding that opened this issue was a person's call
+     to `reactions_list` coming back as JSON-RPC 200 with `Status code: 401` in the text. The 200 is
+     the TRANSPORT and is correct — JSON-RPC carries tool failures inside a result — so the whole
+     question is whether that result is marked `isError`. Pinned here, because nothing pinned it:
+     the flag is produced inside `fastapi-mcp`, and a library that stops raising, or a forward that
+     starts swallowing, turns every refusal success-shaped again with no test to notice.
+
+  2. **A declared argument must reach the tool.** An assembled tool's route took `request` and
+     nothing else, so this app's OpenAPI showed it with no parameters, so `tools/list` published an
+     EMPTY input schema for it — and `additionalProperties: false` then refused every argument an
+     agent passed. `reactions_list(status=…)` could not filter and `reaction_signal` could not be
+     called AT ALL, because its `reaction_id` and `verb` had nowhere to go. The manifest declared
+     them, `bind` verified them against the owning route, and the last step dropped them.
+"""
+from __future__ import annotations
+
+import json
+import pathlib
+
+import httpx
+import pytest
+
+from vexa_mcp import create_app
+
+REPO = pathlib.Path(__file__).resolve().parents[5]
+FLOWS_MANIFEST = json.loads((REPO / "core" / "flows" / "mcp.tools.v1.json").read_text())
+
+FLOWS_OPENAPI = {"paths": {
+    "/flows": {"get": {"summary": "Every flow version the engine knows", "parameters": []}},
+    "/reactions": {"get": {"summary": "Your share of the reaction queue", "parameters": [
+        {"name": "status", "in": "query", "schema": {"type": "string"},
+         "description": "admitted | running | failed | done"},
+        {"name": "subject", "in": "query", "schema": {"type": "string"}}]}},
+    "/reactions/{reaction_id}/{verb}": {"post": {"summary": "Steer one reaction",
+                                                 "parameters": []}},
+    "/timeline": {"get": {"summary": "One person's day, in order", "parameters": [
+        {"name": "subject", "in": "query", "schema": {"type": "string"}},
+        {"name": "since", "in": "query", "schema": {"type": "string"}},
+        {"name": "until", "in": "query", "schema": {"type": "string"}},
+        {"name": "limit", "in": "query", "schema": {"type": "integer"}}]}},
+}}
+
+
+def _discovery(request: httpx.Request) -> httpx.Response:
+    url = str(request.url)
+    if not url.startswith("http://flows"):
+        return httpx.Response(404)
+    if url.endswith("/.well-known/mcp-tools.json"):
+        return httpx.Response(200, json=FLOWS_MANIFEST)
+    if url.endswith("/openapi.json"):
+        return httpx.Response(200, json=FLOWS_OPENAPI)
+    return httpx.Response(404)
+
+
+@pytest.fixture
+def wired():
+    """The whole path: discovery, assembly, registration, the mounted `/mcp` transport — and an
+    upstream whose answer each test chooses. `seen` is what flows actually received."""
+    from fastapi.testclient import TestClient
+
+    seen = []
+    answer = {"status": 200, "json": {"ok": True}}
+
+    def upstream(request: httpx.Request) -> httpx.Response:
+        seen.append(request)
+        return httpx.Response(answer["status"], json=answer["json"])
+
+    app = create_app("http://gateway.test", transport=httpx.MockTransport(upstream),
+                     assembly_env={"ADMIN_API_URL": "http://identity",
+                                   "FLOWS_API_URL": "http://flows"},
+                     assembly_transport=httpx.MockTransport(_discovery))
+    ctx = TestClient(app)
+    client = ctx.__enter__()
+    head = {"Authorization": "Bearer person-key",
+            "Accept": "application/json, text/event-stream",
+            "Content-Type": "application/json"}
+    r = client.post("/mcp", headers=head, json={
+        "jsonrpc": "2.0", "id": 1, "method": "initialize",
+        "params": {"protocolVersion": "2025-03-26", "capabilities": {},
+                   "clientInfo": {"name": "test", "version": "0"}}})
+    head["Mcp-Session-Id"] = r.headers["mcp-session-id"]
+    client.post("/mcp", headers=head, json={"jsonrpc": "2.0",
+                                            "method": "notifications/initialized"})
+
+    class Wired:
+        tools = {t.name: t for t in app.state.mcp.tools}
+
+        def call(self, name, **arguments):
+            got = client.post("/mcp", headers=head, json={
+                "jsonrpc": "2.0", "id": 9, "method": "tools/call",
+                "params": {"name": name, "arguments": arguments}})
+            return got.json()["result"]
+
+        def upstream_answers(self, status, body):
+            answer.update(status=status, json=body)
+
+        @property
+        def seen(self):
+            return seen
+
+    try:
+        yield Wired()
+    finally:
+        ctx.__exit__(None, None, None)
+
+
+# ── 1 · a refusal arrives as a refusal ──────────────────────────────────────────────────────────
+
+def test_an_upstream_refusal_arrives_marked_as_an_error(wired):
+    wired.upstream_answers(401, {"detail": "X-Flows-Admin-Key required"})
+    result = wired.call("reactions_list")
+    assert result.get("isError") is True, result
+    assert "401" in json.dumps(result)
+
+
+def test_a_forbidden_reaches_the_agent_as_the_domains_own_answer(wired):
+    """`that reaction is not yours` is flows' answer and the agent needs to see it — a 403 rewritten
+    at the edge would turn "you may not do that" into "we are broken"."""
+    wired.upstream_answers(403, {"detail": "that reaction is not yours"})
+    result = wired.call("reaction_signal", reaction_id="r-someone-elses", verb="cancel")
+    assert result.get("isError") is True
+    assert "not yours" in json.dumps(result)
+
+
+def test_an_upstream_success_is_not_marked_an_error(wired):
+    """The control. A test that only asserts `isError` on a refusal passes on a server that marks
+    everything an error."""
+    wired.upstream_answers(200, {"reactions": []})
+    result = wired.call("reactions_list")
+    assert not result.get("isError"), result
+
+
+# ── 2 · a declared argument reaches the tool ────────────────────────────────────────────────────
+
+def test_a_declared_argument_is_published_in_the_tools_schema(wired):
+    props = wired.tools["reactions_list"].inputSchema["properties"]
+    assert set(props) == {"status", "subject"}, props
+
+
+def test_a_path_parameter_is_published_and_required(wired):
+    """`/reactions/{reaction_id}/{verb}` cannot be called without them, so an agent that cannot see
+    them cannot call the tool at all — which is what "cancel the join you scheduled" needed."""
+    schema = wired.tools["reaction_signal"].inputSchema
+    assert set(schema["properties"]) == {"reaction_id", "verb"}
+    assert set(schema.get("required") or []) == {"reaction_id", "verb"}
+
+
+def test_an_argument_an_agent_passes_reaches_the_owning_route(wired):
+    wired.call("reactions_list", status="failed")
+    assert wired.seen[-1].url.params.get("status") == "failed"
+
+
+def test_a_path_parameter_lands_in_the_path_not_in_the_query(wired):
+    wired.call("reaction_signal", reaction_id="r-7", verb="cancel")
+    assert wired.seen[-1].url.path == "/reactions/r-7/cancel"
+
+
+def test_an_argument_the_tool_does_not_declare_is_refused_not_dropped(wired):
+    """The other half, and the reason the schema is closed: an argument silently dropped is a
+    success the agent reports for something that did not happen."""
+    result = wired.call("reactions_list", nonesuch="x")
+    assert result.get("isError") is True
+    assert not wired.seen
+
+
+def test_a_tool_with_no_declared_arguments_publishes_none(wired):
+    assert wired.tools["flows_list"].inputSchema.get("properties") == {}

--- a/core/meetings/services/mcp/tests/test_assembled_call_path.py
+++ b/core/meetings/services/mcp/tests/test_assembled_call_path.py
@@ -112,7 +112,7 @@ def wired():
 # ── 1 · a refusal arrives as a refusal ──────────────────────────────────────────────────────────
 
 def test_an_upstream_refusal_arrives_marked_as_an_error(wired):
-    wired.upstream_answers(401, {"detail": "X-Flows-Admin-Key required"})
+    wired.upstream_answers(401, {"detail": "X-Flows-Operator-Key required"})
     result = wired.call("reactions_list")
     assert result.get("isError") is True, result
     assert "401" in json.dumps(result)

--- a/core/meetings/services/mcp/tests/test_assembly.py
+++ b/core/meetings/services/mcp/tests/test_assembly.py
@@ -36,7 +36,7 @@ def _manifest(domain="flows", tools=None, **kw):
         "owner": f"core/{domain}", "base_url_env": f"{domain.upper()}_API_URL",
         "served_at": "/.well-known/mcp-tools.json", "depends_on": ["identity"],
         "tools": tools if tools is not None else [
-            {"name": "flows_list", "identity": "operator", "requires": ["identity", "flows"],
+            {"name": "flows_list", "identity": "operator", "auth": "subject", "requires": ["identity", "flows"],
              "route": {"method": "GET", "path": "/flows"}}],
     }
     doc.update(kw)
@@ -51,23 +51,23 @@ def test_a_manifest_may_only_depend_on_identity():
         m.validate(_manifest(depends_on=["identity", "agent"]))
     m.validate(_manifest(depends_on=["identity"]))
     m.validate(_manifest(domain="identity", depends_on=[], base_url_env="ADMIN_API_URL", tools=[
-        {"name": "settings", "identity": "user", "requires": ["identity"],
+        {"name": "settings", "identity": "user", "auth": "subject", "requires": ["identity"],
          "route": {"method": "GET", "path": "/user/settings"}}]))
 
 
 def test_a_tool_requires_its_own_domain_and_identity_only():
     with pytest.raises(m.ManifestError, match="requires"):
         m.validate(_manifest(tools=[
-            {"name": "x", "identity": "user", "requires": ["identity", "meetings"],
+            {"name": "x", "identity": "user", "auth": "subject", "requires": ["identity", "meetings"],
              "route": {"method": "GET", "path": "/x"}}]))
 
 
 def test_an_edge_owned_tool_may_have_no_route_only_when_it_has_no_door():
     m.validate(_manifest(domain="gateway", base_url_env=None, served_at=None, tools=[
-        {"name": "vexa_overview", "identity": "none", "requires": ["identity"], "route": None}]))
+        {"name": "vexa_overview", "identity": "none", "auth": "subject", "requires": ["identity"], "route": None}]))
     with pytest.raises(m.ManifestError, match="route"):
         m.validate(_manifest(tools=[
-            {"name": "x", "identity": "user", "requires": ["identity", "flows"], "route": None}]))
+            {"name": "x", "identity": "user", "auth": "subject", "requires": ["identity", "flows"], "route": None}]))
 
 
 # ── assembly ─────────────────────────────────────────────────────────────────────────────────
@@ -75,7 +75,7 @@ def test_only_tools_whose_domains_are_deployed_are_served():
     """Eight configurations, not two. A tool the deployment cannot satisfy is ABSENT."""
     flows = _manifest()
     agent = _manifest(domain="agent", base_url_env="AGENT_API_URL", tools=[
-        {"name": "workspace_tree", "identity": "user", "requires": ["identity", "agent"],
+        {"name": "workspace_tree", "identity": "user", "auth": "subject", "requires": ["identity", "agent"],
          "route": {"method": "GET", "path": "/api/workspace/tree"}}])
     both = m.assemble([flows, agent], deployed={"identity", "flows", "agent"})
     assert {t.name for t in both.tools} == {"flows_list", "workspace_tree"}
@@ -87,7 +87,7 @@ def test_only_tools_whose_domains_are_deployed_are_served():
 def test_a_name_claimed_twice_fails_the_boot_and_names_both():
     a = _manifest()
     b = _manifest(domain="agent", base_url_env="AGENT_API_URL", tools=[
-        {"name": "flows_list", "identity": "user", "requires": ["identity", "agent"],
+        {"name": "flows_list", "identity": "user", "auth": "subject", "requires": ["identity", "agent"],
          "route": {"method": "GET", "path": "/x"}}])
     with pytest.raises(m.ManifestError) as e:
         m.assemble([a, b], deployed={"identity", "flows", "agent"})
@@ -98,7 +98,7 @@ def test_a_mounted_manifest_gets_no_precedence_over_an_oss_one():
     """The rule that makes a private mount safe: it collides, it does not shadow."""
     oss = _manifest()
     mounted = _manifest(domain="billing", source="mounted", base_url_env="BILLING_API_URL",
-                        tools=[{"name": "flows_list", "identity": "user",
+                        tools=[{"name": "flows_list", "identity": "user", "auth": "subject",
                                 "requires": ["identity", "billing"],
                                 "route": {"method": "GET", "path": "/seats"}}])
     with pytest.raises(m.ManifestError, match="claimed"):
@@ -163,11 +163,11 @@ def test_a_tool_may_not_take_a_credential_as_an_argument():
     for arg in ("token", "api_key", "access_token", "password"):
         with pytest.raises(m.ManifestError, match="one authentication path"):
             m.validate(_manifest(tools=[
-                {"name": "x", "identity": "user", "requires": ["identity", "flows"],
+                {"name": "x", "identity": "user", "auth": "subject", "requires": ["identity", "flows"],
                  "route": {"method": "GET", "path": "/x"}, "arguments": [arg, "since"]}]))
 
 
 def test_ordinary_arguments_are_untouched():
     m.validate(_manifest(tools=[
-        {"name": "x", "identity": "user", "requires": ["identity", "flows"],
+        {"name": "x", "identity": "user", "auth": "subject", "requires": ["identity", "flows"],
          "route": {"method": "GET", "path": "/x"}, "arguments": ["since", "limit", "status"]}]))

--- a/core/meetings/services/mcp/tests/test_bind.py
+++ b/core/meetings/services/mcp/tests/test_bind.py
@@ -38,7 +38,7 @@ def _assembly(tools):
 
 
 def test_a_bound_tool_takes_its_description_from_the_route():
-    a = _assembly([{"name": "flows_list", "identity": "operator",
+    a = _assembly([{"name": "flows_list", "identity": "operator", "auth": "subject",
                     "requires": ["identity", "flows"],
                     "route": {"method": "GET", "path": "/flows"}}])
     bound = bind.verify(a, {"flows": FLOWS_OPENAPI})
@@ -48,14 +48,14 @@ def test_a_bound_tool_takes_its_description_from_the_route():
 
 def test_a_route_the_domain_does_not_serve_fails_the_boot():
     """The manifest lying about its own service — the one failure this design could otherwise hide."""
-    a = _assembly([{"name": "x", "identity": "user", "requires": ["identity", "flows"],
+    a = _assembly([{"name": "x", "identity": "user", "auth": "subject", "requires": ["identity", "flows"],
                     "route": {"method": "GET", "path": "/nope"}}])
     with pytest.raises(m.ManifestError, match="does not serve"):
         bind.verify(a, {"flows": FLOWS_OPENAPI})
 
 
 def test_the_wrong_method_on_a_real_path_fails_too():
-    a = _assembly([{"name": "x", "identity": "user", "requires": ["identity", "flows"],
+    a = _assembly([{"name": "x", "identity": "user", "auth": "subject", "requires": ["identity", "flows"],
                     "route": {"method": "DELETE", "path": "/flows"}}])
     with pytest.raises(m.ManifestError, match="does not serve"):
         bind.verify(a, {"flows": FLOWS_OPENAPI})
@@ -64,7 +64,7 @@ def test_the_wrong_method_on_a_real_path_fails_too():
 def test_an_argument_the_operation_does_not_take_fails_the_boot():
     """An argument an agent can pass and the route ignores is the worst reply available: the agent
     reports success on something that did not happen."""
-    a = _assembly([{"name": "reactions_list", "identity": "operator",
+    a = _assembly([{"name": "reactions_list", "identity": "operator", "auth": "subject",
                     "requires": ["identity", "flows"],
                     "route": {"method": "GET", "path": "/reactions"},
                     "arguments": ["status", "invented"]}])
@@ -73,7 +73,7 @@ def test_an_argument_the_operation_does_not_take_fails_the_boot():
 
 
 def test_declared_arguments_carry_their_schema_from_the_operation():
-    a = _assembly([{"name": "reactions_list", "identity": "operator",
+    a = _assembly([{"name": "reactions_list", "identity": "operator", "auth": "subject",
                     "requires": ["identity", "flows"],
                     "route": {"method": "GET", "path": "/reactions"},
                     "arguments": ["status", "source_event_prefix"]}])
@@ -86,7 +86,7 @@ def test_a_path_parameter_is_an_argument_without_being_declared():
     """`/reactions/{reaction_id}/{verb}` cannot be called without them, so they are arguments
     whether or not the manifest lists them — and a manifest that had to restate them would be a
     second place to write the route."""
-    a = _assembly([{"name": "reaction_signal", "identity": "user",
+    a = _assembly([{"name": "reaction_signal", "identity": "user", "auth": "subject",
                     "requires": ["identity", "flows"],
                     "route": {"method": "POST", "path": "/reactions/{reaction_id}/{verb}"}}])
     bound = bind.verify(a, {"flows": FLOWS_OPENAPI})
@@ -97,14 +97,14 @@ def test_an_edge_owned_tool_needs_no_openapi():
     doc = {"contract": "mcp.tools.v1", "domain": "gateway", "source": "oss",
            "owner": "core/gateway/services/mcp", "base_url_env": None, "served_at": None,
            "depends_on": ["identity"],
-           "tools": [{"name": "vexa_overview", "identity": "none", "requires": ["identity"],
+           "tools": [{"name": "vexa_overview", "identity": "none", "auth": "subject", "requires": ["identity"],
                       "route": None}]}
     a = m.assemble([doc], deployed={"identity"})
     assert bind.verify(a, {}) == []
 
 
 def test_a_domain_with_no_openapi_at_all_fails_rather_than_binding_blind():
-    a = _assembly([{"name": "flows_list", "identity": "operator",
+    a = _assembly([{"name": "flows_list", "identity": "operator", "auth": "subject",
                     "requires": ["identity", "flows"],
                     "route": {"method": "GET", "path": "/flows"}}])
     with pytest.raises(m.ManifestError, match="OpenAPI"):

--- a/core/meetings/services/mcp/tests/test_discover.py
+++ b/core/meetings/services/mcp/tests/test_discover.py
@@ -21,7 +21,7 @@ FLOWS_MANIFEST = {
     "contract": "mcp.tools.v1", "domain": "flows", "source": "oss", "owner": "core/flows",
     "base_url_env": "FLOWS_API_URL", "served_at": "/.well-known/mcp-tools.json",
     "depends_on": ["identity"],
-    "tools": [{"name": "flows_list", "identity": "operator", "requires": ["identity", "flows"],
+    "tools": [{"name": "flows_list", "identity": "operator", "auth": "subject", "requires": ["identity", "flows"],
                "route": {"method": "GET", "path": "/flows"}}],
 }
 FLOWS_OPENAPI = {"paths": {"/flows": {"get": {"summary": "Every flow version", "parameters": []}}}}

--- a/core/meetings/services/mcp/tests/test_register.py
+++ b/core/meetings/services/mcp/tests/test_register.py
@@ -30,11 +30,11 @@ MANIFEST = {
     "base_url_env": "FLOWS_API_URL", "served_at": "/.well-known/mcp-tools.json",
     "depends_on": ["identity"],
     "tools": [
-        {"name": "flows_list", "identity": "operator", "requires": ["identity", "flows"],
+        {"name": "flows_list", "identity": "operator", "auth": "subject", "requires": ["identity", "flows"],
          "route": {"method": "GET", "path": "/flows"}},
-        {"name": "reactions_list", "identity": "operator", "requires": ["identity", "flows"],
+        {"name": "reactions_list", "identity": "operator", "auth": "subject", "requires": ["identity", "flows"],
          "route": {"method": "GET", "path": "/reactions"}, "arguments": ["status"]},
-        {"name": "reaction_signal", "identity": "user", "requires": ["identity", "flows"],
+        {"name": "reaction_signal", "identity": "user", "auth": "subject", "requires": ["identity", "flows"],
          "route": {"method": "POST", "path": "/reactions/{reaction_id}/{verb}"}},
     ],
 }

--- a/core/meetings/services/mcp/tests/test_register.py
+++ b/core/meetings/services/mcp/tests/test_register.py
@@ -94,11 +94,22 @@ def test_an_undeclared_argument_is_not_forwarded(wired):
 
 
 def test_path_parameters_are_substituted(wired):
+    """As QUERY parameters, which is where they are now declared (issue #1468). They used to be
+    read out of the JSON body, and being undeclared is exactly why an agent could not see them:
+    the tool's input schema is derived from this route's parameters, so `reaction_signal` was
+    published taking nothing and could not be addressed at all."""
     app, seen = wired
-    r = TestClient(app).post("/tools/reaction_signal", json={"reaction_id": "r1", "verb": "retry"},
+    r = TestClient(app).post("/tools/reaction_signal?reaction_id=r1&verb=retry",
                              headers={"X-API-Key": "k"})
     assert r.status_code == 200, r.text
     assert str(seen[-1].url) == "http://flows/reactions/r1/retry"
+
+
+def test_a_path_parameter_is_required_rather_than_guessed(wired):
+    app, seen = wired
+    before = len(seen)
+    r = TestClient(app).post("/tools/reaction_signal?reaction_id=r1", headers={"X-API-Key": "k"})
+    assert r.status_code == 422 and len(seen) == before
 
 
 def test_a_missing_credential_is_refused_before_the_forward(wired):

--- a/core/meetings/services/mcp/tests/test_tool_auth.py
+++ b/core/meetings/services/mcp/tests/test_tool_auth.py
@@ -67,7 +67,7 @@ def test_a_tool_must_say_how_it_is_authenticated():
 def test_the_three_values_and_no_others():
     for good in ("subject", "admin", "none"):
         m.validate(_manifest(tools=[_tool(auth=good)],
-                             admin_auth={"header": "X-Flows-Admin-Key",
+                             admin_auth={"header": "X-Flows-Operator-Key",
                                          "key_env": "VEXA_MCP_FLOWS_ADMIN_KEY"}))
     with pytest.raises(m.ManifestError, match="auth"):
         m.validate(_manifest(tools=[_tool(auth="operator")]))
@@ -84,7 +84,7 @@ def test_an_admin_tool_must_say_which_header_and_which_variable():
 
 ADMIN_MANIFEST = _manifest(
     tools=[_tool(name="flows_retire", auth="admin", path="/admin/thing", method="POST")],
-    admin_auth={"header": "X-Flows-Admin-Key", "key_env": "VEXA_MCP_FLOWS_ADMIN_KEY"})
+    admin_auth={"header": "X-Flows-Operator-Key", "key_env": "VEXA_MCP_FLOWS_ADMIN_KEY"})
 
 
 def test_an_admin_tool_whose_key_this_deployment_does_not_hold_refuses_the_boot():
@@ -153,7 +153,7 @@ def test_an_admin_tool_sends_the_deployments_key_and_not_the_callers():
     client, seen = _wire(ADMIN_MANIFEST, env)
     client.post("/tools/flows_retire", headers={"Authorization": "Bearer person-key"}, json={})
     sent = seen[-1].headers
-    assert sent["X-Flows-Admin-Key"] == "an-operator-key"
+    assert sent["X-Flows-Operator-Key"] == "an-operator-key"
     assert "person-key" not in str(dict(sent))
 
 

--- a/core/meetings/services/mcp/tests/test_tool_auth.py
+++ b/core/meetings/services/mcp/tests/test_tool_auth.py
@@ -1,0 +1,179 @@
+"""A TOOL SAYS WHICH CREDENTIAL ITS DOOR TAKES — issue #1468 C2.
+
+The manifest could say who the CALLER must be (`identity`) and nothing at all about what this edge
+has to PRESENT to the door behind the tool. So the edge did the only thing it could: forward the
+caller's own credential to everything, and find out at call time. Flows' four tools were behind a
+deployment-wide operator key this edge does not hold and must never hold, and the result reached the
+agent as a JSON-RPC answer with a 401 inside it — a tool that is in `tools/list` and cannot work.
+
+`auth` closes that at BOOT, where every other rule in this assembler already lives:
+
+    subject   the caller's own credential travels, which is what this edge does today
+    admin     a deployment-held key travels instead — and the deployment must actually hold it
+    none      nothing travels
+
+A tool whose `auth` this deployment cannot satisfy is REFUSED AT ASSEMBLY, naming it. Not published
+and 401ing later: an agent that cannot see a tool recovers; an agent told a tool exists and handed a
+refusal tells the person the product is broken. That is the same fail-direction as every other rule
+in `manifest.py`, applied to the one fact the contract could not express.
+"""
+from __future__ import annotations
+
+import httpx
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from vexa_mcp import bind, register
+from vexa_mcp import manifest as m
+
+OPENAPI = {"paths": {
+    "/flows": {"get": {"summary": "Every flow version", "parameters": []}},
+    "/admin/thing": {"post": {"summary": "An operator verb", "parameters": []}},
+    "/open": {"get": {"summary": "No credential at all", "parameters": []}},
+}}
+
+
+def _tool(name="flows_list", auth="subject", path="/flows", method="GET", **kw):
+    t = {"name": name, "identity": "user", "requires": ["identity", "flows"],
+         "route": {"method": method, "path": path}}
+    if auth is not ...:
+        t["auth"] = auth
+    t.update(kw)
+    return t
+
+
+def _manifest(tools=None, **kw):
+    doc = {"contract": "mcp.tools.v1", "domain": "flows", "source": "oss", "owner": "core/flows",
+           "base_url_env": "FLOWS_API_URL", "served_at": "/.well-known/mcp-tools.json",
+           "depends_on": ["identity"],
+           "tools": tools if tools is not None else [_tool()]}
+    doc.update(kw)
+    return doc
+
+
+DEPLOYED = {"identity", "flows"}
+
+
+# ── the field exists, and a manifest may not stay silent about it ───────────────────────────────
+
+def test_a_tool_must_say_how_it_is_authenticated():
+    """Optional-with-a-default would reproduce the hole this field is for: the next manifest would
+    say nothing and the edge would guess, exactly as it guessed for flows."""
+    with pytest.raises(m.ManifestError, match="auth"):
+        m.validate(_manifest(tools=[_tool(auth=...)]))
+
+
+def test_the_three_values_and_no_others():
+    for good in ("subject", "admin", "none"):
+        m.validate(_manifest(tools=[_tool(auth=good)],
+                             admin_auth={"header": "X-Flows-Admin-Key",
+                                         "key_env": "VEXA_MCP_FLOWS_ADMIN_KEY"}))
+    with pytest.raises(m.ManifestError, match="auth"):
+        m.validate(_manifest(tools=[_tool(auth="operator")]))
+
+
+def test_an_admin_tool_must_say_which_header_and_which_variable():
+    """`auth: admin` is a promise the DEPLOYMENT has to be able to keep, and it cannot keep one it
+    cannot spell: which header the door reads, and which variable holds the key."""
+    with pytest.raises(m.ManifestError, match="admin_auth"):
+        m.validate(_manifest(tools=[_tool(auth="admin", path="/admin/thing", method="POST")]))
+
+
+# ── satisfiable, or refused at assembly ─────────────────────────────────────────────────────────
+
+ADMIN_MANIFEST = _manifest(
+    tools=[_tool(name="flows_retire", auth="admin", path="/admin/thing", method="POST")],
+    admin_auth={"header": "X-Flows-Admin-Key", "key_env": "VEXA_MCP_FLOWS_ADMIN_KEY"})
+
+
+def test_an_admin_tool_whose_key_this_deployment_does_not_hold_refuses_the_boot():
+    with pytest.raises(m.ManifestError) as e:
+        m.assemble([ADMIN_MANIFEST], deployed=DEPLOYED, env={})
+    assert "flows_retire" in str(e.value) and "VEXA_MCP_FLOWS_ADMIN_KEY" in str(e.value)
+
+
+def test_the_same_manifest_assembles_when_the_deployment_holds_the_key():
+    a = m.assemble([ADMIN_MANIFEST], deployed=DEPLOYED,
+                   env={"VEXA_MCP_FLOWS_ADMIN_KEY": "an-operator-key"})
+    assert [t.name for t in a.tools] == ["flows_retire"]
+    assert a.tools[0].auth == "admin"
+
+
+def test_a_placeholder_is_not_holding_the_key():
+    """A published literal authenticates nobody and everybody — the same refusal list flows-api and
+    the services' config.v1 already keep."""
+    with pytest.raises(m.ManifestError) as e:
+        m.assemble([ADMIN_MANIFEST], deployed=DEPLOYED, env={"VEXA_MCP_FLOWS_ADMIN_KEY": "changeme"})
+    assert "flows_retire" in str(e.value)
+
+
+def test_a_subject_tool_is_always_satisfiable():
+    """It travels the caller's own credential, and the caller brought it."""
+    a = m.assemble([_manifest()], deployed=DEPLOYED, env={})
+    assert [t.auth for t in a.tools] == ["subject"]
+
+
+def test_an_unsatisfiable_tool_never_reaches_the_surface():
+    """The refusal is at ASSEMBLY, before the app has a route for it — never a published tool that
+    401s on first use."""
+    app = FastAPI()
+    with pytest.raises(m.ManifestError):
+        a = m.assemble([ADMIN_MANIFEST], deployed=DEPLOYED, env={})
+        register.register(app, bind.verify(a, {"flows": OPENAPI}), {"flows": "http://flows"})
+    assert not [r for r in app.routes if getattr(r, "operation_id", None) == "flows_retire"]
+
+
+# ── and what actually travels ───────────────────────────────────────────────────────────────────
+
+def _wire(manifest, env):
+    seen = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request)
+        return httpx.Response(200, json={"ok": True})
+
+    app = FastAPI()
+    a = m.assemble([manifest], deployed=DEPLOYED, env=env)
+    register.register(app, bind.verify(a, {"flows": OPENAPI}), {"flows": "http://flows"},
+                      transport=httpx.MockTransport(handler), env=env)
+    return TestClient(app), seen
+
+
+def test_a_subject_tool_forwards_the_callers_own_credential():
+    client, seen = _wire(_manifest(), {})
+    client.get("/tools/flows_list", headers={"Authorization": "Bearer person-key"})
+    assert seen[-1].headers["X-API-Key"] == "person-key"
+
+
+def test_an_admin_tool_sends_the_deployments_key_and_not_the_callers():
+    """The caller is still authenticated at this edge — they just do not get to present their own
+    credential to a door that reads an operator key."""
+    env = {"VEXA_MCP_FLOWS_ADMIN_KEY": "an-operator-key"}
+    client, seen = _wire(ADMIN_MANIFEST, env)
+    client.post("/tools/flows_retire", headers={"Authorization": "Bearer person-key"}, json={})
+    sent = seen[-1].headers
+    assert sent["X-Flows-Admin-Key"] == "an-operator-key"
+    assert "person-key" not in str(dict(sent))
+
+
+def test_a_none_tool_sends_no_credential_at_all():
+    client, seen = _wire(_manifest(tools=[_tool(name="open_thing", auth="none", path="/open",
+                                                identity="none")]), {})
+    client.get("/tools/open_thing")
+    sent = {k.lower(): v for k, v in seen[-1].headers.items()}
+    assert "x-api-key" not in sent and "authorization" not in sent
+
+
+# ── the manifest in this repository declares it ─────────────────────────────────────────────────
+
+def test_flows_four_tools_declare_the_subjects_credential():
+    """Which is the whole point: flows' door now takes the person's own credential (C1), so the
+    edge forwarding it is correct rather than a guess that happened to be wrong."""
+    import json
+    import pathlib
+    doc = json.loads((pathlib.Path(__file__).resolve().parents[5]
+                      / "core/flows/mcp.tools.v1.json").read_text())
+    assert {t["name"]: t.get("auth") for t in doc["tools"]} == {
+        "flows_list": "subject", "reactions_list": "subject",
+        "reaction_signal": "subject", "timeline": "subject"}

--- a/core/meetings/services/mcp/tests/test_tool_auth.py
+++ b/core/meetings/services/mcp/tests/test_tool_auth.py
@@ -167,13 +167,15 @@ def test_a_none_tool_sends_no_credential_at_all():
 
 # ── the manifest in this repository declares it ─────────────────────────────────────────────────
 
-def test_flows_four_tools_declare_the_subjects_credential():
+def test_every_flows_tool_declares_the_subjects_credential():
     """Which is the whole point: flows' door now takes the person's own credential (C1), so the
-    edge forwarding it is correct rather than a guess that happened to be wrong."""
+    edge forwarding it is correct rather than a guess that happened to be wrong. Asserted over
+    WHATEVER the manifest holds, not a list written here — a fifth tool added by another change is
+    exactly the case a hard-coded list would miss."""
     import json
     import pathlib
     doc = json.loads((pathlib.Path(__file__).resolve().parents[5]
                       / "core/flows/mcp.tools.v1.json").read_text())
+    assert doc["tools"], "the flows manifest declares no tools"
     assert {t["name"]: t.get("auth") for t in doc["tools"]} == {
-        "flows_list": "subject", "reactions_list": "subject",
-        "reaction_signal": "subject", "timeline": "subject"}
+        t["name"]: "subject" for t in doc["tools"]}

--- a/deploy/dogfood/rehearse/doors.py
+++ b/deploy/dogfood/rehearse/doors.py
@@ -454,7 +454,7 @@ class LiveDoors(Doors):
         own intake with the lane key is the door built for exactly this caller.
         """
         st, body = _http("POST", f"{FLOWS_API}/events",
-                         {"X-Flows-Admin-Key": self._flows_key, "X-Actor": "rehearse"},
+                         {"X-Flows-Operator-Key": self._flows_key, "X-Actor": "rehearse"},
                          {"event_type": event_type, "source_event_id": source_event_id,
                           "refs": refs})
         if st not in (200, 202) or not isinstance(body, dict):
@@ -537,7 +537,7 @@ class LiveDoors(Doors):
         deadline = time.time() + budget_s
         while True:
             st, body = _http("GET", f"{FLOWS_API}/reactions?limit=80",
-                             {"X-Flows-Admin-Key": self._flows_key})
+                             {"X-Flows-Operator-Key": self._flows_key})
             rows = (body or {}).get("reactions", []) if isinstance(body, dict) else []
             for r in rows:
                 if r.get("flow") != flow:
@@ -588,7 +588,7 @@ class LiveDoors(Doors):
         name — never another lane user's parked work.
         """
         st, body = _http("GET", f"{FLOWS_API}/reactions?limit=100",
-                         {"X-Flows-Admin-Key": self._flows_key})
+                         {"X-Flows-Operator-Key": self._flows_key})
         rows = (body or {}).get("reactions", []) if isinstance(body, dict) else []
         if st != 200 or not isinstance(body, dict):
             raise DoorRefused(f"could not list reactions to cancel the bot leg: {st}")
@@ -601,7 +601,7 @@ class LiveDoors(Doors):
         for r in targets:
             rid = r.get("reaction_id") or r.get("id")
             cst, cb = _http("POST", f"{FLOWS_API}/reactions/{rid}/cancel",
-                            {"X-Flows-Admin-Key": self._flows_key}, {})
+                            {"X-Flows-Operator-Key": self._flows_key}, {})
             (cancelled if 200 <= cst < 300 else refused).append(f"{rid}:{cst}")
         if refused:
             raise DoorRefused(

--- a/deploy/dogfood/rig/vexa_control_mcp.py
+++ b/deploy/dogfood/rig/vexa_control_mcp.py
@@ -232,7 +232,7 @@ def _safe_ws_path(path: str) -> str:
 
 
 def _fkey():
-    return {"X-Flows-Admin-Key": FLOWS_KEY}
+    return {"X-Flows-Operator-Key": FLOWS_KEY}
 
 
 def _safe_error(e: BaseException) -> str:

--- a/docs/docs/flows/authoring.mdx
+++ b/docs/docs/flows/authoring.mdx
@@ -53,8 +53,8 @@ Most day-to-day iteration is the second kind: prompt and cadence changes, zero d
 
 Auth is two tiers, because two different callers reach this API:
 
-- **Reading and steering your own** — `GET /flows`, `GET /reactions`, `POST /reactions/{id}/{verb}`
-  and `GET /timeline` also take **your own Vexa credential** (`Authorization: Bearer …` or
+- **Reading and steering your own** — `GET /flows`, `GET /reactions`, `POST /reactions/{id}/{verb}`,
+  `GET /queue/waiting` and `GET /timeline` also take **your own Vexa credential** (`Authorization: Bearer …` or
   `X-API-Key`). The subject is taken from that credential, so you see and steer your own reactions
   and nobody else's — this is what makes those tools work from your own Claude Code over the MCP
   endpoint. A `subject` argument naming somebody else is refused.

--- a/docs/docs/flows/authoring.mdx
+++ b/docs/docs/flows/authoring.mdx
@@ -51,5 +51,16 @@ Most day-to-day iteration is the second kind: prompt and cadence changes, zero d
 | `GET /reactions?status=…` | the operator projection: what happened, why, what's waiting |
 | `POST /reactions/{id}/retry` · `resume` · `cancel` | the signal verbs — audited rows, never shell surgery |
 
-Auth: `X-Flows-Admin-Key`. New events always select the **newest active version** of each flow;
-running reactions are never migrated.
+Auth is two tiers, because two different callers reach this API:
+
+- **Reading and steering your own** — `GET /flows`, `GET /reactions`, `POST /reactions/{id}/{verb}`
+  and `GET /timeline` also take **your own Vexa credential** (`Authorization: Bearer …` or
+  `X-API-Key`). The subject is taken from that credential, so you see and steer your own reactions
+  and nobody else's — this is what makes those tools work from your own Claude Code over the MCP
+  endpoint. A `subject` argument naming somebody else is refused.
+- **Changing the machine** — `POST /flows`, `POST /flows/{name}/{v}/{action}`, `POST /events` and
+  `POST /events/batch` take the operator key `X-Flows-Admin-Key` and nothing else. The operator key
+  also opens everything above, unscoped, which is the admin console's view.
+
+New events always select the **newest active version** of each flow; running reactions are never
+migrated.

--- a/docs/docs/flows/authoring.mdx
+++ b/docs/docs/flows/authoring.mdx
@@ -59,7 +59,7 @@ Auth is two tiers, because two different callers reach this API:
   and nobody else's — this is what makes those tools work from your own Claude Code over the MCP
   endpoint. A `subject` argument naming somebody else is refused.
 - **Changing the machine** — `POST /flows`, `POST /flows/{name}/{v}/{action}`, `POST /events` and
-  `POST /events/batch` take the operator key `X-Flows-Admin-Key` and nothing else. The operator key
+  `POST /events/batch` take the operator key `X-Flows-Operator-Key` and nothing else (`X-Flows-Admin-Key` still works for one release — it named admin-api's token, which it never was). The operator key
   also opens everything above, unscoped, which is the admin console's view.
 
 New events always select the **newest active version** of each flow; running reactions are never

--- a/docs/docs/flows/developing.mdx
+++ b/docs/docs/flows/developing.mdx
@@ -43,7 +43,7 @@ Three host processes over the stack's Postgres: `flows_worker`, the mailbox inte
 The state **is** the debugger:
 
 ```bash
-curl -s -H "X-Flows-Admin-Key: …" "http://localhost:18200/reactions?status=failed"
+curl -s -H "X-Flows-Operator-Key: …" "http://localhost:18200/reactions?status=failed"
 ```
 
 - `reaction` — where and why: step, status, attempt, `reason`, `next_run_at` (what it's waiting


### PR DESCRIPTION
**Delivers issue:** #1468

## Contribution rights
<!-- Select exactly ONE. This is a legal certification: an agent may explain the choices but
     must not select one for you. See CONTRIBUTOR_RIGHTS.md. -->

- [ ] **Independent:** I created this contribution, or otherwise have the right to submit it
  under Apache-2.0, and it is not owned or controlled by an employer, client, or other entity.
  <!-- rights:independent -->
- [ ] **Employer/client authorization required:** an employer, client, or other entity owns or
  may control this contribution. I am requesting Vexa's private corporate-authorization process.
  <!-- rights:corporate -->
- [ ] **Unsure:** I need a private rights review before merge.
  <!-- rights:uncertain -->

Every commit must also carry the contributor's own DCO `Signed-off-by` line. Selecting the
independent path means no individual CLA is required. Corporate and unsure paths do not stop
technical review, but they do block merge until resolved.

## Observation bundle (the record of your harnessed loop)

Base `adfea1ee7e2efef6c3767319ff889782e8863242` · head `2b184754eefd92bd9222c79ba958933d3b167b38`.
Thirteen commits, each component a red commit and a green one.

- **C1 — the person's own credential.** *Ran:* the four subject-scoped routes against a stubbed
  identity, at base and at head. *Saw:* at base, a person's bearer → `401 X-Flows-Admin-Key
  required`; the operator key → **HTTP 500**, `TypeError: list_reactions() got multiple values for
  argument 'status'`. *Concluded:* the route was unusable for a person AND broken for the operator,
  and the second had never been seen because the first fired in front of it — the route function
  `list_reactions` rebinds the module global imported at the top of the file, so line 388 called
  itself. The flows suite tested the model function and never the route. Both fixed; 40 new
  observations.
- **C2 — the manifest could not express the problem.** *Ran:* `validate` / `assemble` over the
  repository's manifest and synthetic ones. *Saw:* a tool could say who the CALLER must be
  (`identity`) and nothing about what this edge must PRESENT to the door. *Concluded:* the edge had
  exactly one move — forward the caller's credential to everything — so the mismatch could only be
  discovered at call time, by the agent. `auth` makes it a boot question.
- **C3 — the envelope, measured before it was written.** *Ran:* an upstream 401 through an
  assembled tool, at the mounted `/mcp` transport, at base. *Saw:*
  `{"jsonrpc":"2.0","id":2,"result":{"content":[{"type":"text","text":"Error calling
  reactions_list. Status code: 401. …"}],"isError":true}}`. *Concluded:* **the failure was already
  carried.** F113 read the JSON-RPC transport's own 200 as the defect; the 200 is correct — JSON-RPC
  carries tool failures inside a result — and `isError` was set. That half of the component is
  **INVALIDATED**, and the assertion ships anyway: the flag is produced inside `fastapi-mcp` and
  nothing in this repository pinned it.
- **C4 — what the same measurement found instead.** *Ran:* `tools/list` for the assembled tools.
  *Saw:* `reactions_list -> {"type":"object","properties":{},"additionalProperties":false}` — and
  the same for `timeline` and `reaction_signal`. *Concluded:* every declared argument disappeared
  between `bind`, which had just verified each one against the owning route, and the surface,
  because the route's endpoint took `request` and nothing else. `reactions_list` could not filter
  and **`reaction_signal` could not be called at all** — `/reactions/{reaction_id}/{verb}` cannot be
  addressed without its two path parameters and an agent could not see they existed. The issue's
  "cancel the join you scheduled" was unreachable for that reason alone. Fixed by building the
  route with a real signature.
- **C6 — `GET /queue/waiting`, found on the rebase.** *Ran:* a grep for what else on this surface
  claims a subject, after #1482 merged. *Saw:* the route is gated by the operator key and takes the
  person from an `X-User-Id` header its docstring says *"the MCP assembler stamps"* — and **the
  assembler stamps no such header**: `register.py` forwards the caller's credential as `X-API-Key`
  and nothing else. Its manifest entry meanwhile already declares `auth: "subject"`.
  *Concluded:* through the assembly that route has no subject at all, so it answers 400 — or, if
  anyone reaches for the operator key to make it answer, it answers about whoever the query names.
  Contract and door disagreeing is the shape this whole PR is about, one route later, so it joins
  the other four: a person's subject comes from their credential, and `X-User-Id` is ignored when
  one is present. The operator path is untouched, including `X-User-Id` outranking `?subject=`.
- **C5 — the operator header (added mid-flight, from the deployment side).** *Ran:* a grep for the
  header across the line after #1476 merged. *Saw:* `admin_api/app/events.py:74` reads
  `VEXA_FLOWS_API_KEY` — flows-api's own operator key, correctly — and sends it as
  `X-Flows-Admin-Key`. *Concluded:* the name says admin-api's token and never meant one; a lane
  start script carries a `changeme` for exactly that reason. Renamed to `X-Flows-Operator-Key`,
  old name accepted for one release with a once-per-process deprecation line.

## Acceptance floor

| Row | Evidence |
|---|---|
| A1 | `GET /reactions` with a person's bearer → 200, their two rows only. RED at base: the same call with the operator key answered **500** (`TypeError: list_reactions() got multiple values for argument 'status'`), and with a bearer **401**. `test_a_persons_own_bearer_lists_their_own_reactions`, `test_the_operator_key_still_lists_every_reaction`, `test_the_api_key_header_carries_a_bearer_too` — `core/flows/tests/test_subject_bearer.py` |
| A2 | A second person's bearer returns only their own row; `POST /reactions/r-ben/cancel` as Anna → **403**, and the row is still `admitted`. Control: Anna cancelling her own → 200, row `cancelled`. Plus `test_ownership_is_checked_even_when_no_subject_argument_is_sent` — before this, ownership was checked only when the caller ASSERTED a subject |
| A3 | `test_no_credential_at_all_is_refused` × 4 routes → 401. Control: `test_the_operator_key_still_opens_every_one_of_them` × 4 → not 401, unscoped operator behaviour unchanged |
| A4 | `test_a_persons_bearer_does_not_open_an_admin_route` × 4 (`POST /flows`, `/events`, `/events/batch`, `/flows/{n}/{v}/{action}`) → 401. Control: the operator key on the same four → not 401 (past the door each has its own answer — the instance gate's 409, an unknown version's 404 — and this row is about the door) |
| A5 | `subject=512` as Anna → **403** naming it; `subject=126` and `subject=ANNA@vexa.test` → 200; every answer carries `"subject"` so the caller sees whose rows came back. Control: the operator reading `subject=512` → 200, unchanged |
| A6 | Identity unreachable → **503**; identity answering 401 → **401**; identity answering **403** (our internal secret, not their key) → 503. A resolver collapsing these would pass one row and fail the others — all three are asserted. `test_the_resolver_is_the_one_the_gateway_asks` pins that it is `/internal/validate` over `X-Internal-Secret`, not a second lookup |
| A7 | `test_an_admin_tool_whose_key_this_deployment_does_not_hold_refuses_the_boot` — `ManifestError` naming `flows_retire` and `VEXA_MCP_FLOWS_ADMIN_KEY`; `test_an_unsatisfiable_tool_never_reaches_the_surface` — no route exists for it. Controls: the same manifest with the key set assembles and serves it; a placeholder value refuses; a manifest with no `auth` refuses naming the field — `core/meetings/services/mcp/tests/test_tool_auth.py` |
| A8 | `test_an_upstream_refusal_arrives_marked_as_an_error` and `test_a_forbidden_reaches_the_agent_as_the_domains_own_answer` → `isError: true` with the status and the domain's own words. Control: `test_an_upstream_success_is_not_marked_an_error`. **Green at base** — see C3; pinned, not fixed |
| A9 | **Not claimed.** The live run on the rig lane is the human part of this issue and is not mine to sign — see *Validation request*. Nothing here asserts it |
| A10 | `GET /queue/waiting` with a person's bearer answers about **them** — `test_the_queue_takes_a_persons_bearer_and_answers_about_them`; a `subject` naming someone else → 403 and nothing is read; `X-User-Id: 512` alongside Anna's bearer still answers about 126 (`test_a_stamped_user_id_does_not_beat_an_authenticated_person`). Controls: the operator key with `X-User-Id` still outranks `?subject=` (the row `tests/test_queue_waiting.py` owns, still green), and no credential → 401 with nothing read |
| A- | flows **495 passed / 5 skipped**; mcp **214 passed**; admin-api **147 passed**. `gate:python` — 16 packages green. `gate:readme`, `lite-makefile`, `docs-version`, `dataflow`, `isolation`, `isolation-py`, `exports`, `graph`, `graph-py`, `schema`, `contract-version`, `config-contract` (7 services · 311 keys), `db-schema`, `db-budget` — all green at head. Pre-push static gates green, including `contract-conformance` |

**Beyond the floor**, all witnessed, all blocking the issue's own value: the `GET /reactions` 500
(A1's red), assembled tools publishing an empty input schema (C4), and `GET /queue/waiting`'s
contract disagreeing with its door (A10). None was in the prepared table because none had been
seen — the last one did not exist when the table was written.

## Docs diff (D6c)

| page | altitude | change |
|---|---|---|
| `docs/docs/flows/authoring.mdx` | reference | the API table's one-line `Auth: X-Flows-Admin-Key` becomes the two tiers, and says what a person may do with their own credential |
| `docs/docs/flows/developing.mdx` | how-to | the debugging `curl` sends the renamed header |
| `core/flows/README.md` | reference | new *Two tiers at the door*: which caller opens what (five routes), that the subject comes from identity's one resolver, that an unreachable identity is 503, and the header rename. #1482's *What is waiting is flows* section is kept beside it, unchanged |
| `core/meetings/services/mcp/README.md` | reference | new *The manifest contract* — the `identity` vs `auth` table, what each value means, how a tool's arguments are published, and the operator-visible migration note |

**No `mcp.tools.v1` schema file exists** on this line — the contract is `manifest.validate()` plus
that README section, and both say so. Publishing one (P4) would be a second place to write the same
rule and is deliberately not in this PR.

## Operator-visible changes

1. **`auth` is required in `mcp.tools.v1`.** A manifest written against the previous shape —
   including one supplied through `VEXA_MCP_MANIFEST_DIR` — refuses the boot, naming the tool and
   the field. Only one manifest exists in this repository and it is updated here.
2. **`X-Flows-Admin-Key` → `X-Flows-Operator-Key`,** old name accepted for one release with a
   deprecation line printed once per process. Every caller in this repository moves with it. Lane
   scripts outside the repository (`~/.storm/flows-up.sh` and friends) keep working and will print
   the line.
3. **Assembled tools' path parameters move from the JSON body to the query string,** which is where
   they are now declared. This changes the direct `/tools/<name>` HTTP surface, not the MCP one.
4. **`GET /queue/waiting` no longer honours `X-User-Id` when a person's own credential is present.**
   An operator call is unchanged. Nothing in this repository sent both; a private caller that does
   will start getting the credential's answer, which is the one it should have been getting.

## Security checks (required on the diff)

- **No new dependency.** flows resolves over `urllib` through its existing `flows_steps.common.http`
  rather than adding `httpx` for one POST; the mcp service adds only stdlib `inspect` and `os`.
- **No new credential in the tree.** The internal secret is the one flows already reads at boot
  (`INTERNAL_API_SECRET`), passed in rather than re-read, so a missing one is still a boot refusal
  and never a per-request 503. `VEXA_MCP_<DOMAIN>_ADMIN_KEY` is a name the assembler checks for
  presence; no default, and a published placeholder is refused.
- **Widened surface, stated plainly:** four routes that took one operator key now also take a
  person's bearer. Each derives its subject server-side and refuses a subject that is not the
  caller's; ownership on `reaction_signal` is now checked on EVERY call rather than only when the
  caller volunteered a subject, which is a narrowing. The four operator routes are unchanged.
- **Fail directions checked both ways:** an unreachable or misconfigured identity is 503, never a
  verdict on the caller's key (the #495/#483 inversion); a subject nobody answers to owns nothing
  (`REACTION_NOT_YOURS`, unchanged).
- `gate:config-contract` green — no undeclared env read. `gate:isolation-py` and `gate:graph-py`
  green — flows gained no cross-domain import; it calls identity over HTTP, which is the edge it was
  already allowed.
- Secret scanning is disabled on this repository, so it is not evidence here. No new CodeQL surface:
  nothing in this diff logs a credential, formats an exception into a response body, or builds a
  path from caller input.

## Validation request

**A9 is the only row not claimed here, and it needs one operator with two Vexa accounts** — no
meeting participants. Connect a Claude Code to the rig's endpoint as account A, schedule a join,
list it, cancel it; then connect as account B and confirm A's join is neither listed nor
cancellable. Rows A1–A8 are seam-altitude and need no human (D12).

**Deployment (D12b):** the dogfood rig lane on `bbb` is the only deployment that runs flows-api —
there is no flows service in `deploy/compose/docker-compose.yml` yet. Lite and full compose carry no
flows domain, so its tools are absent from `tools/list` by construction and there is nothing to
validate there; the manifest-contract and envelope halves run on every deployment and are validated
at seam altitude. The validator should state the lane's sha, the two account ids, and the
timestamps.

**Watch for three things the tests cannot show:** whether the deprecation line for the old header
appears exactly once per process on a real lane, and whether `reaction_signal` is now offered to the
model with `reaction_id` and `verb` visible in its schema — that is the difference between "cancel
my join" working and the tool being invisible. Third: that `whats_waiting` answers about the caller
through the edge, where no `X-User-Id` is stamped at all.

## Authorship
Sole author: the human submitting this. No agent co-author trailers (D13).
Tooling disclosure (optional, welcome, never an attribution): written with Claude Code.

<!-- vexa-agent -->
