### PR TITLE
fix(whisper): send timestamp_granularities as an array so Groq accepts the request (#1349)

### DIFF
--- a/core/meetings/modules/whisper/package.json
+++ b/core/meetings/modules/whisper/package.json
@@ -11,7 +11,7 @@
   "files": ["dist"],
   "scripts": {
     "build": "tsc",
-    "test": "tsx src/confidence.test.ts && tsx src/errors.test.ts && tsx src/model.test.ts",
+    "test": "tsx src/confidence.test.ts && tsx src/errors.test.ts && tsx src/model.test.ts && tsx src/granularities.test.ts",
     "check:isolation": "node scripts/check-isolation.js"
   },
   "devDependencies": {

--- a/core/meetings/modules/whisper/src/granularities.test.ts
+++ b/core/meetings/modules/whisper/src/granularities.test.ts
@@ -1,0 +1,69 @@
+/**
+ * P5 gate (the #1349 fixture the STT seam lacked): the request the wire actually sees names the
+ * timestamp granularities the way the OpenAI audio API defines them — an ARRAY, so
+ * `timestamp_granularities[]`. Groq's /openai/v1/audio/transcriptions validates the schema and
+ * answers 400 `unknown param \`timestamp_granularities\`` to the unbracketed name, so every live
+ * segment of a Groq-pointed deployment fails until the adapter speaks the array spelling.
+ * `segment` is asserted alongside `word` because Groq answers `segments: null` when only `word` is
+ * asked for, and the client reads `data.segments` — a bracket-only fix trades a loud 400 for a
+ * silent loss of every per-segment timing and confidence. Stubs global fetch and inspects the
+ * multipart body ("validating backend" edge — D-A2).
+ * Run: npm test (chained)  or  npx tsx src/granularities.test.ts
+ */
+import { TranscriptionClient } from './index.js';
+
+let failed = 0;
+const check = (name: string, cond: boolean, detail = '') => {
+  console.log(`  ${cond ? '✅' : '❌'} ${name}${cond ? '' : '  — ' + detail}`);
+  if (!cond) failed++;
+};
+
+const realFetch = globalThis.fetch;
+/** Replace global fetch with a 200 stub that CAPTURES the multipart body. */
+function captureFetch(): () => string {
+  let body = '';
+  (globalThis as any).fetch = async (_url: unknown, init: { body: Buffer }) => {
+    body = Buffer.from(init.body).toString('latin1');
+    return new Response(JSON.stringify({ text: 'ok', language: 'en', duration: 0.1, segments: [] }), { status: 200 });
+  };
+  return () => body;
+}
+/** Every value sent under the given form-part name, in wire order. */
+function partValues(body: string, name: string): string[] {
+  const escaped = name.replace(/[[\]]/g, '\\$&');
+  return [...body.matchAll(new RegExp(`name="${escaped}"\\r\\n\\r\\n([^\\r]*)\\r\\n`, 'g'))].map((m) => m[1]);
+}
+
+async function run() {
+  const pcm = new Float32Array(1600).fill(0.05); // 0.1s of audio
+  const body = captureFetch();
+  const client = new TranscriptionClient({ serviceUrl: 'http://stt.test', model: 'whisper-large-v3-turbo' });
+  await client.transcribe(pcm, 'en');
+  const wire = body();
+
+  // The array spelling is what a schema-validating backend accepts.
+  check('granularities ride the bracketed array name',
+    partValues(wire, 'timestamp_granularities[]').length > 0,
+    'no timestamp_granularities[] part on the wire');
+
+  // The unbracketed name is what Groq 400s on — it must not be sent at all.
+  check('the unbracketed name is never sent',
+    partValues(wire, 'timestamp_granularities').length === 0,
+    `got ${JSON.stringify(partValues(wire, 'timestamp_granularities'))}`);
+
+  // `word` alone answers segments: null, and the client reads data.segments.
+  check('segment is requested alongside word',
+    JSON.stringify(partValues(wire, 'timestamp_granularities[]').slice().sort()) === JSON.stringify(['segment', 'word']),
+    `got ${JSON.stringify(partValues(wire, 'timestamp_granularities[]'))}`);
+
+  // response_format=verbose_json is the precondition for granularities at all (already sent).
+  check('verbose_json still accompanies the granularities',
+    partValues(wire, 'response_format')[0] === 'verbose_json',
+    `got ${JSON.stringify(partValues(wire, 'response_format'))}`);
+
+  globalThis.fetch = realFetch;
+  console.log(failed === 0 ? '\n✅ granularities: all checks passed' : `\n❌ granularities: ${failed} check(s) failed`);
+  process.exit(failed === 0 ? 0 : 1);
+}
+
+run();

--- a/core/meetings/modules/whisper/src/transcription-client.ts
+++ b/core/meetings/modules/whisper/src/transcription-client.ts
@@ -203,12 +203,17 @@ export class TranscriptionClient {
       ));
     }
 
