### PR TITLE
Support Brave Talk (iframe-embedded JaaS/8x8.vc Jitsi deployments)

### DIFF
--- a/core/meetings/modules/join/src/index.ts
+++ b/core/meetings/modules/join/src/index.ts
@@ -157,3 +157,4 @@ export {
 export type { TeamsJoinRedirectReason } from "./msteams/auth-redirect";
 export { joinZoomMeeting, buildZoomWebClientUrl, waitForZoomMeetingAdmission, checkForZoomAdmissionSilent, leaveZoomMeeting, dismissZoomPopups, startZoomRemovalMonitor };
 export { joinJitsiMeeting, buildJitsiMeetingUrl, waitForJitsiMeetingAdmission, checkForJitsiAdmissionSilent, leaveJitsiMeeting, startJitsiRemovalMonitor };
+export { resolveConferenceFrame } from "./jitsi/frame-utils";

--- a/core/meetings/modules/join/src/jitsi/admission.test.ts
+++ b/core/meetings/modules/join/src/jitsi/admission.test.ts
@@ -26,9 +26,14 @@ function check(name: string, ok: boolean, detail?: string) {
 }
 
 // evaluate runs the probe fn in-node; getLobbyState/getAppJoinedState read globalThis.APP.
+// frames()/mainFrame() make this a single-frame page for allJitsiFrames() — the frame-aware
+// scan (added for iframe-embedded deployments like Brave Talk/JaaS) degenerates to exactly the
+// old single-page behavior these tests were written against.
 const page: any = {
   async evaluate(fn: any, arg?: any) { return fn(arg); },
   async waitForTimeout(_ms: number) {},
+  frames() { return [page]; },
+  mainFrame() { return page; },
 };
 
 function setApp(opts: { joined?: boolean; membersOnly?: string | null; knocking?: boolean }) {

--- a/core/meetings/modules/join/src/jitsi/admission.ts
+++ b/core/meetings/modules/join/src/jitsi/admission.ts
@@ -13,18 +13,28 @@ import {
   jitsiRejectionTexts,
   jitsiRemovalTexts,
 } from "./selectors";
+import { allJitsiFrames, isVisibleInAnyFrame, scanFrames } from "./frame-utils";
 
 /** The app's own runtime verdict — the SAME probe join/admission/removal all trust.
  *  jitsi-meet exposes the APP global on every stock deployment; "no-api" = a custom
- *  build stripped it, so the caller falls back to DOM signals. */
+ *  build stripped it, so the caller falls back to DOM signals.
+ *
+ *  Scans every frame, not just the top one: JaaS/8x8.vc-backed deployments (Brave Talk and
+ *  other white-labeled embeds) mount the whole jitsi app — APP global included — inside a
+ *  cross-origin <iframe>, so the top-level document never has it. The first frame to return an
+ *  authoritative verdict (not "no-api") wins. */
 export async function getAppJoinedState(page: Page): Promise<"joined" | "not-joined" | "no-api"> {
-  return await page.evaluate(() => {
-    try {
-      const app = (globalThis as any).APP;
-      if (app?.conference?.isJoined) return app.conference.isJoined() === true ? "joined" : "not-joined";
-      return "no-api";
-    } catch { return "no-api"; }
-  }).catch(() => "no-api") as "joined" | "not-joined" | "no-api";
+  for (const target of allJitsiFrames(page)) {
+    const result = await (target as Page).evaluate(() => {
+      try {
+        const app = (globalThis as any).APP;
+        if (app?.conference?.isJoined) return app.conference.isJoined() === true ? "joined" : "not-joined";
+        return "no-api";
+      } catch { return "no-api"; }
+    }).catch(() => "no-api") as "joined" | "not-joined" | "no-api";
+    if (result !== "no-api") return result;
+  }
+  return "no-api";
 }
 
 /** A fresh meet.jit.si room is members-only until a moderator arrives: the conference join fails
@@ -53,24 +63,28 @@ function membersOnlyLatched(page: Page): boolean {
  *  deployments where the store IS populated). On stock meet.jit.si the members-only latch above
  *  is the primary signal; this returns "no-api" pre-admission when the store isn't wired. */
 export async function getLobbyState(page: Page): Promise<"lobby" | "not-lobby" | "no-api"> {
-  return await page.evaluate(() => {
-    try {
-      const app = (globalThis as any).APP;
-      const state = app?.store?.getState?.();
-      if (!state) return "no-api";
-      const conf = state["features/base/conference"];
-      if (conf && conf.membersOnly) return "lobby"; // members-only lobby room JID when locked out
-      const lobby = state["features/lobby"];
-      if (lobby && lobby.knocking) return "lobby"; // explicit Lobby feature: knocking to be let in
-      return "not-lobby";
-    } catch { return "no-api"; }
-  }).catch(() => "no-api") as "lobby" | "not-lobby" | "no-api";
+  for (const target of allJitsiFrames(page)) {
+    const result = await (target as Page).evaluate(() => {
+      try {
+        const app = (globalThis as any).APP;
+        const state = app?.store?.getState?.();
+        if (!state) return "no-api";
+        const conf = state["features/base/conference"];
+        if (conf && conf.membersOnly) return "lobby"; // members-only lobby room JID when locked out
+        const lobby = state["features/lobby"];
+        if (lobby && lobby.knocking) return "lobby"; // explicit Lobby feature: knocking to be let in
+        return "not-lobby";
+      } catch { return "no-api"; }
+    }).catch(() => "no-api") as "lobby" | "not-lobby" | "no-api";
+    if (result !== "no-api") return result;
+  }
+  return "no-api";
 }
 
 /** The hangup control is footer-only — never rendered on the prejoin or lobby screens. */
 export async function isHangupVisible(page: Page): Promise<boolean> {
   for (const sel of jitsiHangupButtonSelectors) {
-    if (await page.locator(sel).first().isVisible({ timeout: 300 }).catch(() => false)) return true;
+    if (await isVisibleInAnyFrame(page, sel)) return true;
   }
   return false;
 }
@@ -99,13 +113,17 @@ export async function isAdmitted(page: Page): Promise<boolean> {
     const inLobby = await isInLobby(page);
     if (inLobby) return false;
 
-    const prejoinPresent = await page.evaluate((sels: string[]) => {
-      return sels.some((s) => !!document.querySelector(s));
-    }, jitsiPrejoinScreenSelectors).catch(() => true);
+    const prejoinPresent = await scanFrames(
+      page,
+      (sels: string[]) => sels.some((s) => !!document.querySelector(s)),
+      jitsiPrejoinScreenSelectors,
+      (v) => v === false,
+      true, // conservative default: assume still-prejoin (not admitted) if every frame errors
+    );
     if (prejoinPresent) return false;
 
     for (const sel of jitsiConferenceIndicators) {
-      if (await page.locator(sel).first().isVisible({ timeout: 300 }).catch(() => false)) return true;
+      if (await isVisibleInAnyFrame(page, sel)) return true;
     }
     return false;
   } catch {
@@ -126,13 +144,18 @@ async function isInLobby(page: Page): Promise<boolean> {
 
     // DOM fallback: explicit lobby/knock screens + APP-stripped custom builds.
     for (const sel of jitsiLobbyIndicators) {
-      const visible = await page.locator(sel).first().isVisible({ timeout: 200 }).catch(() => false);
-      if (visible) return true;
+      if (await isVisibleInAnyFrame(page, sel)) return true;
     }
-    return await page.evaluate((texts: string[]) => {
-      const bodyText = document.body?.innerText || "";
-      return texts.some((t) => bodyText.toLowerCase().includes(t.toLowerCase()));
-    }, jitsiLobbyTexts).catch(() => false);
+    return await scanFrames(
+      page,
+      (texts: string[]) => {
+        const bodyText = document.body?.innerText || "";
+        return texts.some((t) => bodyText.toLowerCase().includes(t.toLowerCase()));
+      },
+      jitsiLobbyTexts,
+      (v) => v === false,
+      false,
+    );
   } catch {
     return false;
   }
@@ -141,11 +164,17 @@ async function isInLobby(page: Page): Promise<boolean> {
 /** Detect a lobby decline, a kick, or a terminated conference (terminal states). */
 async function isRejectedOrEnded(page: Page): Promise<string | null> {
   try {
-    return await page.evaluate((texts: string[]) => {
-      const bodyText = (document.body?.innerText || "").toLowerCase();
-      for (const t of texts) if (bodyText.includes(t.toLowerCase())) return t;
-      return null;
-    }, [...jitsiRejectionTexts, ...jitsiRemovalTexts]).catch(() => null);
+    return await scanFrames(
+      page,
+      (texts: string[]) => {
+        const bodyText = (document.body?.innerText || "").toLowerCase();
+        for (const t of texts) if (bodyText.includes(t.toLowerCase())) return t;
+        return null;
+      },
+      [...jitsiRejectionTexts, ...jitsiRemovalTexts],
+      (v) => v === null,
+      null,
+    );
   } catch {
     return null;
   }

--- a/core/meetings/modules/join/src/jitsi/frame-utils.ts
+++ b/core/meetings/modules/join/src/jitsi/frame-utils.ts
@@ -1,0 +1,89 @@
+import { Frame, Page } from "playwright";
+
+/**
+ * Some Jitsi deployments (JaaS / 8x8.vc — Brave Talk and other white-labeled embeds) render the
+ * ENTIRE app — prejoin, lobby, conference — inside a cross-origin <iframe>; the top-level page
+ * (e.g. talk.brave.com) has no jitsi DOM of its own. Stock meet.jit.si and most self-hosted
+ * deployments render at the top level instead. Every selector/API check in this module must
+ * therefore try the top frame first (the common case), then fall back to child frames, rather
+ * than assuming one or the other.
+ */
+export function allJitsiFrames(page: Page): (Page | Frame)[] {
+  return [page, ...page.frames().filter((f) => f !== page.mainFrame())];
+}
+
+/** True if `selector` is visible in the top frame or any child frame. */
+export async function isVisibleInAnyFrame(page: Page, selector: string): Promise<boolean> {
+  for (const target of allJitsiFrames(page)) {
+    const visible = await (target as Page).locator(selector).first()
+      .isVisible({ timeout: 200 }).catch(() => false);
+    if (visible) return true;
+  }
+  return false;
+}
+
+/** Poll the top frame and every child frame until `selector` is visible somewhere, or timeout.
+ *  Returns the frame it was found in (so the caller can scope subsequent interactions to it) or
+ *  null. Used to locate the prejoin name input / join button wherever the app actually mounted. */
+export async function findFrameWithVisibleSelector(
+  page: Page,
+  selector: string,
+  timeoutMs: number,
+): Promise<Page | Frame | null> {
+  const deadline = Date.now() + timeoutMs;
+  do {
+    for (const target of allJitsiFrames(page)) {
+      const visible = await (target as Page).locator(selector).first()
+        .isVisible({ timeout: 200 }).catch(() => false);
+      if (visible) return target;
+    }
+    await page.waitForTimeout(300);
+  } while (Date.now() < deadline);
+  return null;
+}
+
+/**
+ * Post-admission: resolve which frame actually hosts the conference DOM (media elements, hangup
+ * button, etc.) — the top frame for stock/self-hosted deployments, or the embedding <iframe> for
+ * JaaS/8x8.vc-backed deployments (Brave Talk and other white-labeled embeds). Capture/recording
+ * setup (finding <audio>/<video> elements to tap) must target this frame, not assume the top one.
+ * Falls back to `page` when nothing matches, preserving prior behavior for the un-iframed case.
+ */
+export async function resolveConferenceFrame(page: Page): Promise<Page | Frame> {
+  for (const target of allJitsiFrames(page)) {
+    const hasMedia = await (target as Page).evaluate(
+      () => document.querySelectorAll('audio, video').length > 0,
+    ).catch(() => false);
+    if (hasMedia) return target;
+  }
+  return page;
+}
+
+/** Run a page.evaluate-style body scan (innerText / querySelector checks) across every frame,
+ *  returning the first non-empty result per `isEmpty`. `def` is the fallback when no frame
+ *  produces a non-empty result (including every frame erroring — detached/cross-origin edge
+ *  cases) — callers pick a conservative default per call site.
+ *
+ *  `arg` is passed through to Playwright's evaluate(fn, arg) as data — `fn` runs inside the
+ *  page/frame's own JS context and can only see what's serialized in through `arg`, never
+ *  outer Node-side closures (selectors, text lists, etc. must travel this way). */
+export async function scanFrames<T, Arg>(
+  page: Page,
+  fn: (arg: Arg) => T,
+  arg: Arg,
+  isEmpty: (v: T) => boolean,
+  def: T,
+): Promise<T> {
+  for (const target of allJitsiFrames(page)) {
+    try {
+      // Playwright's evaluate<Arg, R> overloads can't verify a generic Arg against its internal
+      // Unboxed<Arg> mapped type — the `any` cast is compile-time only; `fn`/`arg` still flow
+      // through unchanged at runtime.
+      const result: T = await (target as Page).evaluate(fn as any, arg);
+      if (!isEmpty(result)) return result;
+    } catch {
+      // cross-origin navigation mid-check / detached frame — try the next one
+    }
+  }
+  return def;
+}

--- a/core/meetings/modules/join/src/jitsi/join.ts
+++ b/core/meetings/modules/join/src/jitsi/join.ts
@@ -8,6 +8,7 @@ import {
   jitsiJoinButtonSelector,
   jitsiGuestEntryTexts,
 } from "./selectors";
+import { findFrameWithVisibleSelector } from "./frame-utils";
 
 // NOTE vs the other platforms: Jitsi Meet is SELF-HOSTABLE — meet.jit.si is just
 // the canonical public deployment. The join layer therefore never rewrites the
@@ -161,14 +162,13 @@ export async function joinJitsiMeeting(
   // option) — clear it before waiting on any jitsi UI.
   await enterAsGuestIfGated(page);
 
-  // waitFor (NOT isVisible — which returns the instantaneous state and ignores its
-  // timeout): the prejoin screen mounts a beat after navigation / the auth landing.
-  const nameField = page.locator(jitsiNameInputSelector).first();
-  const havePrejoin = await nameField
-    .waitFor({ state: "visible", timeout: 15000 })
-    .then(() => true)
-    .catch(() => false);
-  if (havePrejoin) {
+  // Poll the top frame AND every child frame: JaaS/8x8.vc-backed deployments (Brave Talk and
+  // other white-labeled embeds) render the whole prejoin/conference app inside a cross-origin
+  // <iframe> — the top-level document has no jitsi DOM at all. Stock meet.jit.si and most
+  // self-hosted deployments render at the top level, so that path still resolves immediately.
+  const jitsiFrame = await findFrameWithVisibleSelector(page, jitsiNameInputSelector, 15000);
+  if (jitsiFrame) {
+    const nameField = jitsiFrame.locator(jitsiNameInputSelector).first();
     // Fill the display name with REAL keyboard events — jitsi's prejoin is a React
     // form; typing (not a synthetic value-set) reliably enables the join button.
     const current = await nameField.inputValue().catch(() => "");
@@ -179,16 +179,16 @@ export async function joinJitsiMeeting(
     }
     log(`[Jitsi] Name entered: "${botName}"`);
 
-    // Click "Join meeting" DOM-direct first (immune to overlay hit-test stalls),
-    // with a Playwright click as the fallback.
-    const clicked = await page.evaluate((sel: string) => {
+    // Click "Join meeting" DOM-direct first (immune to overlay hit-test stalls), scoped to the
+    // SAME frame the name field was found in — with a Playwright click as the fallback.
+    const clicked = await (jitsiFrame as any).evaluate((sel: string) => {
       const btn = document.querySelector(sel) as HTMLElement | null;
       if (!btn) return false;
       btn.click();
       return true;
     }, jitsiJoinButtonSelector.split(",")[0].trim()).catch(() => false);
     if (!clicked) {
-      const joinBtn = page.locator(jitsiJoinButtonSelector).first();
+      const joinBtn = jitsiFrame.locator(jitsiJoinButtonSelector).first();
       await joinBtn.waitFor({ state: "visible", timeout: 10000 });
       await joinBtn.click({ timeout: 10000 });
     }

--- a/core/meetings/services/bot/src/capture-bridge.ts
+++ b/core/meetings/services/bot/src/capture-bridge.ts
@@ -35,7 +35,7 @@ import {
   type Page,
   type BrowserContext,
 } from '@vexa/remote-browser';
-import { getJoinBrowserArgs } from '@vexa/join';
+import { getJoinBrowserArgs, resolveConferenceFrame } from '@vexa/join';
 import type { RecordingMasterFormat } from '@vexa/recording';
 import { isMixedLanePlatform, type Invocation } from './config.js';
 import type { BotPipeline } from './pipeline.js';
@@ -699,6 +699,13 @@ export async function startCaptureBridge(
   const jitsi = inv.platform === 'jitsi';
   const lane: 'gmeet' | 'mixed' = mixed ? 'mixed' : 'gmeet';
 
+  // JaaS/8x8.vc-backed Jitsi deployments (Brave Talk and other white-labeled embeds) render the
+  // whole conference — media elements included — inside a cross-origin <iframe>; page.evaluate()
+  // only ever reaches the top frame, so capture setup/control must target the resolved frame
+  // instead. Every other platform (and stock/self-hosted Jitsi, which renders at the top level)
+  // keeps targeting `page` exactly as before — resolveConferenceFrame only runs for jitsi.
+  const captureTarget: any = jitsi ? await resolveConferenceFrame(page) : page;
+
   // ── O-TEL-1 raw-signal tap (a DUAL-sink) ──────────────────────────────────────────────────
   // When a TelemetrySink is wired, tee each raw frame to it BEFORE the pipeline consumes it, so a
   // live bug's exact signal is stored as captured-signal.v1 and replays offline (O-TEL-2). The tap
@@ -788,7 +795,7 @@ export async function startCaptureBridge(
   // ── Start the page-side capture (VexaBrowserUtils preferred; production inline fallback). ──
   // The body of this callback runs IN THE BROWSER (Playwright serializes it); DOM globals are
   // reached via globalThis (this file type-checks against the Node lib — no DOM types here).
-  await page.evaluate(async ({ isMixed, isJitsi, isTeams, isZoom, botName, mainAudioGraceMs, mainAudioSilenceMs, mainAudioEnergyRms }) => {
+  await captureTarget.evaluate(async ({ isMixed, isJitsi, isTeams, isZoom, botName, mainAudioGraceMs, mainAudioSilenceMs, mainAudioEnergyRms }: any) => {
     const w = (globalThis as any) as Record<string, any>;
     if (isMixed) {
       // Zoom/Teams: installRemoteAudioHook (installed pre-nav) mirrors each remote WebRTC audio
@@ -1116,7 +1123,7 @@ export async function startCaptureBridge(
       mainAudioGraceMs: Number(process.env.VEXA_TEAMS_MAIN_AUDIO_GRACE_MS || 15000),
       // How long a PICKED mix may stay wholly silent before the lane abandons it for every track.
       mainAudioSilenceMs: Number(process.env.VEXA_TEAMS_MAIN_AUDIO_SILENCE_MS || 20000),
-      mainAudioEnergyRms: Number(process.env.VEXA_TEAMS_MAIN_AUDIO_ENERGY_RMS || 0.006) }).catch((e) => {
+      mainAudioEnergyRms: Number(process.env.VEXA_TEAMS_MAIN_AUDIO_ENERGY_RMS || 0.006) }).catch((e: any) => {
     console.error(`[bot] capture bridge: page-side start failed: ${String(e)}`); // L4: surfaces only on the VM
   });
 
@@ -1132,7 +1139,7 @@ export async function startCaptureBridge(
   return async () => {
     if (countersTimer) clearInterval(countersTimer);
     activity?.unavailable();
-    await page.evaluate(() => {
+    await captureTarget.evaluate(() => {
       const w = (globalThis as any) as Record<string, any>;
       try { w.__vexaGmeetCapture?.stop?.(); } catch { /* best-effort */ }
       try { if (w.__vexaTeamsHealthTimer) { (globalThis as any).clearInterval(w.__vexaTeamsHealthTimer); w.__vexaTeamsHealthTimer = null; } } catch { /* */ }
@@ -1192,6 +1199,10 @@ export async function restartMixedCapture(page: Page): Promise<boolean> {
  */
 export async function startRecording(page: Page, inv: Invocation, recording: BotRecordingSink): Promise<() => Promise<void>> {
   const key = `${inv.platform}/${inv.nativeMeetingId ?? inv.connectionId ?? 'session'}`;
+  // See startCaptureBridge: JaaS/8x8.vc-backed Jitsi (Brave Talk etc.) renders the participant
+  // <audio>/<video> elements inside a cross-origin <iframe> — the recording tap must scan that
+  // frame, not the top page. Every other platform keeps targeting `page` exactly as before.
+  const captureTarget: any = inv.platform === 'jitsi' ? await resolveConferenceFrame(page) : page;
   // Recording part interval (ms): the MediaRecorder timeslice = the durable-upload granularity.
   // Env-overridable (VEXA_RECORDING_TIMESLICE_MS) so a live multi-part run can shrink it to land
   // ≥2 parts in a short meeting (#509 A5); default 15000 (production parity). Each timeslice is a
@@ -1210,7 +1221,7 @@ export async function startRecording(page: Page, inv: Invocation, recording: Bot
   }).catch((e: Error) => { if (!String(e.message).includes('already registered')) throw e; });
 
   // Page-side: start the generic recording tap (finds + combines the page audio elements).
-  await page.evaluate(async (timesliceMs) => {
+  await captureTarget.evaluate(async (timesliceMs: number) => {
     const w = (globalThis as any) as Record<string, any>;
     if (w.VexaBrowserUtils?.createRecordingTap && !w.__vexaRecordingTap) {
       w.__vexaRecordingTap = w.VexaBrowserUtils.createRecordingTap({
@@ -1222,11 +1233,11 @@ export async function startRecording(page: Page, inv: Invocation, recording: Bot
       });
       await w.__vexaRecordingTap.start();
     }
-  }, timesliceMs).catch((e) => { console.error(`[bot] recording bridge: page-side start failed: ${String(e)}`); });
+  }, timesliceMs).catch((e: any) => { console.error(`[bot] recording bridge: page-side start failed: ${String(e)}`); });
 
   // Stop fn: stop the recorder so it flushes the final (isFinal) chunk → master assembly.
   return async () => {
-    await page.evaluate(async () => {
+    await captureTarget.evaluate(async () => {
       const w = (globalThis as any) as Record<string, any>;
       try { await w.__vexaRecordingTap?.stop?.(); } catch { /* best-effort */ }
     }).catch(() => { /* page already gone */ });
@@ -1263,8 +1274,11 @@ export function createSpeakController(page: Page, inv: Invocation): SpeakControl
   // unmutes before speech + auto-mutes after — index.ts:1039–1059). The PulseAudio source
   // (tts_sink → virtual_mic) is the actual audio path and is provided by the VM image.
   const setMic = async (on: boolean): Promise<void> => {
+    // JaaS/8x8.vc-backed Jitsi (Brave Talk etc.): the mic button lives in the embedding <iframe>,
+    // not the top page — resolve it fresh each call (cheap; the toggle isn't in a hot loop).
+    const target: any = platform === 'jitsi' ? await resolveConferenceFrame(page) : page;
     // Runs IN THE BROWSER; reach the DOM via globalThis (no DOM types in this Node-typed file).
-    await page.evaluate(({ on, platform }) => {
+    await target.evaluate(({ on, platform }: any) => {
       const doc = (globalThis as any).document;
       const click = (sel: string) => doc?.querySelector(sel)?.click();
       if (platform === 'teams') click('#microphone-button');

--- a/docs/changelog.d/1513-jitsi-iframe-frame-awareness.md
+++ b/docs/changelog.d/1513-jitsi-iframe-frame-awareness.md
@@ -1,0 +1,8 @@
+- **Jitsi bots join and transcribe JaaS/8x8.vc-backed embeds, including Brave Talk (#1513).**
+  Deployments that render the whole conference — prejoin, lobby, media elements — inside a
+  cross-origin `<iframe>` (rather than at the page's top level, as stock `meet.jit.si` and most
+  self-hosted deployments do) previously left the bot stuck on the prejoin screen forever, or
+  joined silently with zero transcript. Join, admission, and capture/recording now scan child
+  frames alongside the top one. Send `platform` and `meeting_url` explicitly for these embeds —
+  bare-URL auto-detection doesn't yet recognize non-8x8.vc hosts like `talk.brave.com`
+  ([#1512](https://github.com/Vexa-ai/vexa/issues/1512)). See [Send a bot](/how-to/send-a-bot).

--- a/docs/docs/how-to/send-a-bot.mdx
+++ b/docs/docs/how-to/send-a-bot.mdx
@@ -103,6 +103,21 @@ The only thing that changes between platforms is the `platform` value.
       -H "X-API-Key: $API_KEY" -H "Content-Type: application/json" \
       -d '{"platform":"jitsi","native_meeting_id":"MyRoom","meeting_url":"https://meet.jit.si/MyRoom","bot_name":"Vexa"}'
     ```
+
+    **JaaS/8x8.vc-backed embeds** (e.g. [Brave Talk](https://talk.brave.com)) are also covered:
+    these deployments render the whole conference — prejoin, lobby, media elements — inside a
+    cross-origin `<iframe>` rather than at the page's top level, and the join/admission/capture
+    code checks both. `native_meeting_id` is the room segment from the embed's own URL:
+
+    ```bash
+    curl -X POST "$API_BASE/bots" \
+      -H "X-API-Key: $API_KEY" -H "Content-Type: application/json" \
+      -d '{"platform":"jitsi","native_meeting_id":"MyRoom","meeting_url":"https://talk.brave.com/MyRoom","bot_name":"Vexa"}'
+    ```
+
+    Pasting a bare Brave Talk link with no `platform` will **not** auto-detect as Jitsi yet — its
+    host isn't in the recognized list ([#1512](https://github.com/Vexa-ai/vexa/issues/1512)/follow-up).
+    Send `platform` and `meeting_url` explicitly, as above, until that lands.
   </Tab>
 </Tabs>
 


### PR DESCRIPTION
## Summary

Adds Brave Talk support (and any other JaaS/8x8.vc-backed white-labeled Jitsi embed) by making
the Jitsi join, admission, and capture/recording code frame-aware.

Closes #1512.

## Context

JaaS/8x8.vc-backed deployments — Brave Talk (`talk.brave.com`) among them — render the entire
conference app (prejoin, lobby, conference, media elements) inside a cross-origin `<iframe>`. The
top-level page has no jitsi DOM of its own. Stock `meet.jit.si` and most self-hosted deployments
render at the top level instead, and are unaffected either way.

Every DOM/API check in `join.ts`, `admission.ts`, and `capture-bridge.ts` used
`page.evaluate()` / `page.locator()`, which only reach the top frame — so on Brave Talk the bot:

1. Never found the prejoin name field or Join button (logged a false
   `"No prejoin name field detected"` and looped on `"waiting for admission"` forever, having
   never actually entered the room).
2. Once join itself was patched, `isAdmitted()`/`getAppJoinedState()` still couldn't see
   `window.APP` or the hangup button (both live in the iframe), so admission looked "unknown."
3. Once admission was patched too, `startCaptureBridge`/`startRecording` still targeted the top
   frame, so `record-chunker` found zero `<audio>`/`<video>` elements and produced no transcript
   despite the bot visibly sitting in the call.

## Fix

- **New**: `core/meetings/modules/join/src/jitsi/frame-utils.ts` — a shared frame-scanning
  utility (`allJitsiFrames`, `findFrameWithVisibleSelector`, `isVisibleInAnyFrame`, `scanFrames`,
  `resolveConferenceFrame`). Every helper tries the top frame first — byte-identical behavior for
  the un-iframed case — then falls back to scanning child frames. Exported from `@vexa/join`'s
  public index for reuse by the bot service.
- **`jitsi/join.ts`**: the prejoin name-field / Join-button lookup now uses
  `findFrameWithVisibleSelector` and scopes the fill + click to whichever frame it actually found
  the field in.
- **`jitsi/admission.ts`**: `getAppJoinedState`, `getLobbyState`, `isHangupVisible`, the prejoin/
  conference/lobby DOM checks, and the rejection/removal text scan all now scan every frame
  instead of just the top one.
- **`capture-bridge.ts`**: `startCaptureBridge`, `startRecording`, and the speak path's mic
  toggle resolve the actual conference frame (`resolveConferenceFrame` — the frame that has
  `<audio>`/`<video>` elements) and target it for setup, teardown, and control, **only when
  `platform === 'jitsi'`** — every other platform (and stock/self-hosted Jitsi) is untouched.

`page.exposeFunction()` and `context.addInitScript()` already install into every frame by
Playwright's own design (confirmed in this file's existing comments), so the PCM audio bridge and
`window.VexaBrowserUtils` needed no changes — only the *invocation* side needed frame-targeting.

## Docs

- `docs/docs/how-to/send-a-bot.mdx` — Jitsi tab now shows a Brave Talk example and notes that
  bare-URL auto-detection doesn't yet cover non-8x8.vc hosts (tracked as a follow-up in #1512).
- `docs/changelog.d/1513-jitsi-iframe-frame-awareness.md` — per-PR changelog fragment (docs-current
  / ADR-0032).

## Test case

Live end-to-end verification against a real Brave Talk room (`talk.brave.com`), self-hosted
compose stack, `make bot` build of this branch:

1. **Before fix**: bot navigates to the room, logs `"No prejoin name field detected — proceeding
   to admission checks"`, loops `"Still waiting for admission"` until the escalation VNC debug
   view confirms the browser is still sitting on the pre-join screen with the name field visibly
   pre-filled (`"PT's notetaker"`) — the bot just never saw it.
2. **After join+admission fix**: bot logs `"Name entered"` → `"Join clicked"` →
   `"Bot immediately admitted (no lobby)"`. Confirmed via the meeting API (`status: "active"`).
3. **After capture fix**: page console logs `"[record-chunker] 1 media elements (strict)"` →
   `"connected element 1/1"` → `"combined 1 streams"` → `"MediaRecorder started"`. Polling
   `GET /transcripts/jitsi/{room}` returns real transcribed segments matching what was spoken
   into the call, e.g.:
   ```json
   { "text": "Hello, this meeting will have a discussion about the chop head...",
     "language": "en", "completed": true }
   ```
4. Regression check: existing unit tests (`admission.test.ts`, `join.test.ts`) pass unchanged —
   the test `page` stub was extended with `frames()`/`mainFrame()` returning itself, so
   `allJitsiFrames()` degenerates to exactly the prior single-frame behavior for these tests.
   `npx tsx src/jitsi/admission.test.ts` → 6/6 pass; `npx tsx src/jitsi/join.test.ts` → 11/11
   pass.
5. Full `make bot` image build (TypeScript compile across the whole `@vexa/bot` build scope)
   succeeds clean.

**Deployment validated:** self-hosted Compose (`make all` + `make bot`), macOS host via OrbStack,
fresh clone of `main` at `6d6d38a2`, self-hosted CPU transcription unit (`small` → `medium`
model). Not yet validated on Lite or k8s/Helm.

## Known follow-up (not in scope here)

- `password.ts`'s room-password dialog handling is still top-frame-only — an iframe-embedded,
  password-protected Jitsi room would need the same treatment. Not hit by Brave Talk (no password
  prompt in this flow).
- Bare-`meeting_url` platform auto-detection (`resolvePlatform`) doesn't recognize
  `talk.brave.com` or other non-`8x8.vc` JaaS custom domains — `platform` must be sent explicitly
  for now (documented above).
