### PR TITLE
A fact defined in two places cannot silently disagree

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -17,7 +17,7 @@ unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_OBJECT_DIRECTORY GIT_COMMON_DIR G
 # will prove authoritatively on the same sha. The stack/python/build classes cost 5-10 min per
 # push and once blocked a release tag on a LOCAL stale-docker flake. Full suite on demand:
 # `pnpm gates`. Bypass: `git push --no-verify`.
-FAST_GATES="readme dataflow isolation isolation-py exports graph graph-py schema contract-version config-contract domain-doors licenses execution-env test-isolation contract-conformance"
+FAST_GATES="readme dataflow isolation isolation-py exports graph graph-py schema contract-version config-contract domain-doors fact-parity licenses execution-env test-isolation contract-conformance"
 echo "▶ pre-push → static gates ($(echo $FAST_GATES | wc -w | tr -d ' ') fast checks; CI runs the full suite)…"
 for g in $FAST_GATES; do
   node scripts/gates.mjs "$g" || {

--- a/.github/workflows/gates.yml
+++ b/.github/workflows/gates.yml
@@ -40,6 +40,7 @@ jobs:
       - run: pnpm gate:contract-version
       - run: pnpm gate:config-contract
       - run: pnpm gate:domain-doors
+      - run: pnpm gate:fact-parity
       - run: pnpm gate:db-schema
       - run: pnpm gate:db-budget
       - run: pnpm gate:dataflow

--- a/core/agent/control_plane/chat_intents.py
+++ b/core/agent/control_plane/chat_intents.py
@@ -45,8 +45,9 @@ SILENT_KINDS = frozenset({"highlight"})
 # real answer of every scaffolded chat. `worker/engine.py` says exactly this at its own definition —
 # "Distinct from MACHINERY_MARK and not a replacement for it" — and it is the whole reason there are
 # two literals rather than one flag.
-MACHINERY_MARK = "[vexa-machinery]"
-PHASE_MARK = "[vexa-phase:writeback]"
+# ONE SOURCE, three images (shared/marks.py). Re-exported under the names this module has always
+# published, so every reader of `chat_intents.MACHINERY_MARK` is unmoved.
+from shared.marks import MACHINERY_MARK, PHASE_MARK  # noqa: E402 — re-export, see the note above
 SILENT_PREFIX = MACHINERY_MARK + " " + PHASE_MARK + " "
 
 

--- a/core/agent/control_plane/scaffolds.py
+++ b/core/agent/control_plane/scaffolds.py
@@ -89,12 +89,12 @@ TTL_SECONDS = 14 * 24 * 3600
 # did not type a paragraph of instructions, and on 2026-09-02 the founder saw exactly that paragraph
 # painted as his own chat message (ledger F7). The terminal already filters a user turn carrying
 # this mark out of what it renders (`clients/terminal/src/canvas/actions.ts` MACHINERY_MARK /
-# MACHINERY_NOTE); the string is duplicated here rather than shared because the two sides ship in
-# different images, and it is the SAME string on purpose — a rename on either side is a visible
-# regression in the other, which is the cheapest coupling available.
+# MACHINERY_NOTE). The literal now lives once, in `shared/marks.py`, which all three Python images
+# already carry; the terminal's TypeScript copy is the one that genuinely cannot import it, and
+# `gate:fact-parity` compares the two on every push instead of hoping a rename is noticed.
 #
 # "the human sees turns, the agent sees instructions" (founder, 2026-09-02).
-MACHINERY_MARK = "[vexa-machinery]"
+from shared.marks import MACHINERY_MARK  # noqa: E402 — re-export under this module's long-standing name
 MACHINERY_NOTE = (
     "\n\n" + MACHINERY_MARK + " This opening was composed by the product from the link this person "
     "clicked; they did not type it and they cannot see it. Answer it as their first ask, in your own "

--- a/core/agent/control_plane/workspace_reader.py
+++ b/core/agent/control_plane/workspace_reader.py
@@ -102,11 +102,11 @@ _TEMPLATE_BANNER = (
 _TURNS_SIDECAR = "{session}.turns.jsonl"
 
 # The write-back phase runs in the SAME harness session as the turn it follows, so its prompt and
-# its reply are in this transcript. The phase declares itself with this mark (``engine.WRITEBACK_MARK``
-# — duplicated, not imported: the worker ships in its own image; ``tests/test_user_text_field.py``
-# pins the two literals together). Everything from a marked prompt until the next thing a person
-# actually said is bookkeeping the founder was never meant to read back as his own conversation.
-PHASE_MARK = "[vexa-phase:writeback]"
+# its reply are in this transcript. The phase declares itself with this mark — ONE literal now, in
+# ``shared/marks.py``; the worker reads the same constant under its historical name WRITEBACK_MARK.
+# Everything from a marked prompt until the next thing a person actually said is bookkeeping the
+# founder was never meant to read back as his own conversation.
+from shared.marks import PHASE_MARK  # noqa: E402 — re-export under this module's long-standing name
 
 # The harness's own auto-continue. It is a user line nobody typed — the runner nudging a turn that
 # stopped early — and it rendered as a grey USER bubble reading "Continue from where you left off."

--- a/core/agent/shared/marks.py
+++ b/core/agent/shared/marks.py
@@ -1,0 +1,43 @@
+"""THE TWO CHAT MARKS — the literals three images agree on, written once.
+
+A composed opening is not the person's own words: they clicked a link, they did not type a paragraph
+of instructions, and on 2026-09-02 the founder saw exactly that paragraph painted as his own chat
+message (ledger F7). A write-back phase runs in the SAME harness session as the turn it follows, so
+its prompt and its reply land in the transcript the history reader serves, and the founder read those
+back as his own conversation too (F51). Both are machinery, and machinery has to be recognisable in
+the RECORD rather than guessed at from its prose.
+
+WHY ONE MODULE NOW. Until this file existed the two marks were written FOUR and THREE times, and every
+copy carried a comment explaining that the duplication was deliberate because "the sides ship in
+different images". That reason is true of the TypeScript copy and was never true of the Python ones:
+`core/agent/shared` is COPY'd into agent-api (`services/agent-api/Dockerfile`), into the worker
+(`worker/Dockerfile`) and into lite (`deploy/lite/Dockerfile.lite`), and `worker/engine.py` and
+`control_plane/workspace_reader.py` already import from it at module scope. Three images were agreeing
+on a literal by hand while the module that could hold it was already in all three.
+
+WHAT IS STILL DUPLICATED, DELIBERATELY, AND GATED. `clients/terminal/src/canvas/actions.ts` ships in
+the terminal image and cannot import Python. That copy stays — and `gate:fact-parity` compares it to
+this file on every push (`scripts/parity.json`, fact `machinery-mark`), which is what the old comments
+were hoping a human would notice.
+
+ONE MARK PER MEANING, and they are not interchangeable:
+  MACHINERY_MARK  hides the PROMPT bubble — the reply is still shown. A composed opening is machinery
+                  whose ANSWER the person read and must keep.
+  PHASE_MARK      drops the prompt AND every agent turn up to the next thing a person said. A phase
+                  exchange is machinery whose answer nobody was ever shown.
+Suppressing everything after a MACHINERY_MARK turn would delete the first real reply of every
+scaffolded chat; marking a composed opening with the phase mark would swallow it too.
+
+The worker has historically called the second one WRITEBACK_MARK. That name is kept as an alias
+below, so nothing that reads `engine.WRITEBACK_MARK` moves, and there is still exactly one literal.
+"""
+from __future__ import annotations
+
+#: Hides the prompt bubble; the reply is still rendered.
+MACHINERY_MARK = "[vexa-machinery]"
+
+#: Drops the prompt and every agent turn up to the next thing a person actually said.
+PHASE_MARK = "[vexa-phase:writeback]"
+
+#: The worker's historical name for PHASE_MARK. One literal, two names, no second source.
+WRITEBACK_MARK = PHASE_MARK

--- a/core/agent/worker/engine.py
+++ b/core/agent/worker/engine.py
@@ -427,11 +427,11 @@ def mounts_preamble(mounts: list[dict]) -> str:
 # in flight — and the person's answer is never delayed by it, because their answer has already
 # streamed by the time this runs.
 #
-# THE SAME MARK the composed openings carry (control_plane.scaffolds.MACHINERY_MARK, and the
-# terminal's own copy in clients/terminal/src/canvas/actions.ts). Duplicated rather than shared for
-# the same stated reason: the three sides ship in different images, and a rename in one is meant to
-# be a visible regression in the others.
-MACHINERY_MARK = "[vexa-machinery]"
+# THE SAME MARK the composed openings carry. It is now READ from `shared/marks.py` rather than
+# retyped: this image COPYs `core/agent/shared` (worker/Dockerfile) and this module already imports
+# from it, so "the three sides ship in different images" was never a reason the PYTHON copies had to
+# diverge. The terminal's TypeScript copy still cannot import it and is compared by gate:fact-parity.
+from shared.marks import MACHINERY_MARK  # noqa: E402 — re-export; see shared/marks.py
 
 # THE PHASE'S OWN MARK (F51). The write-back phase runs in the SAME harness session as the turn,
 # so its prompt and its reply land in the transcript the history reader serves — and the founder read
@@ -444,7 +444,8 @@ MACHINERY_MARK = "[vexa-machinery]"
 # ever shown. Suppressing everything after a `MACHINERY_MARK` turn would delete the first real reply
 # of every scaffolded chat. One mark per meaning. `control_plane.workspace_reader.history` drops a
 # turn carrying this one and every agent turn up to the next thing a person actually said.
-WRITEBACK_MARK = "[vexa-phase:writeback]"
+# ONE literal, two names: `shared.marks.PHASE_MARK` is what control_plane calls it.
+from shared.marks import WRITEBACK_MARK  # noqa: E402 — re-export; see shared/marks.py
 
 # ⚠ THE FALLBACK IS NOT A TEST CONVENIENCE — it is the majority case for some deployments. A
 # dispatch with no delegation token gets NO MCP at all (`mcp_delegation_config` returns `(None,

--- a/docs/adr/0037-the-target-architecture-one-edge-domains-over-identity-and-runtime.md
+++ b/docs/adr/0037-the-target-architecture-one-edge-domains-over-identity-and-runtime.md
@@ -173,6 +173,18 @@ that everything sometimes has are not.
   the running one; the stateful alternative breaks every in-flight client on each restart. Register
   → reconnect → continue is the copy; the product answer is the OAuth flow the gateway's MCP service
   speaks.
+- **A key is `required-explicit` only if NO valid deployment can lack it.** Recorded from the #1483
+  merge: `VEXA_FLOWS_DB_URL` is `required-explicit`, because a service without its database is not a
+  deployment in any profile — it is a broken one, and it should refuse to start rather than come up
+  and fail per request. The mail keys stay a `capability` (`mailbox`), because a deployment may
+  legitimately run without mail credentials: the dogfood stack's flows lanes run a mail DOUBLE — SMTP
+  to mailpit, no password by construction — and `required-explicit` would refuse their boot over a
+  credential the deployment is right not to have. The general rule, which is the one to apply to the
+  next key rather than to re-derive it: **anything a valid deployment may omit is a `capability` with
+  a declared degrade; anything no valid deployment can omit is `required-explicit`.** The test is not
+  "is this important" — the mail credential is important — it is "does a deployment that lacks this
+  still make sense". `defaulted` is for neither: a default asserts the thing exists.
+
 - **Nothing here is proven by running.** Every count above is a code read of the line at
   `a5ba8e952`. The claims that need a live leg before the first release are decision 4 (a
   `not_present` resolved in a real no-agents deployment) and decision 10 (both profiles booting from

--- a/docs/docs/governance/architecture.mdx
+++ b/docs/docs/governance/architecture.mdx
@@ -109,6 +109,7 @@ runs them). ("ADD" = gap still open; "retire" = scheduled for removal.)
 | `gate:graph-py` | Python cross-package edges are acyclic + allow-listed (the Python twin of the depcruise DAG) | P3 | `check-isolation-py.mjs --mode=graph` | **have** (green-on-empty) |
 | `gate:config-contract` | (ADR-0026) each adopted service's `config.v1.json` is the SSOT for its environment: the declaration conforms to the sealed schema, its vendored `config_preflight.py` is byte-identical to the canonical copy, and declaration ↔ deploy surface is checked in **both** directions on **every** surface — compose, helm, the lite supervisord program env, and the shared `deploy/lite/entrypoint.sh` — plus an undeclared-read scan of the service's source | P14, P9 | `scripts/gates.mjs` | **have** |
 | `gate:domain-doors` | (ADR-0037) every cross-domain HTTP **door** (an env-configured base URL, or a literal `http://<service>:`) is one a domain may open: its own, identity's, the runtime primitive's, one DECLARED optional in its config contract (`capability` class + degrade — the `domain_present` pattern), or a PUBLISH edge — class `publish-edge` on the key, or `publishes_events` on the domain manifest — since a fact handed over best-effort is not a dependency. The edge and the clients reach a domain only through a declared route binding (`routes.v1` / `mcp.tools.v1`). The doors already open on the line sit in a dated allowlist keyed on (file, env-key) — never on a line number, which any edit above it moves — checked in BOTH directions and by count, so a stale or surplus entry fails too and the backlog can only shrink | P2, P3, P9 | `check-domain-doors.mjs` (+ `domain-doors.allow.json`) | **have** (green-on-empty) |
+| `gate:fact-parity` | every fact written in more than one place agrees, or is on a pinned ledger that names the decision blocking it. `scripts/parity.json` declares each fact, its sites and how they are compared (byte-identical file · identical literal · identical membership · identical regex source across languages · the same sentence once its carrier is stripped), plus `forbid_elsewhere` so a declared site list is a real inventory. Generalises the one mechanism in this repo that has held: `config_preflight.py`, vendored into seven packages and never drifted, because a gate compares the bytes | P23 | `check-parity.mjs` (+ `parity.json`) | **have** (green-on-empty) |
 | `gate:test-isolation` | no Python test imports a sibling module's internals (the test lane obeys the same P2 boundary as prod) | P2 | `check-isolation-py.mjs --mode=test-isolation` | **have** (green-on-empty) |
 | `gate:exports` | no consumer deep-imports past a module's `index` | P6 | `package.json` `"exports"` + scan | **have** (locks land per-package) |
 | `gate:readme` | every non-ignored directory has a non-empty `README.md` | P12 | tree-walk | **have** |
@@ -148,6 +149,14 @@ file, the line, and the declaration that would have made it legitimate. The desi
 against is [ADR-0037](https://github.com/Vexa-ai/vexa/blob/main/docs/adr/0037-the-target-architecture-one-edge-domains-over-identity-and-runtime.md),
 which names this gate as the mechanism it expects; the allowlist is the distance between that
 figure and the tree.
+
+**A duplicated fact needs a gate, not a comment.** Four places in this tree carry a comment asserting that a
+copied literal is *"kept identical on purpose"*, and in each case the copies had already diverged when someone
+looked. The one multiply-written fact that has never drifted is the one with a gate on it. `gate:fact-parity`
+generalises that mechanism, and it deliberately does **not** pick winners: where making the copies agree needs a
+product decision — which slug the server writes, whether a `joining` meeting is live — it records every live
+answer, names the decision, and fails if any of them moves without someone writing down that it moved. A gate
+that guesses a product decision makes the wrong answer permanent and calls it enforcement.
 
 **Two-layer enforcement.** Locally, a `pre-push` hook (`.githooks/pre-push`, wired by `core.hooksPath` via the root `prepare` script — zero-dependency, per P17) runs `pnpm gates` and blocks any push that isn't green. In CI, `gates.yml` re-runs each gate as its own step so a failure is unambiguous. `git commit` itself runs nothing — the bar is at **push**, not every commit.
 

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "gate:contract-version": "node scripts/gates.mjs contract-version",
     "gate:config-contract": "node scripts/gates.mjs config-contract",
     "gate:domain-doors": "node scripts/gates.mjs domain-doors",
+    "gate:fact-parity": "node scripts/gates.mjs fact-parity",
     "gate:db-schema": "node scripts/gates.mjs db-schema",
     "gate:db-budget": "node scripts/gates.mjs db-budget",
     "gate:merge-card": "node scripts/merge-card-gate.mjs",

--- a/scripts/check-parity.mjs
+++ b/scripts/check-parity.mjs
@@ -119,6 +119,9 @@ export function checkFact(fact, root = DEFAULT_ROOT) {
     byValue.get(r.value).push(`${site.path}:${r.line}`);
   }
   const distinct = [...byValue.keys()].sort();
+  // value -> the FILES that give it (paths only: a line number moves with any edit above it, and a
+  // ledger that reds on whitespace is a ledger people stop reading)
+  const answers = distinct.map((v) => ({ value: v, sites: byValue.get(v).map((x) => x.split(":")[0]).sort() }));
 
   if (fact.enforced) {
     if (distinct.length > 1) {
@@ -126,14 +129,19 @@ export function checkFact(fact, root = DEFAULT_ROOT) {
       errs.push(`${fact.id} — "${fact.fact}" is written ${(fact.sites || []).length} times and they DISAGREE (${distinct.length} answers):\n${groups}\n        canonical: ${fact.canonical || "(none declared)"} — ${fact.how_to_agree || "make every site read the canonical definition"}`);
     }
   } else {
-    const pinned = (fact.distinct || []).slice().sort();
+    // WHAT IS PINNED IS THE MAPPING, not the set of answers. Pinning only the distinct VALUES let a
+    // site change sides in silence: flip core/agent's runtime hostname from runtime-api to runtime
+    // and both values are still present, so a set comparison sees no change while the tree just
+    // moved. A ledger entry has to say WHO gives WHICH answer, or it is not a baseline.
+    const pinned = JSON.stringify(fact.answers || []);
     if (distinct.length === 1 && (fact.sites || []).length > 1)
       errs.push(`${fact.id} — "${fact.fact}" is now IN PARITY across all ${(fact.sites || []).length} sites. The decision it was waiting on ("${fact.decision}") has been taken: set "enforced": true in ${MANIFEST_PATH} so it can never drift again. The ledger only shrinks.`);
-    else if (JSON.stringify(distinct) !== JSON.stringify(pinned)) {
-      errs.push(`${fact.id} — "${fact.fact}" has CHANGED since it was recorded, and it is a fact nobody has decided yet.\n        recorded: ${pinned.map(short).join("  |  ") || "(nothing)"}\n        found:    ${distinct.map(short).join("  |  ")}\n        Either make the sites agree and set "enforced": true, or update "distinct" in ${MANIFEST_PATH} so the ledger still tells the truth. Decision pending: ${fact.decision}`);
+    else if (JSON.stringify(answers) !== pinned) {
+      const render = (a) => a.map((x) => `          ${short(x.value)}\n            ${x.sites.join("\n            ")}`).join("\n");
+      errs.push(`${fact.id} — "${fact.fact}" has CHANGED since it was recorded, and it is a fact nobody has decided yet.\n        recorded:\n${render(fact.answers || []) || "          (nothing)"}\n        found:\n${render(answers)}\n        Either make the sites agree and set "enforced": true, or re-record with \`node scripts/check-parity.mjs --record\` so the ledger still tells the truth — the diff it writes IS the review. Decision pending: ${fact.decision}`);
     }
   }
-  return { id: fact.id, errs, byValue, distinct };
+  return { id: fact.id, errs, byValue, distinct, answers };
 }
 
 const short = (v) => {
@@ -211,8 +219,8 @@ export function recordLedger(root = DEFAULT_ROOT) {
     if (fact.enforced) continue;
     const r = results.find((x) => x.id === fact.id);
     if (!r) continue;
-    const next = r.distinct.slice().sort();
-    if (JSON.stringify(next) !== JSON.stringify((fact.distinct || []).slice().sort())) { fact.distinct = next; changed++; }
+    const next = r.answers;
+    if (JSON.stringify(next) !== JSON.stringify(fact.answers || [])) { fact.answers = next; delete fact.distinct; changed++; }
   }
   writeFileSync(join(root, MANIFEST_PATH), JSON.stringify(manifest, null, 2) + "\n");
   return changed;

--- a/scripts/check-parity.mjs
+++ b/scripts/check-parity.mjs
@@ -1,0 +1,244 @@
+#!/usr/bin/env node
+/**
+ * The FACT-PARITY checker — P23, one writer per fact, applied to facts that are not data carriers
+ * but LITERALS: a set of statuses, a mark, a sentence, a regex, a default URL.
+ *
+ * THE ARGUMENT IS ONE CONTROL CASE. `config_preflight.py` is vendored byte-identically into six
+ * packages and has never drifted, because `gate:config-contract` fails the build on byte-inequality.
+ * It is the only cross-image constant in this repository with a parity gate, and it is the only
+ * multiply-written fact that has held. Every other one on the 2026-09-03 SSOT survey has either
+ * drifted or is one edit from drifting — including four that carry a comment asserting the copies
+ * are "kept identical on purpose".
+ *
+ * WHAT THIS IS NOT. It is not a refactor. Where one canonical definition can be imported by the
+ * others without anybody deciding anything, this PR imports it and the fact is ENFORCED. Where
+ * agreeing requires choosing which of two live answers is right — which slug the server writes,
+ * whether a `joining` meeting is live — the gate does NOT pick. It records both answers, names the
+ * decision, and refuses to let either side move without saying so. A gate that guesses a product
+ * decision is worse than no gate: it makes the wrong answer permanent and calls it enforcement.
+ *
+ * THE MANIFEST (`scripts/parity.json`) is the deliverable. Each fact declares:
+ *   kind          file-bytes | literal | set | regex-source
+ *   sites[]       {path, pattern} — `pattern` is a JS regex with exactly ONE capture group; it must
+ *                 match exactly once in the file. Zero matches or two is a STALE MANIFEST and fails:
+ *                 the manifest cannot quietly stop describing the tree.
+ *   enforced      true  → every site must agree. This is the teeth.
+ *                 false → the fact has ALREADY DRIFTED and agreeing needs a decision. The distinct
+ *                         values are pinned in `distinct` and `decision` names what must be settled.
+ *                         The gate then fails if what it finds differs from what is pinned — so a
+ *                         drifted fact cannot move without a human writing down that it moved — and
+ *                         fails if the sites have come into agreement, which means the decision was
+ *                         taken and `enforced` should now be true. The ledger can only shrink.
+ *
+ * `regex-source` is a seam, stated as one: for a Python↔TypeScript pair there is no shared module to
+ * import (ADR-0036 item 10), so what is compared is the regex SOURCE STRING. Two engines can still
+ * read one source differently; string equality is the strongest check available without a mechanism
+ * that does not exist, and it is strictly better than the nothing that is there today.
+ */
+import { readFileSync, writeFileSync, existsSync, readdirSync, statSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const DEFAULT_ROOT = join(HERE, "..");
+export const MANIFEST_PATH = "scripts/parity.json";
+
+export function loadManifest(root = DEFAULT_ROOT) {
+  const p = join(root, MANIFEST_PATH);
+  if (!existsSync(p)) return { facts: [] };
+  return JSON.parse(readFileSync(p, "utf8"));
+}
+
+/**
+ * The PROSE normaliser. A sentence that must read the same to a stranger is carried differently in
+ * every file that holds it: a Python implicit-concat splits it at whichever word hit the margin, a
+ * markdown blockquote prefixes every line with "> " and hard-wraps, a TS template literal keeps it
+ * on one line. Those are carrier artefacts, not different sentences, and a byte comparator would
+ * report five spellings where a reader sees one. So prose is compared after the carrier is removed:
+ * quote markers, concatenation seams and every whitespace run collapse to single spaces.
+ * What is NOT normalised: apostrophes. U+2019 vs U+0027 is a real difference in text a stranger
+ * reads, and the rig's copy differs from every other in exactly that way.
+ */
+export const asProse = (raw) => raw
+  .replace(/\\n/g, " ")                  // an escaped newline inside a source string literal
+  .replace(/^[ \t]*>[ \t]?/gm, " ")      // markdown blockquote marker
+  .replace(/["`]/g, "")                   // string delimiters — but NEVER the apostrophe
+  .replace(/"\s*\n\s*"/g, "")           // Python/TS implicit string concatenation seam
+  .replace(/\s+/g, " ")
+  .trim();
+
+/** The set-comparison normaliser: a delimited list of quoted members → a sorted, de-duped array. */
+export const asSet = (raw) => [...new Set(
+  raw.split(/[,|\s]+/).map((t) => t.replace(/^[\s'"`\[({]+|[\s'"`\])}]+$/g, "")).filter(Boolean),
+)].sort();
+
+/** Read one site's value. Returns {value} or {error}. */
+export function readSite(fact, site, root) {
+  const abs = join(root, site.path);
+  if (!existsSync(abs)) return { error: `${site.path} does not exist (the manifest names a file the tree does not have)` };
+  const text = readFileSync(abs, "utf8");
+  if (fact.kind === "file-bytes") return { value: text, line: 1 };
+
+  let re;
+  try { re = new RegExp(site.pattern, site.flags || "m"); }
+  catch (e) { return { error: `${site.path}: the manifest's own pattern does not compile — ${e.message}` }; }
+  const all = [...text.matchAll(new RegExp(re.source, (re.flags.includes("g") ? re.flags : re.flags + "g")))];
+  if (all.length === 0)
+    return { error: `${site.path}: the manifest's pattern matches nothing — either the fact moved or the site is gone. Re-anchor it or delete the site; a pattern that matches nothing silently stops checking.` };
+  if (all.length > 1 && !site.all)
+    return { error: `${site.path}: the manifest's pattern matches ${all.length} times — anchor it to exactly one, or set "all": true if EVERY occurrence in this file must carry the same value.` };
+  if (site.all) {
+    // "all": the fact is written several times in ONE file (five contracts carry the placeholder
+    // list once per key). Every occurrence must agree with every other before the file contributes
+    // a value at all, so an intra-file disagreement is named where it happens rather than being
+    // averaged into whichever match came first.
+    const vals = all.map((x) => x[1]);
+    const norm = (v) => fact.kind === "set" ? asSet(v).join(" · ") : fact.kind === "prose" ? asProse(v) : v;
+    const distinctHere = [...new Set(vals.map(norm))];
+    if (distinctHere.length > 1)
+      return { error: `${site.path}: this file writes the fact ${all.length} times and its own copies disagree — ${distinctHere.map((v) => JSON.stringify(v.slice(0, 80))).join(" vs ")}` };
+  }
+  const m = all[0];
+  if (m[1] === undefined) return { error: `${site.path}: the manifest's pattern has no capture group` };
+  const line = text.slice(0, m.index).split("\n").length;
+  const raw = m[1];
+  const value = fact.kind === "set" ? asSet(raw).join(" · ")
+    : fact.kind === "prose" ? asProse(raw)
+    : raw;
+  return { value, line, raw };
+}
+
+/** Check one fact. Returns {id, errs[], values: Map(value -> [site…]), distinct[]} */
+export function checkFact(fact, root = DEFAULT_ROOT) {
+  const errs = [];
+  const byValue = new Map();
+  for (const site of fact.sites || []) {
+    const r = readSite(fact, site, root);
+    if (r.error) { errs.push(`${fact.id}: ${r.error}`); continue; }
+    if (!byValue.has(r.value)) byValue.set(r.value, []);
+    byValue.get(r.value).push(`${site.path}:${r.line}`);
+  }
+  const distinct = [...byValue.keys()].sort();
+
+  if (fact.enforced) {
+    if (distinct.length > 1) {
+      const groups = distinct.map((v, i) => `        (${i + 1}) ${short(v)}\n            ${byValue.get(v).join("\n            ")}`).join("\n");
+      errs.push(`${fact.id} — "${fact.fact}" is written ${(fact.sites || []).length} times and they DISAGREE (${distinct.length} answers):\n${groups}\n        canonical: ${fact.canonical || "(none declared)"} — ${fact.how_to_agree || "make every site read the canonical definition"}`);
+    }
+  } else {
+    const pinned = (fact.distinct || []).slice().sort();
+    if (distinct.length === 1 && (fact.sites || []).length > 1)
+      errs.push(`${fact.id} — "${fact.fact}" is now IN PARITY across all ${(fact.sites || []).length} sites. The decision it was waiting on ("${fact.decision}") has been taken: set "enforced": true in ${MANIFEST_PATH} so it can never drift again. The ledger only shrinks.`);
+    else if (JSON.stringify(distinct) !== JSON.stringify(pinned)) {
+      errs.push(`${fact.id} — "${fact.fact}" has CHANGED since it was recorded, and it is a fact nobody has decided yet.\n        recorded: ${pinned.map(short).join("  |  ") || "(nothing)"}\n        found:    ${distinct.map(short).join("  |  ")}\n        Either make the sites agree and set "enforced": true, or update "distinct" in ${MANIFEST_PATH} so the ledger still tells the truth. Decision pending: ${fact.decision}`);
+    }
+  }
+  return { id: fact.id, errs, byValue, distinct };
+}
+
+const short = (v) => {
+  const one = String(v).replace(/\s+/g, " ").trim();
+  return one.length > 160 ? one.slice(0, 157) + "…" : one;
+};
+
+// A declared site list is only a real inventory if nothing ELSE writes the fact. `forbid_elsewhere`
+// names the literal and the trees to sweep: any non-test source file outside the declared sites that
+// contains it fails the gate. Without this, single-sourcing a mark today just means someone retypes
+// it next month and the manifest keeps reporting green over two writers.
+const SWEEP_SKIP = new Set(["node_modules", "dist", ".turbo", "__pycache__", ".venv", ".next",
+                            "coverage", "test-results", "playwright-report", "tests", "__tests__"]);
+const SWEEP_EXT = /\.(py|ts|tsx|js|jsx|mjs|cjs|sh|sql|json|yml|yaml|md)$/;
+const sweepTestFile = (n) => /^test_.*\.py$/.test(n) || /_test\.py$/.test(n) || /\.(test|spec)\.[cm]?[jt]sx?$/.test(n);
+
+function sweep(dir, root, needle, hits) {
+  let names; try { names = readdirSync(dir); } catch { return hits; }
+  for (const name of names) {
+    if (name.startsWith(".") || SWEEP_SKIP.has(name)) continue;
+    const p = join(dir, name);
+    let st; try { st = statSync(p); } catch { continue; }
+    if (st.isDirectory()) { sweep(p, root, needle, hits); continue; }
+    if (!SWEEP_EXT.test(name) || sweepTestFile(name)) continue;
+    let text; try { text = readFileSync(p, "utf8"); } catch { continue; }
+    const i = text.indexOf(needle);
+    if (i < 0) continue;
+    hits.push({ path: p.slice(root.length + 1).replace(/\\/g, "/"), line: text.slice(0, i).split("\n").length });
+  }
+  return hits;
+}
+
+/** Every non-test source file outside `fact.sites` that still writes the literal. */
+export function strayWriters(fact, root = DEFAULT_ROOT) {
+  if (!fact.forbid_elsewhere) return [];
+  const declared = new Set((fact.sites || []).map((s) => s.path));
+  const hits = [];
+  for (const r of fact.scan || ["core", "clients", "deploy", "services", "libs", "sdks"])
+    if (existsSync(join(root, r))) sweep(join(root, r), root, fact.forbid_elsewhere, hits);
+  return hits.filter((h) => !declared.has(h.path));
+}
+
+export function checkParity(root = DEFAULT_ROOT) {
+  const manifest = loadManifest(root);
+  const errs = [];
+  const results = [];
+  const seen = new Set();
+  for (const fact of manifest.facts || []) {
+    if (seen.has(fact.id)) { errs.push(`duplicate fact id "${fact.id}"`); continue; }
+    seen.add(fact.id);
+    if (!fact.enforced && !fact.decision)
+      errs.push(`${fact.id}: an unenforced fact must name the decision that would settle it ("decision")`);
+    const r = checkFact(fact, root);
+    for (const h of strayWriters(fact, root))
+      r.errs.push(`${fact.id}: ${h.path}:${h.line} writes "${fact.forbid_elsewhere}" and is not a declared site — read it from ${fact.canonical || "the canonical definition"} instead, or add the site to ${MANIFEST_PATH} and say why a third writer is right.`);
+    results.push(r);
+    errs.push(...r.errs);
+  }
+  const enforced = (manifest.facts || []).filter((f) => f.enforced);
+  const ledger = (manifest.facts || []).filter((f) => !f.enforced);
+  const siteCount = (manifest.facts || []).reduce((n, f) => n + (f.sites || []).length, 0);
+  return { manifest, results, errs, enforced, ledger, siteCount };
+}
+
+/**
+ * Write today's answers into each LEDGER fact's `distinct`. This is how a drifted fact is BASELINED,
+ * never how one is fixed: it records what the tree says so that the next change to any copy has to
+ * be written down. Run it deliberately — the diff it produces IS the review — and never to make a
+ * red gate quiet, which is the one use that would turn the ledger back into wallpaper.
+ */
+export function recordLedger(root = DEFAULT_ROOT) {
+  const { manifest, results } = checkParity(root);
+  let changed = 0;
+  for (const fact of manifest.facts || []) {
+    if (fact.enforced) continue;
+    const r = results.find((x) => x.id === fact.id);
+    if (!r) continue;
+    const next = r.distinct.slice().sort();
+    if (JSON.stringify(next) !== JSON.stringify((fact.distinct || []).slice().sort())) { fact.distinct = next; changed++; }
+  }
+  writeFileSync(join(root, MANIFEST_PATH), JSON.stringify(manifest, null, 2) + "\n");
+  return changed;
+}
+
+// CLI: `node scripts/check-parity.mjs [--ledger|--record]`
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  if (process.argv.includes("--record")) {
+    const n = recordLedger();
+    console.log(`recorded today's answers for ${n} ledger fact(s) in ${MANIFEST_PATH} — read the diff, it is the review`);
+    process.exit(0);
+  }
+  const res = checkParity();
+  if (process.argv.includes("--ledger")) {
+    for (const f of res.ledger) {
+      const r = res.results.find((x) => x.id === f.id);
+      console.log(`\n■ ${f.id} — ${f.fact}   (${(f.sites || []).length} sites, ${r.distinct.length} answers)`);
+      console.log(`  decision: ${f.decision}`);
+      for (const v of r.distinct) {
+        console.log(`   • ${short(v)}`);
+        for (const s of r.byValue.get(v)) console.log(`       ${s}`);
+      }
+    }
+  } else {
+    for (const e of res.errs) console.log("✗ " + e);
+    console.log(`${res.enforced.length} enforced fact(s) · ${res.ledger.length} on the drift ledger · ${res.siteCount} sites · ${res.errs.length} error(s)`);
+  }
+  process.exit(res.errs.length ? 1 : 0);
+}

--- a/scripts/check-parity.test.mjs
+++ b/scripts/check-parity.test.mjs
@@ -1,0 +1,235 @@
+// Tests OF the fact-parity checker — the instrument gate:fact-parity trusts.
+//
+// The first group runs against synthetic repos (mkdtemp) so they assert the RULE, not today's tree.
+// The last two run against THIS repository: the manifest still describes the tree, and the tip is
+// green. The point of the synthetic ones is the failure modes that would make the gate LIE —
+// a pattern that matches nothing, a pattern that matches twice, a ledger fact that quietly moved.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { checkParity, asSet, asProse } from "./check-parity.mjs";
+
+const REPO = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+function fixture(facts, files) {
+  const root = mkdtempSync(join(tmpdir(), "parity-"));
+  const all = { "scripts/parity.json": JSON.stringify({ contract: "parity.v1", facts }), ...files };
+  for (const [p, body] of Object.entries(all)) {
+    mkdirSync(join(root, dirname(p)), { recursive: true });
+    writeFileSync(join(root, p), body);
+  }
+  return root;
+}
+const run = (root) => { try { return checkParity(root); } finally { /* caller cleans */ } };
+
+const MARK = (v) => `MACHINERY_MARK = "${v}"\n`;
+const markFact = (extra = {}) => [{
+  id: "machinery-mark", fact: "the machinery mark", kind: "literal", enforced: true,
+  sites: [
+    { path: "a/x.py", pattern: 'MACHINERY_MARK = "([^"]+)"' },
+    { path: "b/y.ts", pattern: 'MACHINERY_MARK = "([^"]+)"' },
+  ], ...extra,
+}];
+
+test("an ENFORCED fact whose sites agree passes; one that disagrees is named with both answers", () => {
+  const ok = fixture(markFact(), { "a/x.py": MARK("[vexa-machinery]"), "b/y.ts": MARK("[vexa-machinery]") });
+  const bad = fixture(markFact(), { "a/x.py": MARK("[vexa-machinery]"), "b/y.ts": MARK("[vexa-machinary]") });
+  try {
+    assert.deepEqual(run(ok).errs, []);
+    const e = run(bad).errs;
+    assert.equal(e.length, 1);
+    assert.match(e[0], /DISAGREE \(2 answers\)/);
+    assert.match(e[0], /\[vexa-machinery\]/);
+    assert.match(e[0], /\[vexa-machinary\]/, "both live answers must be in the failure — the reader has to see what to reconcile");
+    assert.match(e[0], /a\/x\.py:1/);
+    assert.match(e[0], /b\/y\.ts:1/);
+  } finally { rmSync(ok, { recursive: true, force: true }); rmSync(bad, { recursive: true, force: true }); }
+});
+
+test("a pattern that matches NOTHING fails — a manifest that stopped describing the tree reports green", () => {
+  const root = fixture(markFact(), { "a/x.py": MARK("[vexa-machinery]"), "b/y.ts": "// the constant was renamed\n" });
+  try {
+    const e = run(root).errs;
+    assert.equal(e.length, 1);
+    assert.match(e[0], /matches nothing/);
+    assert.match(e[0], /b\/y\.ts/);
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test("a pattern that matches TWICE fails — the gate must not compare whichever came first", () => {
+  const root = fixture(markFact(), { "a/x.py": MARK("[vexa-machinery]"), "b/y.ts": MARK("[vexa-machinery]") + MARK("[vexa-machinery]") });
+  try {
+    const e = run(root).errs;
+    assert.equal(e.length, 1);
+    assert.match(e[0], /matches 2 times/);
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test("a SET fact compares membership, not spelling or order", () => {
+  const facts = [{
+    id: "live", fact: "the live set", kind: "set", enforced: true,
+    sites: [
+      { path: "a/p.py", pattern: "LIVE = \\{([^}]*)\\}" },
+      { path: "b/q.ts", pattern: "LIVE = new Set\\(\\[([^\\]]*)\\]\\)" },
+    ],
+  }];
+  const ok = fixture(facts, {
+    "a/p.py": 'LIVE = {"active", "joining", "awaiting_admission"}\n',
+    "b/q.ts": 'const LIVE = new Set(["awaiting_admission",\n  "active",\n  "joining"])\n',
+  });
+  const bad = fixture(facts, {
+    "a/p.py": 'LIVE = {"active", "joining", "awaiting_admission"}\n',
+    "b/q.ts": 'const LIVE = new Set(["active", "joining"])\n',
+  });
+  try {
+    assert.deepEqual(run(ok).errs, [], "different order, different quoting, different container — same membership");
+    assert.equal(run(bad).errs.length, 1, "a missing member is a real disagreement");
+  } finally { rmSync(ok, { recursive: true, force: true }); rmSync(bad, { recursive: true, force: true }); }
+});
+
+test("asSet unquotes, de-dupes and sorts, and is blind to the container", () => {
+  assert.deepEqual(asSet('"b", "a", \'a\''), ["a", "b"]);
+  assert.deepEqual(asSet("[ 'z' , `y` ]"), ["y", "z"]);
+});
+
+test("PROSE compares the sentence, not the carrier — but never normalises the apostrophe", () => {
+  const NL = "\n";
+  const APOS = String.fromCharCode(39);
+  const facts = [{
+    id: "vis", fact: "the disclosure", kind: "prose", enforced: true,
+    sites: [
+      { path: "a/t.py", pattern: "S = \\(([\\s\\S]*?)\\)" },
+      { path: "b/t.md", pattern: "^(Vexa runs[^\\n]*)$" },
+      { path: "c/t.md", pattern: "((?:^> .*\\n)*^> Vexa runs[\\s\\S]*?agents\\.)" },
+    ],
+  }];
+  const sentence = "Vexa runs on this org" + APOS + "s own servers; what you keep is visible to the agents.";
+  const py = 'S = ("Vexa runs on this org' + APOS + 's own servers; what you keep "' + NL + '     "is visible to the agents.")' + NL;
+  const md = sentence + NL;
+  const quoted = "> Vexa runs on this org" + APOS + "s own servers; what you keep" + NL + "> is visible to the agents." + NL;
+  const ok = fixture(facts, { "a/t.py": py, "b/t.md": md, "c/t.md": quoted });
+  // the SAME sentence with a typographic apostrophe is a different sentence to the stranger reading it
+  const curly = fixture(facts, { "a/t.py": py, "b/t.md": md.replace(APOS, "\u2019"), "c/t.md": quoted });
+  try {
+    assert.deepEqual(run(ok).errs, [],
+      "a Python concat split, a markdown hard wrap and a blockquote are carriers, not different sentences");
+    assert.equal(run(curly).errs.length, 1, "U+2019 vs U+0027 is a real difference in text a stranger reads");
+  } finally { rmSync(ok, { recursive: true, force: true }); rmSync(curly, { recursive: true, force: true }); }
+});
+
+test("asProse strips the carrier and keeps the apostrophe", () => {
+  assert.equal(asProse('> one\n> two'), "one two");
+  assert.equal(asProse('"a "\n  "b"'), "a b");
+  assert.equal(asProse("it's"), "it's");
+});
+
+test('"all": every occurrence in one file must agree before the file has an answer', () => {
+  const facts = [{
+    id: "idx", fact: "the index predicate", kind: "set", enforced: true,
+    sites: [
+      { path: "a/models.py", pattern: "IN \\(([^)]*)\\)", all: true },
+      { path: "b/models.py", pattern: "IN \\(([^)]*)\\)", all: true },
+    ],
+  }];
+  const two = "x = \"IN ('a', 'b')\"\ny = \"IN ('a', 'b')\"\n";
+  const ok = fixture(facts, { "a/models.py": two, "b/models.py": two });
+  const inner = fixture(facts, { "a/models.py": "x = \"IN ('a', 'b')\"\ny = \"IN ('a', 'c')\"\n", "b/models.py": two });
+  try {
+    assert.deepEqual(run(ok).errs, [], "two identical occurrences per file is one answer per file");
+    const e = run(inner).errs;
+    assert.equal(e.length, 1);
+    assert.match(e[0], /its own copies disagree/,
+      "an intra-file disagreement must be named where it happens, not averaged into the first match");
+  } finally { rmSync(ok, { recursive: true, force: true }); rmSync(inner, { recursive: true, force: true }); }
+});
+
+test("forbid_elsewhere makes the site list an INVENTORY — a stray writer fails, a test does not", () => {
+  const facts = [{
+    id: "mark", fact: "the mark", kind: "literal", enforced: true, canonical: "core/shared/marks.py",
+    sites: [{ path: "core/shared/marks.py", pattern: 'MARK = "([^"]+)"' }],
+    forbid_elsewhere: "[vexa-machinery]", scan: ["core", "clients"],
+  }];
+  const clean = fixture(facts, {
+    "core/shared/marks.py": 'MARK = "[vexa-machinery]"\n',
+    "core/agent/tests/test_x.py": 'assert "[vexa-machinery]" in out\n',
+    "core/agent/uses.py": "from shared.marks import MARK\n",
+  });
+  const stray = fixture(facts, {
+    "core/shared/marks.py": 'MARK = "[vexa-machinery]"\n',
+    "clients/terminal/src/retyped.ts": 'const M = "[vexa-machinery]";\n',
+  });
+  try {
+    assert.deepEqual(run(clean).errs, [], "a test that asserts the literal is not a second writer of it");
+    const e = run(stray).errs;
+    assert.equal(e.length, 1);
+    assert.match(e[0], /clients\/terminal\/src\/retyped\.ts:1/);
+    assert.match(e[0], /not a declared site/);
+  } finally { rmSync(clean, { recursive: true, force: true }); rmSync(stray, { recursive: true, force: true }); }
+});
+
+const ledgerFact = (distinct) => [{
+  id: "slug", fact: "the entity slug", kind: "literal", enforced: false,
+  decision: "which slug the server writes and the client must reproduce",
+  distinct,
+  sites: [
+    { path: "a/x.py", pattern: 'SLUG = "([^"]+)"' },
+    { path: "b/y.ts", pattern: 'SLUG = "([^"]+)"' },
+  ],
+}];
+
+test("a LEDGER fact passes while it matches what was recorded, and fails the moment it moves", () => {
+  const files = { "a/x.py": 'SLUG = "[^a-zA-Z0-9]+"\n', "b/y.ts": 'SLUG = "[^a-z0-9]+"\n' };
+  const pinned = fixture(ledgerFact(["[^a-z0-9]+", "[^a-zA-Z0-9]+"]), files);
+  const moved = fixture(ledgerFact(["[^a-z0-9]+", "[^a-zA-Z0-9]+"]),
+    { ...files, "b/y.ts": 'SLUG = "[^a-z0-9_]+"\n' });
+  try {
+    assert.deepEqual(run(pinned).errs, [], "a drifted fact that has not moved is not news");
+    const e = run(moved).errs;
+    assert.equal(e.length, 1);
+    assert.match(e[0], /has CHANGED since it was recorded/);
+    assert.match(e[0], /decision pending|Decision pending/);
+  } finally { rmSync(pinned, { recursive: true, force: true }); rmSync(moved, { recursive: true, force: true }); }
+});
+
+test("a LEDGER fact that comes into agreement FAILS — the decision was taken, so enforce it", () => {
+  const root = fixture(ledgerFact(["[^a-z0-9]+", "[^a-zA-Z0-9]+"]),
+    { "a/x.py": 'SLUG = "[^a-z0-9]+"\n', "b/y.ts": 'SLUG = "[^a-z0-9]+"\n' });
+  try {
+    const e = run(root).errs;
+    assert.equal(e.length, 1);
+    assert.match(e[0], /now IN PARITY/);
+    assert.match(e[0], /"enforced": true/, "the failure must say exactly what to do next");
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test("an unenforced fact that names no decision is itself an error", () => {
+  const root = fixture([{ id: "x", fact: "f", kind: "literal", enforced: false, distinct: [], sites: [] }], {});
+  try {
+    assert.ok(run(root).errs.some((e) => /must name the decision/.test(e)));
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test("a file-bytes fact is byte-exact", () => {
+  const facts = [{ id: "pre", fact: "the preflight", kind: "file-bytes", enforced: true,
+    sites: [{ path: "a/p.py" }, { path: "b/p.py" }] }];
+  const ok = fixture(facts, { "a/p.py": "x = 1\n", "b/p.py": "x = 1\n" });
+  const bad = fixture(facts, { "a/p.py": "x = 1\n", "b/p.py": "x = 1\n\n" });
+  try {
+    assert.deepEqual(run(ok).errs, []);
+    assert.equal(run(bad).errs.length, 1, "one trailing newline is a drift — that is the point of vendoring VERBATIM");
+  } finally { rmSync(ok, { recursive: true, force: true }); rmSync(bad, { recursive: true, force: true }); }
+});
+
+test("this repository's manifest still describes the tree, and the tip is green", () => {
+  const res = checkParity(REPO);
+  assert.deepEqual(res.errs, []);
+  assert.ok(res.enforced.length >= 1, "at least the control case is enforced");
+  for (const f of res.manifest.facts || []) {
+    assert.ok(f.fact && f.kind && Array.isArray(f.sites), `${f.id}: a fact names itself, its kind and its sites`);
+    if (!f.enforced) assert.ok(f.decision && f.decision.length > 20, `${f.id}: the ledger names the decision that settles it`);
+    if (f.enforced) assert.ok(f.canonical || f.sites.length === 1, `${f.id}: an enforced fact names where the truth lives`);
+  }
+});

--- a/scripts/check-parity.test.mjs
+++ b/scripts/check-parity.test.mjs
@@ -170,10 +170,10 @@ test("forbid_elsewhere makes the site list an INVENTORY — a stray writer fails
   } finally { rmSync(clean, { recursive: true, force: true }); rmSync(stray, { recursive: true, force: true }); }
 });
 
-const ledgerFact = (distinct) => [{
+const ledgerFact = (answers) => [{
   id: "slug", fact: "the entity slug", kind: "literal", enforced: false,
   decision: "which slug the server writes and the client must reproduce",
-  distinct,
+  answers,
   sites: [
     { path: "a/x.py", pattern: 'SLUG = "([^"]+)"' },
     { path: "b/y.ts", pattern: 'SLUG = "([^"]+)"' },
@@ -182,9 +182,9 @@ const ledgerFact = (distinct) => [{
 
 test("a LEDGER fact passes while it matches what was recorded, and fails the moment it moves", () => {
   const files = { "a/x.py": 'SLUG = "[^a-zA-Z0-9]+"\n', "b/y.ts": 'SLUG = "[^a-z0-9]+"\n' };
-  const pinned = fixture(ledgerFact(["[^a-z0-9]+", "[^a-zA-Z0-9]+"]), files);
-  const moved = fixture(ledgerFact(["[^a-z0-9]+", "[^a-zA-Z0-9]+"]),
-    { ...files, "b/y.ts": 'SLUG = "[^a-z0-9_]+"\n' });
+  const BASE = [{ value: "[^a-z0-9]+", sites: ["b/y.ts"] }, { value: "[^a-zA-Z0-9]+", sites: ["a/x.py"] }];
+  const pinned = fixture(ledgerFact(BASE), files);
+  const moved = fixture(ledgerFact(BASE), { ...files, "b/y.ts": 'SLUG = "[^a-z0-9_]+"\n' });
   try {
     assert.deepEqual(run(pinned).errs, [], "a drifted fact that has not moved is not news");
     const e = run(moved).errs;
@@ -195,7 +195,7 @@ test("a LEDGER fact passes while it matches what was recorded, and fails the mom
 });
 
 test("a LEDGER fact that comes into agreement FAILS — the decision was taken, so enforce it", () => {
-  const root = fixture(ledgerFact(["[^a-z0-9]+", "[^a-zA-Z0-9]+"]),
+  const root = fixture(ledgerFact([{ value: "[^a-z0-9]+", sites: ["b/y.ts"] }, { value: "[^a-zA-Z0-9]+", sites: ["a/x.py"] }]),
     { "a/x.py": 'SLUG = "[^a-z0-9]+"\n', "b/y.ts": 'SLUG = "[^a-z0-9]+"\n' });
   try {
     const e = run(root).errs;
@@ -205,8 +205,35 @@ test("a LEDGER fact that comes into agreement FAILS — the decision was taken, 
   } finally { rmSync(root, { recursive: true, force: true }); }
 });
 
+test("a LEDGER fact reds when a site SWITCHES SIDES, even though the answers are unchanged", () => {
+  // The failure this test exists for: pinning only the distinct VALUES let a site move from one
+  // camp to the other in silence, because both values were still present. What is pinned is the
+  // MAPPING. Measured on the real tree first: flipping core/agent's runtime hostname was invisible.
+  const three = [
+    { path: "a/x.py", pattern: 'H = "([^"]+)"' },
+    { path: "b/y.py", pattern: 'H = "([^"]+)"' },
+    { path: "c/z.py", pattern: 'H = "([^"]+)"' },
+  ];
+  const facts = (answers) => [{ id: "host", fact: "the runtime hostname", kind: "literal",
+    enforced: false, decision: "what the runtime is actually called on the network", answers, sites: three }];
+  const pinnedAnswers = [
+    { value: "http://runtime-api:8090", sites: ["a/x.py", "b/y.py"] },
+    { value: "http://runtime:8090", sites: ["c/z.py"] },
+  ];
+  const H = (v) => `H = "${v}"\n`;
+  const same = fixture(facts(pinnedAnswers), { "a/x.py": H("http://runtime-api:8090"), "b/y.py": H("http://runtime-api:8090"), "c/z.py": H("http://runtime:8090") });
+  const switched = fixture(facts(pinnedAnswers), { "a/x.py": H("http://runtime-api:8090"), "b/y.py": H("http://runtime:8090"), "c/z.py": H("http://runtime:8090") });
+  try {
+    assert.deepEqual(run(same).errs, []);
+    const e = run(switched).errs;
+    assert.equal(e.length, 1, "both values still exist — a set comparison would have seen nothing");
+    assert.match(e[0], /has CHANGED since it was recorded/);
+    assert.match(e[0], /b\/y\.py/, "the failure must name the site that moved");
+  } finally { rmSync(same, { recursive: true, force: true }); rmSync(switched, { recursive: true, force: true }); }
+});
+
 test("an unenforced fact that names no decision is itself an error", () => {
-  const root = fixture([{ id: "x", fact: "f", kind: "literal", enforced: false, distinct: [], sites: [] }], {});
+  const root = fixture([{ id: "x", fact: "f", kind: "literal", enforced: false, answers: [], sites: [] }], {});
   try {
     assert.ok(run(root).errs.some((e) => /must name the decision/.test(e)));
   } finally { rmSync(root, { recursive: true, force: true }); }
@@ -229,7 +256,11 @@ test("this repository's manifest still describes the tree, and the tip is green"
   assert.ok(res.enforced.length >= 1, "at least the control case is enforced");
   for (const f of res.manifest.facts || []) {
     assert.ok(f.fact && f.kind && Array.isArray(f.sites), `${f.id}: a fact names itself, its kind and its sites`);
-    if (!f.enforced) assert.ok(f.decision && f.decision.length > 20, `${f.id}: the ledger names the decision that settles it`);
+    if (!f.enforced) {
+      assert.ok(f.decision && f.decision.length > 20, `${f.id}: the ledger names the decision that settles it`);
+      assert.ok(Array.isArray(f.answers) && f.answers.length, `${f.id}: a ledger fact pins WHO gives WHICH answer`);
+      assert.ok(!("distinct" in f), `${f.id}: the old value-only baseline must not survive — a site could switch sides under it`);
+    }
     if (f.enforced) assert.ok(f.canonical || f.sites.length === 1, `${f.id}: an enforced fact names where the truth lives`);
   }
 });

--- a/scripts/gates.mjs
+++ b/scripts/gates.mjs
@@ -5,13 +5,14 @@
  * Usage: node scripts/gates.mjs [readme|isolation|isolation-py|exports|graph|graph-py|schema|
  *                                contract-version|config-contract|python|stack|node|health|access|
  *                                tracing|replay|telemetry|eval|licenses|compose|execution-env|
- *                                lite-makefile|domain-doors|all]
+ *                                lite-makefile|domain-doors|fact-parity|all]
  */
 import { readdirSync, existsSync, readFileSync, writeFileSync, statSync } from "node:fs";
 import { join } from "node:path";
 import { execSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import { checkDomainDoors, ALLOW_PATH as DOORS_ALLOW } from "./check-domain-doors.mjs";
+import { checkParity, MANIFEST_PATH as PARITY_MANIFEST } from "./check-parity.mjs";
 
 const ROOT = process.cwd();
 const SKIP = new Set(["node_modules", "dist", ".turbo", "__pycache__", "test-results", "playwright-report", "coverage"]);
@@ -1422,7 +1423,30 @@ function gateDomainDoors() {
   return true;
 }
 
-const GATES = { readme: gateReadme, "lite-makefile": gateLiteMakefile, "docs-version": gateDocsVersion, dataflow: gateDataflow, isolation: gateIsolation, "isolation-py": gateIsolationPy, exports: gateExports, graph: gateGraph, "graph-py": gateGraphPy, schema: gateSchema, "contract-version": gateContractVersion, "config-contract": gateConfigContract, "db-schema": gateDbSchema, "db-budget": gateDbBudget, python: gatePython, stack: gateStack, node: gateNode, health: gateHealth, access: gateAccess, tracing: gateTracing, replay: gateReplay, telemetry: gateTelemetry, eval: gateEval, licenses: gateLicenses, "image-licenses": gateImageLicenses, "runtime-parity": gateRuntimeParity, compose: gateCompose, "execution-env": gateExecutionEnv, "test-isolation": gateTestIsolation, "arch-report": gateArchReport, parity: gateParity, "compose-stress": gateComposeStress, "compose-chaos": gateComposeChaos, "eval-baseline": gateEvalBaseline, "contract-conformance": gateContractConformance, "domain-doors": gateDomainDoors };
+const GATES = { readme: gateReadme, "lite-makefile": gateLiteMakefile, "docs-version": gateDocsVersion, dataflow: gateDataflow, isolation: gateIsolation, "isolation-py": gateIsolationPy, exports: gateExports, graph: gateGraph, "graph-py": gateGraphPy, schema: gateSchema, "contract-version": gateContractVersion, "config-contract": gateConfigContract, "db-schema": gateDbSchema, "db-budget": gateDbBudget, python: gatePython, stack: gateStack, node: gateNode, health: gateHealth, access: gateAccess, tracing: gateTracing, replay: gateReplay, telemetry: gateTelemetry, eval: gateEval, licenses: gateLicenses, "image-licenses": gateImageLicenses, "runtime-parity": gateRuntimeParity, compose: gateCompose, "execution-env": gateExecutionEnv, "test-isolation": gateTestIsolation, "arch-report": gateArchReport, parity: gateParity, "compose-stress": gateComposeStress, "compose-chaos": gateComposeChaos, "eval-baseline": gateEvalBaseline, "contract-conformance": gateContractConformance, "domain-doors": gateDomainDoors, "fact-parity": gateFactParity };
+// gate:fact-parity (P23 — one writer per fact) — the generalisation of the ONE control case in this
+// repository. `config_preflight.py` is vendored byte-identically into seven packages and has never
+// drifted, because check 2 of gate:config-contract fails the build on byte-inequality. Every other
+// multiply-written fact in the tree either has drifted or is one edit away — the 2026-09-03 SSOT
+// survey found an entity slug with three implementations that already resolve a non-ASCII name to
+// two different filenames, a "live meeting" status set with ten declarations and four memberships,
+// and four comments asserting that copies are "kept identical on purpose" beside copies that are not.
+//
+// scripts/parity.json names each fact and where it is written. A fact is ENFORCED (every site must
+// agree — the teeth) or on the DRIFT LEDGER (it has already disagreed and agreeing needs a product
+// decision, so the gate records both answers, names the decision, and refuses to let either side
+// move silently). The gate does not pick winners: a gate that guesses a product decision makes the
+// wrong answer permanent and calls it enforcement.
+function gateFactParity() {
+  let res;
+  try { res = checkParity(ROOT); }
+  catch (e) { return fail([`fact-parity: the checker or ${PARITY_MANIFEST} itself failed — ${errText(e).slice(0, 800)}`]); }
+  if (!(res.manifest.facts || []).length) { console.log("  ✓ gate:fact-parity — no parity manifest yet (green-on-empty)"); return true; }
+  if (res.errs.length) return fail([`fact-parity (P23, one writer per fact) — facts written twice that disagree:`, ...res.errs.map((e) => "   " + e)]);
+  console.log(`  ✓ gate:fact-parity — ${res.enforced.length} enforced fact(s) agree across ${res.enforced.reduce((n, f) => n + f.sites.length, 0)} site(s) · ${res.ledger.length} on the drift ledger, each pinned and naming its pending decision (\`node scripts/check-parity.mjs --ledger\`)`);
+  return true;
+}
+
 const which = process.argv[2] || "all";
 
 // `seal` (not a gate) — (re)freeze the current published contracts into contracts.seal.json.

--- a/scripts/parity.json
+++ b/scripts/parity.json
@@ -200,11 +200,32 @@
         }
       ],
       "enforced": false,
-      "distinct": [
-        "[^a-z0-9]+",
-        "[^a-zA-Z0-9]+",
-        "s.toLowerCase().replace(/[^a-z0-9]+/g, \"-\").replace(/^-+|-+$/g, \"\")",
-        "s.toLowerCase().replace(/[^a-z0-9]+/g, \"-\").replace(/^-|-$/g, \"\")"
+      "answers": [
+        {
+          "value": "[^a-z0-9]+",
+          "sites": [
+            "core/agent/shared/core.py"
+          ]
+        },
+        {
+          "value": "[^a-zA-Z0-9]+",
+          "sites": [
+            "core/agent/shared/entities.py"
+          ]
+        },
+        {
+          "value": "s.toLowerCase().replace(/[^a-z0-9]+/g, \"-\").replace(/^-+|-+$/g, \"\")",
+          "sites": [
+            "clients/terminal/src/ui-kit/docLinks.tsx"
+          ]
+        },
+        {
+          "value": "s.toLowerCase().replace(/[^a-z0-9]+/g, \"-\").replace(/^-|-$/g, \"\")",
+          "sites": [
+            "clients/terminal/src/surfaces/meeting.tsx",
+            "clients/terminal/src/surfaces/meetingModel.ts"
+          ]
+        }
       ]
     },
     {
@@ -224,9 +245,19 @@
         }
       ],
       "enforced": false,
-      "distinct": [
-        "company · decision · meeting · person · project",
-        "company · person · task · topic"
+      "answers": [
+        {
+          "value": "company · decision · meeting · person · project",
+          "sites": [
+            "core/agent/shared/entities.py"
+          ]
+        },
+        {
+          "value": "company · person · task · topic",
+          "sites": [
+            "clients/terminal/src/surfaces/meetingModel.ts"
+          ]
+        }
       ]
     },
     {
@@ -254,9 +285,21 @@
         }
       ],
       "enforced": false,
-      "distinct": [
-        "Vexa runs on this organisation's own servers; the recording and transcript stay there.",
-        "Vexa runs on this organisation's own servers; what you and your colleagues keep in your workspaces is visible to the company's agents; recordings and transcripts stay here."
+      "answers": [
+        {
+          "value": "Vexa runs on this organisation's own servers; the recording and transcript stay there.",
+          "sites": [
+            "core/flows/src/flows_defs/production.py"
+          ]
+        },
+        {
+          "value": "Vexa runs on this organisation's own servers; what you and your colleagues keep in your workspaces is visible to the company's agents; recordings and transcripts stay here.",
+          "sites": [
+            "behavior/asks/setup-global.md",
+            "behavior/mail/attendee-head.md",
+            "core/flows/src/flows_steps/mailtext.py"
+          ]
+        }
       ]
     },
     {
@@ -276,9 +319,19 @@
         }
       ],
       "enforced": false,
-      "distinct": [
-        "+ MACHINERY_MARK + This opening was composed by the product from the link this person clicked",
-        "+ MACHINERY_MARK + This opening was composed by the product from the link this person clicked; they did not type it and they cannot see it. Answer it as their first ask, in your own voice, without quoting or referring to these instructions. # READ SILENTLY. This rides on EVERY composed opening, not just the setup preset, because the # failure is the shape of the model rather than of one prompt: the founder's first setup turn # opened with I'll start by reading…, let me look at what actually exists in the mounts, # I've got what I need to begin — three lines of narration before one word addressed to him. # Reading is how the job is done, not part of the job; announcing it teaches the reader only # that they are waiting. Read whatever you need silently: the FIRST sentence you emit is addressed to the person, and you never narrate your own tool use. # TEMPLATES ARE SHAPES. An agent read kg/templates/person.md as if it described somebody and # created a real entity from the example inside it; a person was then shown a template rendered # as their own document. Both are the same mistake — a shape treated as a fact — and it is worth # one sentence on every turn rather than a rule in one preset. Anything marked template: true, and anything under kg/templates/, is a SHAPE and never a fact: copy it to make a new record, never cite it, never name it to a person, and never treat the example inside it as somebody real. # (unset) IS A GAP. A group workspace created before the template-free seed still carries the # seed's placeholders in its README, and an agent reported the project's objective is still # (unset) as though that were something it had found out. It is the templates-are-SHAPES # mistake one step smaller — a blank read as a value — so it gets the sentence next to it. (unset) and any other angle-bracket or placeholder value is a GAP, never a fact: say the thing is not recorded yet and offer to fill it in, never report the placeholder as the answer. # Decision 24. A composed opening is the turn most likely to meet a name for the first time # — an attendee clicking a post-meeting link brings a whole room with them — and it is the # turn least likely to stop and write pages, because it is answering an ask. A name without a page gets one now: whatever this turn learns about a person, company, meeting, project or decision goes in through entity_upsert with its source. Facts carry a source; gaps go to kg/MISSING.md, never invented. # F70. The founder asked for a bot and was told I don't have a bot-dispatch tool in this # session. The tool was there: the CLI logged hasTools: true, the rig served 57 tools # including bot_send, and the model never attempted a call. Asked afterwards to list its # tools it listed them all, then said it had been guessing at my own capabilities instead of # checking them. A refusal is the one answer that must never be produced from memory. Your tools are exactly the ones in your tool list. Never say you lack a capability without checking the list; if a call fails, report its error verbatim. # F71. The founder was handed curl -X POST https://api.vexa.ai/bots -H X-API-Key: … — the # agent's workaround for a thing it believed it could not do, which it could. Two failures in # one line: it made him the runtime, and it put a key in a chat. Never hand the person an API call, a curl command, a key or a token. If you cannot do something, say that you cannot do it right now and why, in one sentence. # F73. After a successful send the agent offered a link into the product the person was # already looking at. The panel is moved by the harness, not by you — there is no tool here to # call for it, and a URL is the one thing that cannot help someone already inside the app. The person is INSIDE the app: never give them an app URL or a link into it, and never tell them to open one. Say what is on screen now. # F69. A bare meeting link is not a topic to discuss. It is the whole instruction, and the # turn that answers it with a question has spent the moment the person needed. A message that is only a meeting URL means: send the bot now. # F72. Correcting yourself and then asking whether to proceed spends a second turn on a # decision already made — and on a standing instruction it re-asks something already answered. After correcting yourself on something the person has already told you, DO the thing in that same turn. Never re-ask what they have already answered."
+      "answers": [
+        {
+          "value": "+ MACHINERY_MARK + This opening was composed by the product from the link this person clicked",
+          "sites": [
+            "clients/terminal/src/canvas/actions.ts"
+          ]
+        },
+        {
+          "value": "+ MACHINERY_MARK + This opening was composed by the product from the link this person clicked; they did not type it and they cannot see it. Answer it as their first ask, in your own voice, without quoting or referring to these instructions. # READ SILENTLY. This rides on EVERY composed opening, not just the setup preset, because the # failure is the shape of the model rather than of one prompt: the founder's first setup turn # opened with I'll start by reading…, let me look at what actually exists in the mounts, # I've got what I need to begin — three lines of narration before one word addressed to him. # Reading is how the job is done, not part of the job; announcing it teaches the reader only # that they are waiting. Read whatever you need silently: the FIRST sentence you emit is addressed to the person, and you never narrate your own tool use. # TEMPLATES ARE SHAPES. An agent read kg/templates/person.md as if it described somebody and # created a real entity from the example inside it; a person was then shown a template rendered # as their own document. Both are the same mistake — a shape treated as a fact — and it is worth # one sentence on every turn rather than a rule in one preset. Anything marked template: true, and anything under kg/templates/, is a SHAPE and never a fact: copy it to make a new record, never cite it, never name it to a person, and never treat the example inside it as somebody real. # (unset) IS A GAP. A group workspace created before the template-free seed still carries the # seed's placeholders in its README, and an agent reported the project's objective is still # (unset) as though that were something it had found out. It is the templates-are-SHAPES # mistake one step smaller — a blank read as a value — so it gets the sentence next to it. (unset) and any other angle-bracket or placeholder value is a GAP, never a fact: say the thing is not recorded yet and offer to fill it in, never report the placeholder as the answer. # Decision 24. A composed opening is the turn most likely to meet a name for the first time # — an attendee clicking a post-meeting link brings a whole room with them — and it is the # turn least likely to stop and write pages, because it is answering an ask. A name without a page gets one now: whatever this turn learns about a person, company, meeting, project or decision goes in through entity_upsert with its source. Facts carry a source; gaps go to kg/MISSING.md, never invented. # F70. The founder asked for a bot and was told I don't have a bot-dispatch tool in this # session. The tool was there: the CLI logged hasTools: true, the rig served 57 tools # including bot_send, and the model never attempted a call. Asked afterwards to list its # tools it listed them all, then said it had been guessing at my own capabilities instead of # checking them. A refusal is the one answer that must never be produced from memory. Your tools are exactly the ones in your tool list. Never say you lack a capability without checking the list; if a call fails, report its error verbatim. # F71. The founder was handed curl -X POST https://api.vexa.ai/bots -H X-API-Key: … — the # agent's workaround for a thing it believed it could not do, which it could. Two failures in # one line: it made him the runtime, and it put a key in a chat. Never hand the person an API call, a curl command, a key or a token. If you cannot do something, say that you cannot do it right now and why, in one sentence. # F73. After a successful send the agent offered a link into the product the person was # already looking at. The panel is moved by the harness, not by you — there is no tool here to # call for it, and a URL is the one thing that cannot help someone already inside the app. The person is INSIDE the app: never give them an app URL or a link into it, and never tell them to open one. Say what is on screen now. # F69. A bare meeting link is not a topic to discuss. It is the whole instruction, and the # turn that answers it with a question has spent the moment the person needed. A message that is only a meeting URL means: send the bot now. # F72. Correcting yourself and then asking whether to proceed spends a second turn on a # decision already made — and on a standing instruction it re-asks something already answered. After correcting yourself on something the person has already told you, DO the thing in that same turn. Never re-ask what they have already answered.",
+          "sites": [
+            "core/agent/control_plane/scaffolds.py"
+          ]
+        }
       ]
     },
     {
@@ -310,9 +363,22 @@
         }
       ],
       "enforced": false,
-      "distinct": [
-        "defaulted",
-        "required-explicit"
+      "answers": [
+        {
+          "value": "defaulted",
+          "sites": [
+            "core/meetings/services/meeting-api/src/meeting_api/config.v1.json"
+          ]
+        },
+        {
+          "value": "required-explicit",
+          "sites": [
+            "core/agent/control_plane/config.v1.json",
+            "core/flows/src/config.v1.json",
+            "core/gateway/services/gateway/src/gateway/config.v1.json",
+            "core/identity/services/admin-api/src/admin_api/config.v1.json"
+          ]
+        }
       ]
     },
     {
@@ -336,9 +402,20 @@
         }
       ],
       "enforced": false,
-      "distinct": [
-        "http://runtime-api:8090",
-        "http://runtime:8090"
+      "answers": [
+        {
+          "value": "http://runtime-api:8090",
+          "sites": [
+            "core/agent/control_plane/config.v1.json",
+            "core/agent/shared/config.py"
+          ]
+        },
+        {
+          "value": "http://runtime:8090",
+          "sites": [
+            "core/meetings/services/meeting-api/src/meeting_api/config.v1.json"
+          ]
+        }
       ]
     },
     {
@@ -406,12 +483,45 @@
           "pattern": "WHERE status IN \\(([^)]*)\\)"
         }
       ],
-      "distinct": [
-        "active · awaiting_admission · joining · needs_help · needs_human_help · requested · stopping",
-        "active · awaiting_admission · joining · needs_help · requested · stopping",
-        "active · awaiting_admission · joining · requested · scheduled · stopping",
-        "active · awaiting_admission · joining · requested · stopping",
-        "active · awaiting_admission · requested"
+      "answers": [
+        {
+          "value": "active · awaiting_admission · joining · needs_help · needs_human_help · requested · stopping",
+          "sites": [
+            "core/meetings/services/meeting-api/src/meeting_api/bot_spawn/auto_join.py"
+          ]
+        },
+        {
+          "value": "active · awaiting_admission · joining · needs_help · requested · stopping",
+          "sites": [
+            "clients/terminal/src/surfaces/liveMeetings.ts",
+            "clients/terminal/src/surfaces/meetingModel.ts",
+            "core/agent/control_plane/meeting_steering.py",
+            "core/agent/control_plane/scaffolds.py",
+            "core/agent/control_plane/schedule_digest.py",
+            "core/meetings/services/meeting-api/src/meeting_api/collector/transcript_import.py",
+            "deploy/dogfood/bin/blank-instance.sh",
+            "deploy/dogfood/rehearse/doors.py"
+          ]
+        },
+        {
+          "value": "active · awaiting_admission · joining · requested · scheduled · stopping",
+          "sites": [
+            "core/identity/services/admin-api/src/admin_api/schema/models.py",
+            "core/meetings/services/meeting-api/src/meeting_api/sessions/models.py"
+          ]
+        },
+        {
+          "value": "active · awaiting_admission · joining · requested · stopping",
+          "sites": [
+            "core/meetings/services/meeting-api/src/meeting_api/bot_spawn/service.py"
+          ]
+        },
+        {
+          "value": "active · awaiting_admission · requested",
+          "sites": [
+            "deploy/dogfood/rig/vexa_control_mcp.py"
+          ]
+        }
       ]
     }
   ]

--- a/scripts/parity.json
+++ b/scripts/parity.json
@@ -1,0 +1,418 @@
+{
+  "contract": "parity.v1",
+  "dated": "2026-09-03",
+  "measured_on": "Vexa-ai/vexa branch minutes-mcp-viewer",
+  "what_this_is": [
+    "Every fact in this repository that is written in more than one place, and what must be true of",
+    "the copies. P23 is 'one writer per data carrier'; these are not carriers, they are LITERALS — a",
+    "set of statuses, a mark, a sentence, a regex, a default URL — and nothing was checking them.",
+    "",
+    "The control case is the whole argument: config_preflight.py is vendored byte-identically into",
+    "seven packages and has NEVER drifted, because a gate fails the build on byte-inequality. It is",
+    "the only cross-image constant in this tree with a parity gate, and it is the only multiply-",
+    "written fact that has held. Four other facts carry a comment asserting the copies are 'kept",
+    "identical on purpose', beside copies that are not.",
+    "",
+    "A fact is either ENFORCED — every site must agree, and the gate is the reason they will — or on",
+    "the DRIFT LEDGER: it has already disagreed, and making the sites agree requires choosing which",
+    "live answer is right. The gate does not choose. It records every answer, names the decision, and",
+    "fails if any of them moves without a human writing down that it moved. It also fails when a",
+    "ledger fact comes into agreement, because that means the decision was taken and the fact should",
+    "now be enforced. The ledger can only shrink.",
+    "",
+    "Each site's `pattern` is a JS regex with exactly one capture group that must match EXACTLY ONCE",
+    "in the file. Zero matches or two is a failure: a manifest that has quietly stopped describing",
+    "the tree is worse than no manifest, because it reports green."
+  ],
+  "kinds": {
+    "file-bytes": "the whole file must be byte-identical to every other site's",
+    "literal": "the captured text must be identical",
+    "set": "the captured text is split on commas/whitespace, unquoted, de-duped and sorted — membership must be identical, order and spelling of the container need not be",
+    "regex-source": "the captured text is a regular expression SOURCE compared as a string. Used where the sites are in different languages and no shared module can exist (ADR-0036 item 10): two engines may still read one source differently, so this is the strongest check available without a mechanism that does not exist — and strictly stronger than the nothing there is today.",
+    "(any kind) forbid_elsewhere": "names the literal itself: any non-test source file under `scan` that contains it and is not a declared site fails. A site list is only an inventory if nothing else writes the fact — without this, single-sourcing a mark today just means someone retypes it next month and the manifest reports green over two writers.",
+    "prose": "the captured text is a SENTENCE compared after its carrier is removed — blockquote markers, string-concatenation seams and whitespace runs collapse. A Python implicit-concat splits a sentence at whichever word hit the margin and a markdown file hard-wraps it; those are not different sentences. Apostrophes are NOT normalised: U+2019 vs U+0027 is a real difference in text a stranger reads."
+  },
+  "facts": [
+    {
+      "id": "config-preflight",
+      "fact": "the config.v1 boot preflight",
+      "kind": "file-bytes",
+      "enforced": true,
+      "canonical": "deploy/contracts/config.v1/preflight.py",
+      "how_to_agree": "vendor the canonical file VERBATIM into the service package",
+      "why": "THE CONTROL CASE. Seven vendored copies, md5 628e79b499… on every one, no drift since the gate landed. It is listed here so the manifest states the whole rule rather than only its exceptions — and so the mechanism that works is described in the same place as the facts that need it. gate:config-contract check 2 enforces this independently; the duplication is deliberate and cheap.",
+      "sites": [
+        {
+          "path": "deploy/contracts/config.v1/preflight.py"
+        },
+        {
+          "path": "core/agent/control_plane/config_preflight.py"
+        },
+        {
+          "path": "core/flows/src/config_preflight.py"
+        },
+        {
+          "path": "core/gateway/services/gateway/src/gateway/config_preflight.py"
+        },
+        {
+          "path": "core/identity/services/admin-api/src/admin_api/config_preflight.py"
+        },
+        {
+          "path": "core/meetings/services/mcp/src/vexa_mcp/config_preflight.py"
+        },
+        {
+          "path": "core/meetings/services/meeting-api/src/meeting_api/config_preflight.py"
+        },
+        {
+          "path": "core/runtime/src/runtime_kernel/config_preflight.py"
+        }
+      ]
+    },
+    {
+      "id": "machinery-mark",
+      "fact": "the machinery mark — the literal that hides a composed opening's prompt bubble",
+      "kind": "literal",
+      "enforced": true,
+      "canonical": "core/agent/shared/marks.py",
+      "how_to_agree": "import it from shared.marks in Python; the terminal's copy is the one genuine mirror and this gate is what keeps it honest",
+      "why": "Was written FOUR times across three images — control_plane/chat_intents.py, control_plane/scaffolds.py, worker/engine.py, clients/terminal/src/canvas/actions.ts — each with a comment saying the duplication was deliberate because 'the sides ship in different images'. True of the TypeScript copy; never true of the Python ones: core/agent/shared is COPY'd into agent-api, the worker AND lite, and two of the three modules already imported from it at module scope. Three images were agreeing on a literal by hand while the module that could hold it was already in all three. The Python side is now one definition; what is left is the one copy that cannot import Python, and it is gated here rather than hoped about in a comment.",
+      "sites": [
+        {
+          "path": "core/agent/shared/marks.py",
+          "pattern": "^MACHINERY_MARK = \"([^\"]+)\""
+        },
+        {
+          "path": "clients/terminal/src/canvas/actions.ts",
+          "pattern": "MACHINERY_MARK = \"([^\"]+)\""
+        }
+      ],
+      "forbid_elsewhere": "[vexa-machinery]",
+      "scan": [
+        "core",
+        "clients"
+      ]
+    },
+    {
+      "id": "phase-mark",
+      "fact": "the write-back phase mark — the literal that drops a phase exchange out of the history",
+      "kind": "literal",
+      "enforced": true,
+      "canonical": "core/agent/shared/marks.py",
+      "how_to_agree": "import PHASE_MARK (worker: WRITEBACK_MARK, an alias of the same constant) from shared.marks",
+      "why": "Was written THREE times under TWO names — control_plane/workspace_reader.py PHASE_MARK, control_plane/chat_intents.py PHASE_MARK, worker/engine.py WRITEBACK_MARK — all three inside core/agent, where not even an image boundary excused it. Now one literal with the worker's historical name kept as an alias. There is no TypeScript copy, so this fact has exactly ONE writer; `forbid_elsewhere` is what keeps it that way, because a fact with one writer stays that way only while something checks.",
+      "sites": [
+        {
+          "path": "core/agent/shared/marks.py",
+          "pattern": "^PHASE_MARK = \"([^\"]+)\""
+        },
+        {
+          "path": "core/agent/llm/openai_agent.py",
+          "pattern": "tests for `(\\[vexa-phase:writeback\\])`",
+          "note": "prose, not a definition — but a comment that names the mark must name it right, and declaring it here is what keeps forbid_elsewhere a true inventory"
+        }
+      ],
+      "forbid_elsewhere": "[vexa-phase:writeback]",
+      "scan": [
+        "core",
+        "clients"
+      ]
+    },
+    {
+      "id": "placeholder-secrets",
+      "fact": "the published placeholder values a deployment's internal secret must never still hold (F95)",
+      "kind": "set",
+      "enforced": true,
+      "canonical": "core/flows/src/flows_steps/common.py — INTERNAL_SECRET_PLACEHOLDERS (the list with a name; the JSON contracts carry it as data)",
+      "how_to_agree": "one list; a contract that adds a placeholder adds it everywhere, or the boot preflight of one service accepts what another refuses",
+      "why": "Ten retypings of one seven-value list across five config.v1 contracts and two Python modules. Unlike every other fact on this page it has NOT drifted — every site is value- and order-identical today — which is exactly why it is enforced rather than laddered: this is the moment the gate costs nothing and buys everything. F95 was one secret with three names shipping the published placeholder as its default; the whole point of the list is that every service refuses the SAME values. There is nothing in deploy/contracts/config.v1 to import from — the schema types forbidden_values as an unconstrained string array — so extracting a shared artefact is a contract change and a design choice, and this PR does not make it. The gate holds the ten in agreement until someone does.",
+      "sites": [
+        {
+          "path": "core/agent/control_plane/config.v1.json",
+          "pattern": "\"forbidden_values\"\\s*:\\s*\\[([^\\]]*)\\]",
+          "flags": "m",
+          "all": true,
+          "note": "every forbidden_values list in this contract must be the same list"
+        },
+        {
+          "path": "core/flows/src/config.v1.json",
+          "pattern": "\"forbidden_values\"\\s*:\\s*\\[([^\\]]*)\\]",
+          "flags": "m",
+          "all": true,
+          "note": "every forbidden_values list in this contract must be the same list"
+        },
+        {
+          "path": "core/gateway/services/gateway/src/gateway/config.v1.json",
+          "pattern": "\"forbidden_values\"\\s*:\\s*\\[([^\\]]*)\\]",
+          "flags": "m",
+          "all": true,
+          "note": "every forbidden_values list in this contract must be the same list"
+        },
+        {
+          "path": "core/identity/services/admin-api/src/admin_api/config.v1.json",
+          "pattern": "\"forbidden_values\"\\s*:\\s*\\[([^\\]]*)\\]",
+          "flags": "m",
+          "all": true,
+          "note": "every forbidden_values list in this contract must be the same list"
+        },
+        {
+          "path": "core/meetings/services/meeting-api/src/meeting_api/config.v1.json",
+          "pattern": "\"forbidden_values\"\\s*:\\s*\\[([^\\]]*)\\]",
+          "flags": "m",
+          "all": true,
+          "note": "every forbidden_values list in this contract must be the same list"
+        },
+        {
+          "path": "core/flows/src/flows_steps/common.py",
+          "pattern": "INTERNAL_SECRET_PLACEHOLDERS = \\(([^)]*)\\)"
+        },
+        {
+          "path": "deploy/dogfood/rig/vexa_control_mcp.py",
+          "pattern": "INTERNAL_SECRET_PLACEHOLDERS = \\(([^)]*)\\)"
+        }
+      ]
+    },
+    {
+      "id": "entity-slug",
+      "fact": "the slug that turns an entity's name into its filename",
+      "kind": "literal",
+      "decision": "WHICH SLUG THE SERVER WRITES AND EVERY CLIENT MUST REPRODUCE. Two live answers today, and they are not cosmetic: core/agent/shared/entities.py NFKD ascii-folds first, so \"Zoe Muller\" with a diaeresis and an umlaut becomes zoe-muller; every one of the other eight implementations produces zo-m-ller. The server writes the first filename and the terminal's wikilink chip looks for the second, so the chip never resolves for a non-ASCII name. Also open, and separate: the length cap is 80 (entities.py), 60 (production.py), 40 (workspace_attach.py) or absent (all TypeScript), and the empty-input fallback is \"\", \"shared\", \"untitled\", \"meeting\" or \"unknown\" depending on which one ran.",
+      "why": "Nine non-test implementations, not the four the survey first claimed. The manifest records each verbatim so no tenth appears quietly and no existing one moves without someone writing down that it moved. NOT a candidate for mechanical unification: the fix is that the server RETURNS the slug it wrote (entity_upsert), which is a product decision about an API, and picking one of the nine here would make one of the two current filenames permanent.",
+      "sites": [
+        {
+          "path": "core/agent/shared/entities.py",
+          "pattern": "re\\.sub\\(r\"(\\[\\^a-zA-Z0-9\\]\\+)\""
+        },
+        {
+          "path": "core/agent/shared/core.py",
+          "pattern": "re\\.sub\\(r\"(\\[\\^a-z0-9\\]\\+)\""
+        },
+        {
+          "path": "clients/terminal/src/ui-kit/docLinks.tsx",
+          "pattern": "entitySlug = \\(s: string\\) => (s\\.toLowerCase\\(\\)[^;]*);"
+        },
+        {
+          "path": "clients/terminal/src/surfaces/meetingModel.ts",
+          "pattern": "const slug = \\(s: string\\) => (s\\.toLowerCase\\(\\)[^;]*);"
+        },
+        {
+          "path": "clients/terminal/src/surfaces/meeting.tsx",
+          "pattern": "const docSlug = \\(s: string\\) => (s\\.toLowerCase\\(\\)[^;]*);"
+        }
+      ],
+      "enforced": false,
+      "distinct": [
+        "[^a-z0-9]+",
+        "[^a-zA-Z0-9]+",
+        "s.toLowerCase().replace(/[^a-z0-9]+/g, \"-\").replace(/^-+|-+$/g, \"\")",
+        "s.toLowerCase().replace(/[^a-z0-9]+/g, \"-\").replace(/^-|-$/g, \"\")"
+      ]
+    },
+    {
+      "id": "entity-kind-enum",
+      "fact": "the kinds an entity may be, and therefore the directories kg/entities may contain",
+      "kind": "set",
+      "decision": "WHETHER topic AND task ARE ENTITY KINDS. The server's writer refuses both and raises EntityRefused; the terminal types every participant and every mentioned title as \"topic\" and mints kg/entities/topic/<slug>.md for it (meetingModel.ts entityFor, reached from canvas/useMeeting.ts on every live meeting). Meanwhile meeting, project and decision cannot be expressed in the terminal at all. Either the server grows the two kinds or the terminal stops minting a path the writer will refuse — and until that is decided, the terminal is building links into a namespace that does not exist.",
+      "why": "Two declarations, five kinds against four, sharing only person and company. shared/governance.py's path gate accepts any kind segment, so a terminal-written topic path passes governance and fails later in entity_rel_path — the disagreement surfaces as far as possible from where it was made.",
+      "sites": [
+        {
+          "path": "core/agent/shared/entities.py",
+          "pattern": "^KINDS = \\(([^)]*)\\)"
+        },
+        {
+          "path": "clients/terminal/src/surfaces/meetingModel.ts",
+          "pattern": "export type EntityType = ([^;]*);"
+        }
+      ],
+      "enforced": false,
+      "distinct": [
+        "company · decision · meeting · person · project",
+        "company · person · task · topic"
+      ]
+    },
+    {
+      "id": "visibility-sentence",
+      "fact": "the visibility disclosure — the sentence telling a stranger who can see what they keep in a workspace",
+      "kind": "prose",
+      "decision": "WHETHER THE PRODUCTION DATA STATEMENT SAYS WHAT THE OTHERS SAY. Five sites carry the founder-decision-21 sentence identically. Two do not. flows_defs/production.py ships \"Vexa runs on this organisation's own servers; the recording and transcript stay there.\" — which drops the entire clause about a colleague's workspace being visible to the company's agents, on a live outbound path. That is a materially weaker disclosure, not a wording variant, and only a human can rule on what a stranger must be told. Separately, the rig's copy is written in the third person and uses U+2019 apostrophes where every other copy uses ASCII.",
+      "why": "Seven spellings of one sentence, three of them behind a fallback chain. The five that agree do so by luck: they are five independent retypings and nothing compares them. Recording them here makes the next edit to any one of them visible.",
+      "sites": [
+        {
+          "path": "core/flows/src/flows_steps/mailtext.py",
+          "pattern": "VISIBILITY_SENTENCE = \\(([\\s\\S]*?)\\)\\n"
+        },
+        {
+          "path": "behavior/mail/attendee-head.md",
+          "pattern": "^(Vexa runs on this organisation.s own servers;[^\\n]*)$"
+        },
+        {
+          "path": "behavior/asks/setup-global.md",
+          "pattern": "((?:^> .*\\n)*^> Vexa runs on this organisation.s own servers;[\\s\\S]*?stay here\\.)"
+        },
+        {
+          "path": "core/flows/src/flows_defs/production.py",
+          "pattern": "(\"Vexa runs on this organisation.s own servers; the recording and transcript stay there\\.\")"
+        }
+      ],
+      "enforced": false,
+      "distinct": [
+        "Vexa runs on this organisation's own servers; the recording and transcript stay there.",
+        "Vexa runs on this organisation's own servers; what you and your colleagues keep in your workspaces is visible to the company's agents; recordings and transcripts stay here."
+      ]
+    },
+    {
+      "id": "machinery-note",
+      "fact": "the machinery note — the prose a composed opening carries so the agent knows nobody typed it",
+      "kind": "prose",
+      "decision": "WHICH INSTRUCTION THE AGENT ACTUALLY GETS. The Python copy carries a clause the TypeScript copy does not. The two are handed to the same model in different code paths, so the model is given different instructions depending on which side composed the opening. Unlike the mark it rides on, this is prose with meaning and the two bodies cannot be reconciled mechanically — someone has to say which instruction is right.",
+      "why": "The mark this note carries is now single-sourced (fact machinery-mark). The note is not, and it had already drifted: scaffolds.py continues past where actions.ts stops. Kept on the ledger rather than fixed, because choosing the surviving text is choosing what the agent is told.",
+      "sites": [
+        {
+          "path": "core/agent/control_plane/scaffolds.py",
+          "pattern": "MACHINERY_NOTE = \\(([\\s\\S]*?)\\)\\n"
+        },
+        {
+          "path": "clients/terminal/src/canvas/actions.ts",
+          "pattern": "export const MACHINERY_NOTE = ([^;]*);"
+        }
+      ],
+      "enforced": false,
+      "distinct": [
+        "+ MACHINERY_MARK + This opening was composed by the product from the link this person clicked",
+        "+ MACHINERY_MARK + This opening was composed by the product from the link this person clicked; they did not type it and they cannot see it. Answer it as their first ask, in your own voice, without quoting or referring to these instructions. # READ SILENTLY. This rides on EVERY composed opening, not just the setup preset, because the # failure is the shape of the model rather than of one prompt: the founder's first setup turn # opened with I'll start by reading…, let me look at what actually exists in the mounts, # I've got what I need to begin — three lines of narration before one word addressed to him. # Reading is how the job is done, not part of the job; announcing it teaches the reader only # that they are waiting. Read whatever you need silently: the FIRST sentence you emit is addressed to the person, and you never narrate your own tool use. # TEMPLATES ARE SHAPES. An agent read kg/templates/person.md as if it described somebody and # created a real entity from the example inside it; a person was then shown a template rendered # as their own document. Both are the same mistake — a shape treated as a fact — and it is worth # one sentence on every turn rather than a rule in one preset. Anything marked template: true, and anything under kg/templates/, is a SHAPE and never a fact: copy it to make a new record, never cite it, never name it to a person, and never treat the example inside it as somebody real. # (unset) IS A GAP. A group workspace created before the template-free seed still carries the # seed's placeholders in its README, and an agent reported the project's objective is still # (unset) as though that were something it had found out. It is the templates-are-SHAPES # mistake one step smaller — a blank read as a value — so it gets the sentence next to it. (unset) and any other angle-bracket or placeholder value is a GAP, never a fact: say the thing is not recorded yet and offer to fill it in, never report the placeholder as the answer. # Decision 24. A composed opening is the turn most likely to meet a name for the first time # — an attendee clicking a post-meeting link brings a whole room with them — and it is the # turn least likely to stop and write pages, because it is answering an ask. A name without a page gets one now: whatever this turn learns about a person, company, meeting, project or decision goes in through entity_upsert with its source. Facts carry a source; gaps go to kg/MISSING.md, never invented. # F70. The founder asked for a bot and was told I don't have a bot-dispatch tool in this # session. The tool was there: the CLI logged hasTools: true, the rig served 57 tools # including bot_send, and the model never attempted a call. Asked afterwards to list its # tools it listed them all, then said it had been guessing at my own capabilities instead of # checking them. A refusal is the one answer that must never be produced from memory. Your tools are exactly the ones in your tool list. Never say you lack a capability without checking the list; if a call fails, report its error verbatim. # F71. The founder was handed curl -X POST https://api.vexa.ai/bots -H X-API-Key: … — the # agent's workaround for a thing it believed it could not do, which it could. Two failures in # one line: it made him the runtime, and it put a key in a chat. Never hand the person an API call, a curl command, a key or a token. If you cannot do something, say that you cannot do it right now and why, in one sentence. # F73. After a successful send the agent offered a link into the product the person was # already looking at. The panel is moved by the harness, not by you — there is no tool here to # call for it, and a URL is the one thing that cannot help someone already inside the app. The person is INSIDE the app: never give them an app URL or a link into it, and never tell them to open one. Say what is on screen now. # F69. A bare meeting link is not a topic to discuss. It is the whole instruction, and the # turn that answers it with a question has spent the moment the person needed. A message that is only a meeting URL means: send the bot now. # F72. Correcting yourself and then asking whether to proceed spends a second turn on a # decision already made — and on a standing instruction it re-asks something already answered. After correcting yourself on something the person has already told you, DO the thing in that same turn. Never re-ask what they have already answered."
+      ]
+    },
+    {
+      "id": "internal-secret-class",
+      "fact": "how each service's config contract classes INTERNAL_API_SECRET, and therefore what it does when it is unset",
+      "kind": "literal",
+      "decision": "WHETHER ONE ENV VAR MAY HAVE THREE BOOT BEHAVIOURS. Four contracts declare it required-explicit (boot refuses); meeting-api declares it defaulted (boots, and silently stops attaching the internal header); runtime lists it surface_only (never read); the MCP service does not declare it at all, so gate:config-contract cannot see it there. Whether meeting-api's leniency is correct is a product decision about a security boundary — a service that quietly drops an auth header when a secret is missing is a different failure mode from one that refuses to start, and it is not for a gate to choose.",
+      "why": "F95 was one secret with three names. This is the same secret with three boot behaviours, and each contract argues its own case in its own description field where no reader compares them.",
+      "sites": [
+        {
+          "path": "core/gateway/services/gateway/src/gateway/config.v1.json",
+          "pattern": "\"key\": \"INTERNAL_API_SECRET\",\\s*\\n\\s*\"class\": \"([a-z-]+)\""
+        },
+        {
+          "path": "core/identity/services/admin-api/src/admin_api/config.v1.json",
+          "pattern": "\"key\": \"INTERNAL_API_SECRET\",\\s*\\n\\s*\"class\": \"([a-z-]+)\""
+        },
+        {
+          "path": "core/agent/control_plane/config.v1.json",
+          "pattern": "\"key\": \"INTERNAL_API_SECRET\",\\s*\\n\\s*\"class\": \"([a-z-]+)\""
+        },
+        {
+          "path": "core/flows/src/config.v1.json",
+          "pattern": "\"key\": \"INTERNAL_API_SECRET\",\\s*\\n\\s*\"class\": \"([a-z-]+)\""
+        },
+        {
+          "path": "core/meetings/services/meeting-api/src/meeting_api/config.v1.json",
+          "pattern": "\"key\": \"INTERNAL_API_SECRET\",\\s*\\n\\s*\"class\": \"([a-z-]+)\""
+        }
+      ],
+      "enforced": false,
+      "distinct": [
+        "defaulted",
+        "required-explicit"
+      ]
+    },
+    {
+      "id": "runtime-door-default",
+      "fact": "the runtime's own hostname, as the two domains that call it each write it down",
+      "kind": "literal",
+      "decision": "WHAT THE RUNTIME IS CALLED. meeting-api defaults RUNTIME_API_URL to http://runtime:8090; core/agent defaults VEXA_RUNTIME_API_URL to http://runtime-api:8090. Same port, DIFFERENT DNS NAME, for one service. Compose sets both keys explicitly, which is why nothing has broken — the disagreement bites only where the env is unset, which is every deployment that has not copied compose's exact block. One of the two names is wrong and a human has to say which.",
+      "why": "The sharpest of the door-default divergences, and the only one where the two values could not both work. Kept separate from the other doors because it is the one that is not merely untidy.",
+      "sites": [
+        {
+          "path": "core/meetings/services/meeting-api/src/meeting_api/config.v1.json",
+          "pattern": "\"key\": \"RUNTIME_API_URL\",[\\s\\S]{0,200}?\"default\": \"([^\"]+)\""
+        },
+        {
+          "path": "core/agent/shared/config.py",
+          "pattern": "runtime_api_url: str = \"([^\"]+)\""
+        },
+        {
+          "path": "core/agent/control_plane/config.v1.json",
+          "pattern": "\"key\": \"VEXA_RUNTIME_API_URL\",[\\s\\S]{0,200}?\"default\": \"([^\"]+)\""
+        }
+      ],
+      "enforced": false,
+      "distinct": [
+        "http://runtime-api:8090",
+        "http://runtime:8090"
+      ]
+    },
+    {
+      "id": "live-meeting-set",
+      "fact": "which meeting statuses mean the meeting is LIVE",
+      "kind": "set",
+      "enforced": false,
+      "decision": "WHAT COUNTS AS A LIVE MEETING, AND WHERE THAT IS DECIDED. Six answers across fourteen production sites. Three of them are load-bearing disagreements, not spellings: (1) the SQL index predicate that four model files share includes `scheduled` and omits `needs_help`, so the index the live queries were built for covers a different set of rows than the application calls live; (2) the rig calls a `joining` meeting not-live, so a meeting the terminal is showing as starting is invisible to the MCP; (3) `auto_join.py` carries the parent-side alias `needs_human_help` that nothing else does. Making them agree means deciding what live MEANS and then serving it from meeting-api as a phase field, which is a product decision about an API and a database index — not something a gate may pick.",
+      "why": "Fourteen production declarations of one concept, in five packages and two languages, plus a shell script. Nothing compares them and the survey found six distinct memberships. DELIBERATELY EXCLUDED as different questions, not copies of this one: `reconcile._PRE_ACTIVE_STATUSES` and `flows_steps/meeting.py`'s pre-active branch (before-active, not live), `reconcile._LIVENESS_GATED` (which rows the liveness sweep may touch), `collector/app._FSM_OWNED_STATUSES` (includes terminals) and `meeting.tsx` BADGE_STATUSES (rendering). Naming the exclusions here is the point: a manifest that quietly folded them in would be asserting a unification nobody decided.",
+      "sites": [
+        {
+          "path": "core/agent/control_plane/meeting_steering.py",
+          "pattern": "LIVE_STATUSES = \\{([^}]*)\\}"
+        },
+        {
+          "path": "core/agent/control_plane/schedule_digest.py",
+          "pattern": "_LIVE = \\{([^}]*)\\}"
+        },
+        {
+          "path": "core/agent/control_plane/scaffolds.py",
+          "pattern": "_LIVE_STATUSES = frozenset\\(\\{([^}]*)\\}"
+        },
+        {
+          "path": "clients/terminal/src/surfaces/meetingModel.ts",
+          "pattern": "LIVE_PHASE_STATUSES = new Set\\(\\[([^\\]]*)\\]"
+        },
+        {
+          "path": "clients/terminal/src/surfaces/liveMeetings.ts",
+          "pattern": "LIVE_STATUSES = new Set\\(\\[([^\\]]*)\\]"
+        },
+        {
+          "path": "core/meetings/services/meeting-api/src/meeting_api/collector/transcript_import.py",
+          "pattern": "IN_FLIGHT_STATUSES = frozenset\\(\\{([^}]*)\\}"
+        },
+        {
+          "path": "core/meetings/services/meeting-api/src/meeting_api/bot_spawn/auto_join.py",
+          "pattern": "LIVE_STATUSES = \\(([^)]*)\\)"
+        },
+        {
+          "path": "core/meetings/services/meeting-api/src/meeting_api/bot_spawn/service.py",
+          "pattern": "_ACTIVE_STATUSES = \\(([^)]*)\\)"
+        },
+        {
+          "path": "core/identity/services/admin-api/src/admin_api/schema/models.py",
+          "pattern": "text\\(\\s*\"\\(status IN \\(([^)]*)\\)",
+          "all": true,
+          "note": "the SQL index predicate, written twice in this file (two indexes) — both must be the same predicate"
+        },
+        {
+          "path": "core/meetings/services/meeting-api/src/meeting_api/sessions/models.py",
+          "pattern": "text\\(\\s*\"\\(status IN \\(([^)]*)\\)",
+          "all": true,
+          "note": "the mirror of the admin-api predicate; sessions/models.py states it must stay verbatim-equal to the query's ORDER BY or the planner will not substitute the index"
+        },
+        {
+          "path": "deploy/dogfood/rig/vexa_control_mcp.py",
+          "pattern": "\\.lower\\(\\) in \\(([^)]*)\\)"
+        },
+        {
+          "path": "deploy/dogfood/rehearse/doors.py",
+          "pattern": "LIVE_STATUSES = \\(([^)]*)\\)"
+        },
+        {
+          "path": "deploy/dogfood/bin/blank-instance.sh",
+          "pattern": "WHERE status IN \\(([^)]*)\\)"
+        }
+      ],
+      "distinct": [
+        "active · awaiting_admission · joining · needs_help · needs_human_help · requested · stopping",
+        "active · awaiting_admission · joining · needs_help · requested · stopping",
+        "active · awaiting_admission · joining · requested · scheduled · stopping",
+        "active · awaiting_admission · joining · requested · stopping",
+        "active · awaiting_admission · requested"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
**Delivers issue:** #1491

## Contribution rights
<!-- Select exactly ONE. This is a legal certification: an agent may explain the choices but
     must not select one for you. See CONTRIBUTOR_RIGHTS.md. -->

- [ ] **Independent:** I created this contribution, or otherwise have the right to submit it
  under Apache-2.0, and it is not owned or controlled by an employer, client, or other entity.
  <!-- rights:independent -->
- [ ] **Employer/client authorization required:** an employer, client, or other entity owns or
  may control this contribution. I am requesting Vexa's private corporate-authorization process.
  <!-- rights:corporate -->
- [ ] **Unsure:** I need a private rights review before merge.
  <!-- rights:uncertain -->

Every commit must also carry the contributor's own DCO `Signed-off-by` line. Selecting the
independent path means no individual CLA is required. Corporate and unsure paths do not stop
technical review, but they do block merge until resolved.

## THE RED LIST — seven decisions, both live answers each

This is the deliverable. `node scripts/check-parity.mjs --ledger` prints it in full; the decision text is in `scripts/parity.json`. **This PR does not settle any of them.**

| fact | sites | answers | the decision |
|---|---|---|---|
| **entity-slug** | 5 | 4 | Which slug the server writes and every client reproduces. `entities.py` NFKD-folds → `zoe-muller`; the other eight implementations → `zo-m-ller`. **The terminal's wikilink chip has never resolved a non-ASCII name.** Also open, separately: the cap is 80 / 60 / 40 / none, and empty input yields `""` / `shared` / `untitled` / `meeting` / `unknown`. |
| **live-meeting-set** | 13 | 5 | What counts as a live meeting. The SQL index predicate (4 model files) includes `scheduled`, omits `needs_help` — the index the live queries were built for covers different rows than the app calls live. The rig calls a `joining` meeting not-live. `auto_join.py` alone carries `needs_human_help`. |
| **visibility-sentence** | 4 | 2 | Whether the production data statement says what the others say. `flows_defs/production.py:864` ships *"…own servers; the recording and transcript stay there."* on a live outbound path, dropping the whole clause about a colleague's workspace being visible to the company's agents (founder decision 21). Not a wording variant. |
| **entity-kind-enum** | 2 | 2 | Whether `topic` and `task` are entity kinds. The terminal types every participant as `topic` and mints `kg/entities/topic/<slug>.md` — a path the server's writer refuses with `EntityRefused`. Reached on every live meeting via `useMeeting.ts`. |
| **internal-secret-class** | 5 | 2 | Whether one env var may have three boot behaviours. Four contracts `required-explicit`; meeting-api `defaulted` (boots and silently stops attaching the internal header); runtime `surface_only`; the MCP service does not declare it at all. A security boundary, not a style question. |
| **runtime-door-default** | 3 | 2 | What the runtime is called. `http://runtime:8090` vs `http://runtime-api:8090` — same port, different DNS name, one service. Compose sets both keys, so nothing has broken; it bites wherever the env is unset. One of the two is wrong. |
| **machinery-note** | 2 | 2 | Which instruction the agent actually gets. The Python copy carries a clause the TypeScript copy does not, and both are handed to the same model on different paths. |

**Deliberately excluded, and named so the exclusion is reviewable:** `reconcile._PRE_ACTIVE_STATUSES`, `_LIVENESS_GATED`, `collector._FSM_OWNED_STATUSES` and `meeting.tsx` `BADGE_STATUSES` share the live set's vocabulary and answer different questions. Folding them in would assert a unification nobody decided.

**The Python↔TypeScript seam, stated as one.** For the cross-language facts there is no shared module to import (ADR-0036 item 10). The manifest compares the regex/literal **source string**. Two engines can read one source differently, so this is the strongest check available without a mechanism that does not exist — and strictly stronger than the nothing there is today.

## Observation bundle (the record of your harnessed loop)

- **C1 — the checker.** Ran: a first manifest keyed on `os.getenv`-style single anchors. Saw: patterns that matched twice (five config contracts carry the placeholder list once per key) and patterns that matched nothing (a comment that had been reworded). Concluded: both must be **failures**, not tolerated — a manifest that has quietly stopped describing the tree reports green, which is worse than no manifest. Added `"all": true` for the legitimately-repeated case, which also catches a file whose own copies disagree.
- **C1 (2) — prose.** Ran: a byte comparison over the visibility sentence. Saw: five spellings where a reader sees one — a Python implicit-concat splits at whichever word hit the margin, markdown hard-wraps and prefixes `> `. Concluded: compare the sentence with the carrier stripped, but **never** normalise the apostrophe — U+2019 vs U+0027 is a real difference in text a stranger reads, and the rig's copy differs in exactly that way.
- **C2 — the marks.** Ran: `grep` for the two literals, then read the three Dockerfiles. Saw: every copy carried a comment saying the duplication was deliberate because the sides ship in different images — and `core/agent/shared` is COPY'd into agent-api, the worker **and** lite, with two of the three modules already importing from it at module scope. Concluded: the stated reason was true of the TypeScript copy and never of the Python ones. Single-sourced the Python side; the TS copy stays and is now gated instead of hoped about.
- **C2 (2) — the placeholder list, an assumption that did not survive.** Ran: a set comparison across all ten sites. Saw: they **agree** — value- and order-identical. Concluded: this is not a refactor candidate. There is nothing in `deploy/contracts/config.v1` to import from (the schema types `forbidden_values` as an unconstrained string array), so extracting a shared artefact is a contract change and a design choice. Enforced it instead, which is the moment it costs nothing and buys everything.
- **C3 — the ledger, and the red-first pass that caught a real hole.** Ran: the three negative controls. Saw: two went red; the third did not. Flipping `core/agent`'s runtime hostname from `runtime-api` to `runtime` left **both** values present, so the value-set baseline saw no change while a site had just switched camps. Concluded: a ledger entry that cannot say **who** gives **which** answer is not a baseline. Re-pinned on the mapping and added the test; the same control now reds and names the file that moved. That commit is separate and deliberate — the gate was wrong until it went red on the input it exists to catch.
- **C4 — the suite.** Ran: `time node scripts/gates.mjs fact-parity` → **0.11 s**. Concluded: it clears the pre-push wall-clock bar with room to spare.
- **Not ours, untouched.** The `vexa-compose-gate` compose project running on bbb belongs to `~/dev/wt-fc` (branch `flows-compose`). This work ran no Docker gate and started no container.

## Acceptance floor

| Row | Evidence |
|---|---|
| A1 | `node scripts/gates.mjs fact-parity` at head → `✓ 4 enforced fact(s) agree across 19 site(s) · 7 on the drift ledger`. **RED control:** one letter changed in the terminal's `MACHINERY_MARK` → exit 1, `machinery-mark … is written 2 times and they DISAGREE (2 answers): (1) [vexa-machinary] clients/terminal/src/canvas/actions.ts:96 (2) [vexa-machinery] core/agent/shared/marks.py:37`, plus the canonical file and how to agree. Restored. |
| A2 | **RED control:** `clients/terminal/src/_stray.ts` containing the mark → `machinery-mark: clients/terminal/src/_stray.ts:1 writes "[vexa-machinery]" and is not a declared site — read it from core/agent/shared/marks.py instead, or add the site … and say why a third writer is right.` Deleted. |
| A3 | **RED control:** `core/agent/shared/config.py` switched from `runtime-api` to `runtime` → red, printing recorded-vs-found **with the files under each answer**, so the moved site is visible. Both values still existed; the earlier value-set baseline was green on this exact input, which is why the mapping is pinned. Restored. |
| A4 | `node --test scripts/check-parity.test.mjs` → 15/15. "a pattern that matches NOTHING fails" and "a pattern that matches TWICE fails" are two of them; `"all": true` has its own pair, including a file whose own copies disagree. |
| A5 | Same run: prose passes a Python concat split, a markdown hard wrap and a blockquote of one sentence; the identical fixture with U+2019 is **red**. |
| A6 | `grep -rn '"\[vexa-machinery\]"\|"\[vexa-phase:writeback\]"' --include=*.py core/agent \| grep -v tests` → **no output**. `core/agent` pytest → **1588 passed**, including `test_chat_intents.py` and `test_user_text_field.py`, which pin those literals. |
| A7 | `time node scripts/gates.mjs fact-parity` → `real 0m0.113s`. |
| A- | No-regression at head: 19 static (non-Docker) gates green (`readme · docs-version · isolation · exports · graph · schema · contract-version · config-contract · db-schema · db-budget · dataflow · licenses · isolation-py · graph-py · test-isolation · execution-env · contract-conformance · domain-doors · fact-parity`); `node --test scripts/*.test.mjs release/*.test.mjs` → **170 pass / 0 fail**; `core/agent` pytest → **1588 passed**. Docker gates not run — they are CI's, and bbb is shared. |

## Docs diff (D6c)

- `docs/docs/governance/architecture.mdx` § 4 — the `gate:fact-parity` row (the table's own rule is that every gate in the `GATES` map appears there), plus a paragraph at concept altitude saying what it is for: **a duplicated fact needs a gate, not a comment** — four places in this tree assert their copies are "kept identical on purpose" and in each case the copies had already diverged.
- `docs/adr/0037-…` § Consequences — **the config-key rule recorded at the #1483 merge**, contract doctrine rather than a code change: `VEXA_FLOWS_DB_URL` is `required-explicit` because a service without its database is not a deployment; the mail keys stay a `capability` (`mailbox`) because a deployment may legitimately run without mail credentials — the dogfood stack's flows lanes run a mail double (SMTP to mailpit, no password by construction) and `required-explicit` would refuse their boot. Stated generally: **a key is `required-explicit` only if no valid deployment can lack it; anything a valid deployment may omit is a `capability` with a declared degrade.** The test is not "is this important" — the mail credential is important — it is "does a deployment that lacks this still make sense".
- No user-facing page changes: nothing a user of Vexa does changes. The reader here is a contributor.

## Security checks (required on the diff)

- **Dependency/licence:** no dependency added — the checker is `node:fs` / `node:path` / `node:url` only; the sole `package.json` change is one `scripts` entry. `pnpm gate:licenses` at head → 514 deps OSS-clean, unchanged.
- **Secrets:** the diff adds no value of any kind. `scripts/parity.json` holds repo paths, regexes, env-var and constant NAMES, and two published-placeholder lists that are already in five committed contracts — no credential. GitGuardian runs on the diff. Note the one security-adjacent **finding**, recorded on the ledger and not changed here: `INTERNAL_API_SECRET` has three boot behaviours across seven contracts, and `core/flows/src/flows_integrations/flows_api.py` still carries a four-value pre-F95 refusal list missing both `vexa-internal-secret` and `lite-internal-secret`.
- **SAST-shaped:** the new code executes nothing, spawns nothing and opens no socket — it reads files and compares strings. The one production change is two Python modules importing a constant instead of retyping it, covered by 1588 tests. `gate:config-contract`, `gate:db-schema` and `gate:execution-env` (P14 — secrets are references only) green at head.

## Validation request

Any competent non-author with a terminal. **The gate is the cheap part; the ledger is what needs you.**

1. `node scripts/gates.mjs fact-parity` at head → green.
2. `node scripts/check-parity.mjs --ledger` → read the seven. The question is not *are these real* — the file:line evidence settles that — but **is each `decision` field the right question, and is anything missing from a fact's site list?** A fact whose sites are incomplete under-reports its own drift, and that is the failure mode this gate cannot catch by itself.
3. Change one letter of `MACHINERY_MARK` in `clients/terminal/src/canvas/actions.ts`, run it again, watch it name both answers and both files. `git checkout` the file.
4. `time node scripts/gates.mjs fact-parity` → confirm it is under 2 s on your machine; it is in your pre-push path now.
5. Sanity-check the one production change: `core/agent/shared/marks.py` and its four importers, against `core/agent/services/agent-api/Dockerfile`, `core/agent/worker/Dockerfile` and `deploy/lite/Dockerfile.lite` — all three COPY `core/agent/shared`.

**Deployment validated (D12b): none, and deliberately.** A static CI gate that runs no service and starts no container behaves identically everywhere because it runs nowhere. Build provenance for every run above: branch `parity-gates` at head, based on `minutes-mcp-viewer` `69d5ba3a2`, fresh `git worktree` on the bbb host, `pnpm install --frozen-lockfile`, `uv run pytest` for `core/agent`, no env deltas from stock. Lite, compose, k8s and hosted are honestly unclaimed: nobody ran them, and this change cannot reach them.

## Authorship
Sole author: the human submitting this. No agent co-author trailers (D13).
Tooling disclosure (optional, welcome, never an attribution): drafted with Claude Code.

<!-- vexa-agent -->