-    // Request word-level timestamps
-    parts.push(Buffer.from(
-      `--${boundary}\r\n` +
-      `Content-Disposition: form-data; name="timestamp_granularities"\r\n\r\n` +
-      `word\r\n`
-    ));
+    // Request segment- AND word-level timestamps. The field is an ARRAY in the OpenAI audio API,
+    // so each granularity is its own `timestamp_granularities[]` part; backends that validate the
+    // schema (Groq) reject the bare `timestamp_granularities` name outright. `segment` is listed
+    // explicitly because asking for `word` alone answers with `segments: null`.
+    for (const granularity of ['segment', 'word']) {
+      parts.push(Buffer.from(
+        `--${boundary}\r\n` +
+        `Content-Disposition: form-data; name="timestamp_granularities[]"\r\n\r\n` +
+        `${granularity}\r\n`
+      ));
+    }
 
     // Max speech segment duration (controls how often Whisper splits segments)
     if (this.maxSpeechDurationSec !== undefined) {

--- a/docs/changelog.d/1349-groq-timestamp-granularities.md
+++ b/docs/changelog.d/1349-groq-timestamp-granularities.md
@@ -1,0 +1,9 @@
+- **Groq-backed transcription produces segments again: the STT client names the timestamp
+  granularities as an array (#1349).** The bot's whisper client sent the form part
+  `timestamp_granularities`; Groq's `/openai/v1/audio/transcriptions` validates the OpenAI audio
+  schema and answers `400 unknown param` to that name, so every live segment of a Groq-pointed
+  deployment failed and the meeting ended on its `stt_degraded` breaker. The client now sends
+  `timestamp_granularities[]` — and asks for `segment` as well as `word`, because a word-only
+  request answers `segments: null` and the client reads `data.segments`. Backends that ignore the
+  field (the bundled `deploy/transcription` unit) are unaffected. See
+  [Configuration](/configuration).


### PR DESCRIPTION
**Delivers issue:** #1349

## Contribution rights
<!-- Select exactly ONE. This is a legal certification: an agent may explain the choices but
     must not select one for you. See CONTRIBUTOR_RIGHTS.md. -->

- [x] **Independent:** I created this contribution, or otherwise have the right to submit it
  under Apache-2.0, and it is not owned or controlled by an employer, client, or other entity.
  <!-- rights:independent -->
- [ ] **Employer/client authorization required:** an employer, client, or other entity owns or
  may control this contribution. I am requesting Vexa's private corporate-authorization process.
  <!-- rights:corporate -->
- [ ] **Unsure:** I need a private rights review before merge.
  <!-- rights:uncertain -->

Every commit carries my own DCO `Signed-off-by`.

## Observation bundle (the record of your harnessed loop)

- **C1 — reproduce without a live meeting first.** ran: `curl` against the real Groq endpoint with
  the client's exact field name · saw: `-F timestamp_granularities=word` → `400 {"error":{"message":
  "unknown param \`timestamp_granularities\`"}}`; `-F 'timestamp_granularities[]=word'` → `200` ·
  concluded: the report is accurate and the defect is in the field NAME, reproducible off-meeting.

- **C2 — establish what the bracketed form actually returns.** ran: the same probe asking for
  `word` only, then for `segment`+`word` · saw: word-only answers `"segments": null` with a
  top-level `words` array; `segment`+`word` answers with BOTH populated · concluded: **the
  issue's proposed one-line fix is incomplete.** The client reads `data.segments`
  (`transcription-client.ts:270`), so bracketing alone yields `allSegments = []`, the text falls
  back to raw `data.text`, and every per-segment `start`/`end`/`avg_logprob`/`no_speech_prob` is
  lost — trading a loud 400 for a silent degradation. Groq's own docs corroborate: at word
  granularity the response "returns only word, start, and end timestamps". The fix must name
  `segment` explicitly.

- **C3 — the fix + the fixture the seam lacked.** ran: `npx tsx src/granularities.test.ts` at base
  and at head · saw: base RED (3 of 4 checks fail, `the unbracketed name is never sent — got
  ["word"]`), head GREEN (4/4) · concluded: red→green holds on the wire bytes, mirroring the #522
  `model.test.ts` fixture pattern for the same "validating backend" edge (D-A2).

- **C4 — live witness, my own run, before opening this.** ran: bot image built from this branch,
  full compose, real Google Meet, `TRANSCRIPTION_SERVICE_URL=https://api.groq.com/openai`,
  `TRANSCRIPTION_MODEL=whisper-large-v3-turbo`, **no proxy or shim anywhere in the path** · saw:
  `"unknown param"` count **0**, client faults **0**, 8 speaker-attributed segments streaming
  live · concluded: the value is real end-to-end, not just green on the wire assertion.

- **C5 — negative control on the other side of the boundary.** ran: the same unbracketed
  `timestamp_granularities=word` against a self-hosted `deploy/transcription` GPU unit
  (`large-v3-turbo`, `device: cuda`) · saw: **HTTP 200** · concluded: the bundled unit accepts the
  field either way, which is why this never surfaced in-house and why the fix is
  behaviour-neutral for it.

## Acceptance floor

#1349 is an incoming bug report rather than a prepared issue, so there is no numbered table; rows
below map to its claims.

| Row | Evidence |
|---|---|
| The 400 reproduces off-meeting | `-F timestamp_granularities=word` → `400 unknown param`; `-F 'timestamp_granularities[]=word'` → `200`. Base sha `3f5c3c03`. |
| Red→green on the wire | `granularities.test.ts`: base RED 3/4 fail (`got ["word"]`), head GREEN 4/4. Negative control is the base leg itself. |
| Live: a Groq deployment transcribes end-to-end | Full compose, Google Meet, patched bot image, direct to Groq: 0 × `unknown param`, 0 client faults, 8 segments. Contrast the report's 157 failures tripping `stt_degraded`. |
| No-regression for backends that ignore the field | Bundled GPU unit returns 200 for both spellings (C5); `response_format=verbose_json` unchanged; no config flag added. |
| Gates | `gate:node` — 18 package(s) build + test green. Pre-push static suite green (`readme dataflow isolation isolation-py exports graph graph-py schema contract-version config-contract licenses execution-env test-isolation contract-conformance`). |

**Exceeded the report with new witnessed value:** the `segments: null` finding (C2). Shipping the
issue's literal one-liner would have looked like a fix and silently removed all per-segment timing
and confidence.

## Docs diff (D6c)

`docs/changelog.d/1349-groq-timestamp-granularities.md` — one fragment, per
`docs/changelog.d/README.md`. Argued no-impact elsewhere: no env, API, or configuration surface
changes, so `configuration.mdx` / `deployment.mdx` need no edit — their existing Groq guidance
(`TRANSCRIPTION_MODEL=whisper-large-v3-turbo`) becomes true rather than changing.

## Security checks (required on the diff)

- **Dependencies:** none added or changed. `gate:licenses` green — 459 deps OSS-clean (Cat A; the
  2 pre-existing Cat-B exceptions unchanged).
- **Secrets:** diff scanned; no credentials, keys, or tokens introduced (0 hits).
- **Attack surface:** the change alters only outbound multipart field *names* on an existing
  request to an already-configured endpoint. No new network destination, no new input parsing, no
  auth path touched.
- **SAST:** not run locally beyond the repo's own gate suite; CI's is authoritative.

## Validation request

**Preferred signer:** the reporter of #1349 (their Lite + Groq rig is the natural A1 harness).

**What to watch:** on a Groq-pointed deployment, join one Meet call and confirm (a) no
`unknown param` in the bot's `[TranscriptionClient]` lines, (b) `GET /transcripts/...` non-empty,
and critically (c) **segments carry real `start`/`end` values** — that is the row that separates
this fix from the bracket-only version.

**Deployment I validated (D12b):** full Docker Compose, repo sha `3f5c3c03` + this branch, bot
image built from this checkout (`make -C deploy/compose bot`), published `:v012` images for all
other services, long-lived clone. Env deltas from stock: `TRANSCRIPTION_SERVICE_URL`,
`TRANSCRIPTION_SERVICE_TOKEN`, `TRANSCRIPTION_MODEL=whisper-large-v3-turbo`.
**Not validated by me:** Lite, k8s/helm, hosted — honestly unclaimed.

**Adjacent findings reported on the issue, deliberately NOT fixed here** (kept out to hold this PR
to one defect): `words` still arrive empty on Groq because it returns them top-level while the
client reads them nested per segment (`:276`); and `max_speech_duration_s` (`:217`) /
`min_silence_duration_ms` (`:226`) are not Groq parameters either — dormant unless configured, but
the same 400 class. Happy to file either separately.

## Authorship
Sole author: the human submitting this. No agent co-author trailers (D13).
Tooling disclosure (optional, welcome, never an attribution): drafted with Claude Code; every
command, probe, and live run above was executed and its raw output read before being claimed here.
