### PR TITLE
agent-api: validate the workspace repository host and pin git transports

### DIFF
--- a/core/agent/control_plane/api.py
+++ b/core/agent/control_plane/api.py
@@ -59,6 +59,7 @@ from control_plane.workspace_attach import (
     swap_workspace,
     workspace_dir_for,
 )
+from control_plane.repo_ref import RepoRefError, assert_fetchable
 from control_plane.workspace_publish import PublishError, RepoExistsError, publish_workspace, published_remote_url
 from control_plane.workspace_git_sync import RemoteSyncError, pull_origin, push_origin, remote_status
 from control_plane.workspace_purpose import read_purpose, write_purpose
@@ -1569,6 +1570,12 @@ def create_app(
         Mounting is by-folder (``<root>/<subject>`` is what the next dispatch mounts), so the swapped
         tree takes effect on the subject's next turn — no dispatch change needed."""
         subject = subject_of(request)
+        # The repository is a caller-supplied instruction to THIS SERVER to go and fetch something, so
+        # the transport and the host are settled before anything reaches git (see control_plane/repo_ref).
+        try:
+            assert_fetchable(body.repo)
+        except RepoRefError as exc:
+            raise HTTPException(status_code=400, detail=str(exc))
         _tok = (body.token or "").strip() or git_creds.read_github_token(wsr.root, subject)
         try:
             result = swap_workspace(wsr.root, subject, body.repo, body.ref or "main",
@@ -1622,6 +1629,10 @@ def create_app(
         """ADD a workspace to the active set WITHOUT parking the others (the additive counterpart of swap).
         Clones/restores the target if needed. Idempotent — an already-active workspace is a no-op."""
         subject = subject_of(request)
+        try:
+            assert_fetchable(body.repo)     # same gate as swap — see control_plane/repo_ref
+        except RepoRefError as exc:
+            raise HTTPException(status_code=400, detail=str(exc))
         _tok = (body.token or "").strip() or git_creds.read_github_token(wsr.root, subject)
         try:
             result = activate_workspace(wsr.root, subject, body.repo, body.ref or "main",

--- a/core/agent/control_plane/config.v1.json
+++ b/core/agent/control_plane/config.v1.json
@@ -333,6 +333,13 @@
       "targets": []
     },
     {
+      "key": "VEXA_ALLOW_LOCAL_REPO_ROOT",
+      "class": "defaulted",
+      "default": "(unset)",
+      "description": "os.pathsep-separated list of directories a caller-supplied workspace repository may live under as a scheme-less local path (POST /api/workspace/swap|activate). Unset — the default and every hosted deployment — refuses local paths outright; a self-hosted deployment that legitimately clones from a disk mirror names its roots here. Values are resolved and proven contained before any filesystem access (control_plane/repo_ref.py)",
+      "targets": []
+    },
+    {
       "key": "TRANSCRIPTION_SERVICE_URL",
       "class": "defaulted",
       "default": "(unset)",

--- a/core/agent/control_plane/repo_ref.py
+++ b/core/agent/control_plane/repo_ref.py
@@ -177,16 +177,37 @@ def allowed_local_roots() -> list[Path]:
     return roots
 
 
-def _assert_allowed_local(value: str) -> None:
+def contained_local_path(value: str) -> Path:
+    """The RESOLVED path a scheme-less repository reference names, proven to sit under a configured
+    root — or ``RepoRefError``. The caller-supplied string never leaves this function.
+
+    Containment is asserted TWICE, and the order is the point:
+
+    * **lexically first**, on ``os.path.normpath(os.path.abspath(value))``. That collapses ``..``
+      without touching the filesystem, so a value that escapes a root is refused *before* it is used
+      in any path expression at all;
+    * **then again on the symlink-resolved path**, because a symlink planted inside a root points
+      wherever it likes and the lexical pass cannot see through it.
+
+    Only the resolved path is returned, so no caller can reach past the check by re-using the raw
+    string."""
     roots = allowed_local_roots()
     if not roots:
         raise RepoRefError(LOCAL_SENTENCE, kind="local")
+
+    prefixes = [os.path.normpath(os.path.abspath(str(r))) for r in roots]
+    candidate = os.path.normpath(os.path.abspath(value.strip()))
+    if not any(candidate == p or candidate.startswith(p + os.sep) for p in prefixes):
+        raise RepoRefError(LOCAL_SENTENCE, kind="local")
+
     try:
-        p = Path(value).resolve()
+        resolved = Path(candidate).resolve(strict=False)
+        real_roots = [Path(p).resolve(strict=False) for p in prefixes]
     except OSError:
         raise RepoRefError(LOCAL_SENTENCE, kind="local") from None
-    if not any(p == r or r in p.parents for r in roots):
+    if not any(resolved == r or resolved.is_relative_to(r) for r in real_roots):
         raise RepoRefError(LOCAL_SENTENCE, kind="local")
+    return resolved
 
 
 def assert_allowed_scheme(raw: Optional[str]) -> None:
@@ -208,7 +229,7 @@ def assert_allowed_scheme(raw: Optional[str]) -> None:
         return
     if _SCP.match(v):
         return
-    _assert_allowed_local(v)
+    contained_local_path(v)                 # refuses unless it resolves inside a configured root
 
 
 def assert_fetchable(raw: Optional[str]) -> None:

--- a/core/agent/control_plane/repo_ref.py
+++ b/core/agent/control_plane/repo_ref.py
@@ -190,25 +190,27 @@ def contained_local_path(value: str) -> Path:
       wherever it likes and the lexical pass cannot see through it.
 
     Only the resolved path is returned, so no caller can reach past the check by re-using the raw
-    string. The guard is written as a plain ``if`` that DOMINATES the filesystem call rather than an
-    ``any(...)`` over a generator: the containment is the same either way, but only this shape says
-    so in the control flow, where a reader — or a static analyser — can see it."""
+    string.
+
+    Both guards are a LONE ``startswith`` that dominates every use of the value they guard. The
+    obvious ``candidate == root or candidate.startswith(root + os.sep)`` says the same thing to a
+    reader and something weaker to a checker — a true disjunction proves neither half — so the
+    trailing separator carries the "or the root itself" case instead, and the containment is one
+    condition."""
     roots = allowed_local_roots()
     if not roots:
         raise RepoRefError(LOCAL_SENTENCE, kind="local")
 
-    candidate = os.path.normpath(os.path.abspath(value.strip()))
-    for prefix in (os.path.normpath(os.path.abspath(str(r))) for r in roots):
-        if candidate == prefix or candidate.startswith(prefix + os.sep):
-            # Lexically contained. ONLY here does the value touch the filesystem, and the
-            # symlink-resolved result is checked against the same root before it is returned.
-            try:
-                resolved = Path(candidate).resolve(strict=False)
-                root = Path(prefix).resolve(strict=False)
-            except OSError:
-                continue
-            if resolved == root or resolved.is_relative_to(root):
-                return resolved
+    # Trailing separator on both sides: `<root>/` matches the root itself and everything under it,
+    # and `<root>evil/` matches neither. `Path()` discards it again.
+    candidate = os.path.normpath(os.path.abspath(value.strip())) + os.sep
+    for root in (os.path.normpath(os.path.abspath(str(r))) for r in roots):
+        if candidate.startswith(root + os.sep):
+            # Lexically contained. Now the same question of the SYMLINK-RESOLVED path, which is a
+            # different one: a link planted inside the root points wherever it likes.
+            real = os.path.realpath(candidate) + os.sep
+            if real.startswith(os.path.realpath(root) + os.sep):
+                return Path(real)
     raise RepoRefError(LOCAL_SENTENCE, kind="local")
 
 

--- a/core/agent/control_plane/repo_ref.py
+++ b/core/agent/control_plane/repo_ref.py
@@ -1,0 +1,218 @@
+"""repo_ref.py — what a caller-supplied "Repository" may be, decided BEFORE any git process starts.
+
+``POST /api/workspace/swap`` and ``POST /api/workspace/activate`` take a repository from the caller
+and hand it to ``git clone``. ``git clone`` is a fetch **this server** performs, so the field is not
+only a name for something the caller owns — it is an instruction to this process to go somewhere and
+come back with the result. Two properties follow, and neither was true before this module existed:
+
+* **the HOST must be somewhere the caller could have reached themselves.** ``http://169.254.169.254/a/b``
+  is the cloud metadata service and ``http://admin-api:8001/a/b`` is a compose neighbour; both are
+  perfectly well-formed repository URLs, and the outcome of the fetch comes back to the caller in the
+  (token-redacted) clone error. ``assert_public_host`` is that half.
+* **the TRANSPORT must be one we named.** ``ext::sh -c <command>`` is a git URL that runs a shell
+  command, and ``file:///etc`` is a git URL that reads the local filesystem. ``assert_allowed_scheme``
+  is that half, and ``shared.gitenv.pinned_git_env`` enforces the same list a second time inside git
+  itself, so a transport we did not name cannot be reached even by a caller we did not anticipate.
+
+Both checks run **before any subprocess is created**, which is the part that matters: a validator that
+runs after git has already been told where to go has not protected anything.
+
+The checks are duplicated — once at the route, once inside ``workspace_attach._git_clone`` — on
+purpose, so a credential-bearing fetch cannot reach git through the MCP, a future route, or a test
+that forgot.
+
+**What this module does NOT close, stated plainly:** a DNS name that resolves to an internal address
+(``localtest.me``, a rebinding record) passes ``_host_is_internal``, because the check is on the name
+and the resolution happens inside git. Closing that needs resolution-time enforcement (resolve, check
+every answer, pin the connection), which is a different mechanism than a string check.
+"""
+from __future__ import annotations
+
+import ipaddress
+import os
+import re
+from pathlib import Path
+from typing import Optional
+
+
+class RepoRefError(ValueError):
+    """A repository reference we refuse. ``kind`` names which gate refused it (``host`` · ``scheme`` ·
+    ``local``) so a caller can branch without parsing the message."""
+
+    def __init__(self, message: str, *, kind: str = "shape") -> None:
+        super().__init__(message)
+        self.kind = kind
+
+
+#: What the user is told when the shape is right but the HOST is somewhere only this server can reach.
+HOST_SENTENCE = ("That host is not reachable as a repository. Use a public or company git host, "
+                 "not an address inside the deployment.")
+#: …and when the TRANSPORT is one we do not carry.
+SCHEME_SENTENCE = ("That is not a repository URL we can fetch. Use https://, ssh://, or "
+                   "git@host:owner/repo.")
+#: …and when it is a path on this server's own disk, which is not a thing a caller may name.
+LOCAL_SENTENCE = ("That is a path on the server, not a repository URL. Use https://, ssh://, or "
+                  "git@host:owner/repo.")
+
+#: The transports a caller-supplied repository may name. Everything else — ``ext``, ``file``, ``git``,
+#: ``ftp`` and the whole ``<helper>::`` family — is refused: ``ext::`` runs a shell command and
+#: ``file://`` reads this server's disk, and neither is a fetch the caller could have made themselves.
+ALLOWED_SCHEMES = ("https", "http", "ssh")
+
+#: Opt-in escape hatch for a SELF-HOSTED deployment that legitimately attaches repos from a local path
+#: or an NFS mount: an ``os.pathsep``-separated list of roots a scheme-less path may live under. UNSET
+#: (the default, and every hosted deployment) means a local path is refused outright — which is the
+#: behaviour change this module introduces for self-hosters, and the reason it is an env var rather
+#: than a removal: ``git clone /var/lib/vexa/workspaces/<someone-else>`` was a read of another
+#: subject's workspace, and a deployment that really does clone from disk must now say so.
+LOCAL_ROOTS_ENV = "VEXA_ALLOW_LOCAL_REPO_ROOT"
+
+#: ``scheme://…`` — a transport named the ordinary way.
+_SCHEME = re.compile(r"^([A-Za-z][A-Za-z0-9+.-]*)://")
+#: ``helper::…`` — git's remote-helper syntax, which is how ``ext::sh -c …`` gets to run a command.
+_HELPER = re.compile(r"^([A-Za-z][A-Za-z0-9+.-]*)::")
+#: ``user@host:path`` — the scp-like form, the one shape with a host and no scheme.
+_SCP = re.compile(r"^[A-Za-z0-9._-]+@(\[[0-9A-Fa-f:.]+\]|[A-Za-z0-9._-]+):")
+#: The host of a URL, userinfo skipped (``https://token@host/…`` must be read as ``host``).
+_URL_HOST = re.compile(r"^[A-Za-z][A-Za-z0-9+.-]*://(?:[^/@\s]+@)?([^/\s]+)")
+
+
+def _bare_host(host: str) -> str:
+    """``host[:port]`` → ``host``, brackets stripped, lowercased. A bracketed literal (``[::1]:8080``)
+    is unwrapped first, because an unbracketed IPv6 address is all colons and a naive port strip
+    would turn ``::1`` into ``:``."""
+    h = (host or "").strip().rstrip(".").lower()
+    if h.startswith("["):
+        end = h.find("]")
+        return h[1:end] if end > 0 else h[1:]
+    if h.count(":") == 1 and re.search(r":\d{1,5}$", h):
+        h = h.rsplit(":", 1)[0]
+    return h
+
+
+def _unwrapped(ip: ipaddress._BaseAddress) -> ipaddress._BaseAddress:
+    """The IPv4 address an IPv6 address is carrying, if it is carrying one.
+
+    ``::ffff:127.0.0.1`` is loopback written as IPv6, and ``IPv6Address.is_loopback`` is False for it —
+    the flag describes ``::1``, not what the address maps to. Same for 6to4 and Teredo. Unwrap first,
+    then ask the question, so the answer does not depend on which notation the caller chose."""
+    mapped = getattr(ip, "ipv4_mapped", None)
+    if mapped is not None:
+        return mapped
+    sixtofour = getattr(ip, "sixtofour", None)
+    if sixtofour is not None:
+        return sixtofour
+    teredo = getattr(ip, "teredo", None)
+    if teredo:
+        return teredo[1]
+    return ip
+
+
+def _host_is_internal(host: str) -> bool:
+    """Is this host somewhere only the SERVER can reach — i.e. would fetching it be a request the
+    caller could not have made themselves?
+
+    Two rules, and the second is the one that catches a service name:
+
+    * a literal IP (in any notation) that is loopback, private, link-local, reserved, multicast or
+      unspecified — ``127.0.0.1``, ``10.0.0.5``, ``169.254.169.254``, ``::1``, ``::ffff:127.0.0.1``;
+    * a BARE LABEL — a name with no dot. Every public and company git host is fully qualified; an
+      unqualified name resolves only inside the deployment's own network, which is the whole class
+      ``admin-api``, ``redis`` and ``meeting-api`` belong to. ``localhost`` included.
+
+    A DOTTED name is left alone even when it is obviously internal (``git.internal:8080`` is an
+    accepted self-hosted mirror): a name with a dot is one somebody configured, and refusing it would
+    break the self-host case to close nothing the two rules above leave open — the deployment's own
+    neighbours all answer to bare labels."""
+    h = _bare_host(host)
+    if not h:
+        return True
+    try:
+        ip = _unwrapped(ipaddress.ip_address(h))
+    except ValueError:
+        return "." not in h               # a bare label: only resolvable inside the deployment
+    return bool(ip.is_loopback or ip.is_private or ip.is_link_local or ip.is_reserved
+                or ip.is_multicast or ip.is_unspecified)
+
+
+def _checked_host(host: str) -> str:
+    """``host``, or ``RepoRefError`` — the seam a URL normalizer threads every parsed host through."""
+    if _host_is_internal(host):
+        raise RepoRefError(HOST_SENTENCE, kind="host")
+    return host
+
+
+def host_of(raw: Optional[str]) -> Optional[str]:
+    """The host a repository reference names, or ``None`` when it names none (a local path)."""
+    v = (raw or "").strip()
+    m = _URL_HOST.match(v) or _SCP.match(v)
+    return m.group(1) if m else None
+
+
+def assert_public_host(raw: Optional[str]) -> None:
+    """Refuse a deployment-internal HOST, wherever the call came from.
+
+    Deliberately NARROWER than :func:`assert_allowed_scheme`, so it can also sit inside
+    ``workspace_attach._git_clone`` — which is reached by tests and internal callers with values that
+    name no host at all. It says nothing about a value that is not URL-shaped; only that a value which
+    IS one may not point at something only this server can reach."""
+    host = host_of(raw)
+    if host is not None and _host_is_internal(host):
+        raise RepoRefError(HOST_SENTENCE, kind="host")
+
+
+def allowed_local_roots() -> list[Path]:
+    """The roots a scheme-less repository path may live under — empty unless a self-host operator set
+    :data:`LOCAL_ROOTS_ENV`, which is the default and means "no local paths"."""
+    raw = os.environ.get(LOCAL_ROOTS_ENV, "")
+    roots: list[Path] = []
+    for part in raw.split(os.pathsep):
+        part = part.strip()
+        if not part:
+            continue
+        try:
+            roots.append(Path(part).resolve())
+        except OSError:                     # an unresolvable root configures nothing
+            continue
+    return roots
+
+
+def _assert_allowed_local(value: str) -> None:
+    roots = allowed_local_roots()
+    if not roots:
+        raise RepoRefError(LOCAL_SENTENCE, kind="local")
+    try:
+        p = Path(value).resolve()
+    except OSError:
+        raise RepoRefError(LOCAL_SENTENCE, kind="local") from None
+    if not any(p == r or r in p.parents for r in roots):
+        raise RepoRefError(LOCAL_SENTENCE, kind="local")
+
+
+def assert_allowed_scheme(raw: Optional[str]) -> None:
+    """Refuse a transport we did not name — the caller-supplied half of the gate.
+
+    ``ext::sh -c …`` runs a command, ``file:///etc`` reads this server's disk, ``git://`` is
+    unauthenticated and unencrypted, and a scheme-less path is a location on this server rather than a
+    repository anyone could name. Each is a well-formed git URL, which is exactly why a shape check
+    that only asks "does this parse" does not catch them."""
+    v = (raw or "").strip()
+    if not v:
+        return                              # omitted → swap back to the seed; never reaches git
+    if _HELPER.match(v):                    # ext:: / any remote-helper transport
+        raise RepoRefError(SCHEME_SENTENCE, kind="scheme")
+    m = _SCHEME.match(v)
+    if m:
+        if m.group(1).lower() not in ALLOWED_SCHEMES:
+            raise RepoRefError(SCHEME_SENTENCE, kind="scheme")
+        return
+    if _SCP.match(v):
+        return
+    _assert_allowed_local(v)
+
+
+def assert_fetchable(raw: Optional[str]) -> None:
+    """The whole gate for a caller-supplied repository: a transport we carry, at a host the caller
+    could have reached. What every API route calls before the value goes anywhere near git."""
+    assert_allowed_scheme(raw)
+    assert_public_host(raw)

--- a/core/agent/control_plane/repo_ref.py
+++ b/core/agent/control_plane/repo_ref.py
@@ -190,24 +190,26 @@ def contained_local_path(value: str) -> Path:
       wherever it likes and the lexical pass cannot see through it.
 
     Only the resolved path is returned, so no caller can reach past the check by re-using the raw
-    string."""
+    string. The guard is written as a plain ``if`` that DOMINATES the filesystem call rather than an
+    ``any(...)`` over a generator: the containment is the same either way, but only this shape says
+    so in the control flow, where a reader — or a static analyser — can see it."""
     roots = allowed_local_roots()
     if not roots:
         raise RepoRefError(LOCAL_SENTENCE, kind="local")
 
-    prefixes = [os.path.normpath(os.path.abspath(str(r))) for r in roots]
     candidate = os.path.normpath(os.path.abspath(value.strip()))
-    if not any(candidate == p or candidate.startswith(p + os.sep) for p in prefixes):
-        raise RepoRefError(LOCAL_SENTENCE, kind="local")
-
-    try:
-        resolved = Path(candidate).resolve(strict=False)
-        real_roots = [Path(p).resolve(strict=False) for p in prefixes]
-    except OSError:
-        raise RepoRefError(LOCAL_SENTENCE, kind="local") from None
-    if not any(resolved == r or resolved.is_relative_to(r) for r in real_roots):
-        raise RepoRefError(LOCAL_SENTENCE, kind="local")
-    return resolved
+    for prefix in (os.path.normpath(os.path.abspath(str(r))) for r in roots):
+        if candidate == prefix or candidate.startswith(prefix + os.sep):
+            # Lexically contained. ONLY here does the value touch the filesystem, and the
+            # symlink-resolved result is checked against the same root before it is returned.
+            try:
+                resolved = Path(candidate).resolve(strict=False)
+                root = Path(prefix).resolve(strict=False)
+            except OSError:
+                continue
+            if resolved == root or resolved.is_relative_to(root):
+                return resolved
+    raise RepoRefError(LOCAL_SENTENCE, kind="local")
 
 
 def assert_allowed_scheme(raw: Optional[str]) -> None:

--- a/core/agent/control_plane/workspace_attach.py
+++ b/core/agent/control_plane/workspace_attach.py
@@ -29,7 +29,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Callable, Optional
 
-from shared.gitenv import scrubbed_git_env
+from control_plane.repo_ref import assert_public_host
+from shared.gitenv import pinned_git_env, scrubbed_git_env
 from shared.seeding import resolve_seed_dir, seed_workspace, validate_seed
 
 log = logging.getLogger(__name__)
@@ -139,18 +140,30 @@ def _git_clone(repo_url: str, ref: str, dest: Path, token: Optional[str] = None)
     the persisted ``origin`` is reset to the token-free URL so the credential never lands in the cloned
     ``.git/config`` or the synced workspace (P15 — mirrors ``GitHubVcs.push``). Git is run with prompts
     disabled so a missing/invalid credential FAILS LOUD instead of hanging on a terminal prompt. Any
-    failure raises ``CloneError`` with the token redacted from the message."""
+    failure raises ``CloneError`` with the token redacted from the message.
+
+    The repository is validated BEFORE any subprocess exists: ``git clone`` is a fetch this server
+    performs, so a URL naming an address only this server can reach turns the attach dialog into a
+    server-side request forge (``http://169.254.169.254/…``, ``http://admin-api:8001/…``) with the
+    outcome readable in the clone error. The check is repeated here rather than trusted from the route
+    so it also covers the MCP, a future route, and a test that forgot — the same stance the token
+    redaction takes. The transport allow-list (``pinned_git_env``) is the second half: a URL may not
+    reach a transport that runs a command (``ext::``) or reads this host's disk (``file://``), and an
+    ``https`` clone may not redirect down into one."""
     dest.parent.mkdir(parents=True, exist_ok=True)
+    assert_public_host(repo_url)      # never make this server fetch its own neighbours (R-D15)
     # scrubbed env: a hook-exported GIT_DIR would re-point every op below at the hook's repo
-    # (see shared/gitenv.py); prompts stay disabled so a bad credential fails loud.
-    env = scrubbed_git_env(GIT_ASKPASS="true", GIT_TERMINAL_PROMPT="0")
+    # (see shared/gitenv.py); prompts stay disabled so a bad credential fails loud; the transport
+    # allow-list is pinned to what this URL legitimately needs.
+    env = pinned_git_env(repo_url, GIT_ASKPASS="true", GIT_TERMINAL_PROMPT="0")
     url = _authenticated_url(repo_url, token)
 
     def redact(text: str) -> str:
         return text.replace(token, "***") if token else text
 
     try:
-        subprocess.run(["git", "clone", "--quiet", url, str(dest)],
+        # `--` so a repository beginning with `-` is a repository and not an option to `git clone`.
+        subprocess.run(["git", "clone", "--quiet", "--", url, str(dest)],
                        check=True, capture_output=True, text=True, env=env)
         if token:  # never persist the credential in the cloned repo's origin (P15)
             subprocess.run(["git", "-C", str(dest), "remote", "set-url", "origin", repo_url],

--- a/core/agent/control_plane/workspace_git_sync.py
+++ b/core/agent/control_plane/workspace_git_sync.py
@@ -29,7 +29,7 @@ from pathlib import Path
 from typing import Optional
 
 from shared.adapters import GitPushError, push_with_token
-from shared.gitenv import scrubbed_git_env
+from shared.gitenv import pinned_git_env, scrubbed_git_env
 
 from control_plane.workspace_publish import PUBLISH_REMOTE, _URL_CREDENTIAL_RE, _display_url
 
@@ -50,12 +50,18 @@ def _redacted(text: str, token: Optional[str]) -> str:
     return text.replace(token, "***") if token else text
 
 
-def _git(ws: Path, *args: str, token: Optional[str] = None, check: bool = True) -> subprocess.CompletedProcess:
+def _git(ws: Path, *args: str, token: Optional[str] = None, check: bool = True,
+         url: Optional[str] = None) -> subprocess.CompletedProcess:
     """Run a git command in ``ws`` with a scrubbed env + prompts disabled; failures raise a token-redacted
-    ``RemoteSyncError`` (unless ``check=False``, which returns the completed process for the caller to read)."""
+    ``RemoteSyncError`` (unless ``check=False``, which returns the completed process for the caller to read).
+
+    ``url`` marks this as a NETWORK op and pins git's transport allow-list to what that remote needs —
+    the home remote was written from a repository the subject supplied at attach time, so it is a
+    caller-influenced URL even though it is read back out of ``.git/config``."""
+    overrides = {"GIT_ASKPASS": "true", "GIT_TERMINAL_PROMPT": "0"}
     proc = subprocess.run(
         ["git", "-C", str(ws), *args], capture_output=True, text=True,
-        env=scrubbed_git_env(GIT_ASKPASS="true", GIT_TERMINAL_PROMPT="0"),
+        env=pinned_git_env(url, **overrides) if url is not None else scrubbed_git_env(**overrides),
     )
     if check and proc.returncode != 0:
         raise RemoteSyncError(_redacted(f"git {' '.join(args)} failed: {proc.stderr.strip()}", token))
@@ -205,7 +211,7 @@ def pull_origin(ws: str | Path, *, token: Optional[str] = None) -> PullResult:
         proto, rest = url.split("://", 1)
         auth_url = f"{proto}://{token}@{rest}"
     # Fetch from the URL directly (not a persisted remote) so the credential never lands anywhere.
-    fetch = _git(wsp, "fetch", "--quiet", auth_url, branch, token=token, check=False)
+    fetch = _git(wsp, "fetch", "--quiet", auth_url, branch, token=token, check=False, url=url)
     if fetch.returncode != 0:
         raise RemoteSyncError(_redacted(f"fetch from {remote} failed: {fetch.stderr.strip()}", token))
     fetched = _git(wsp, "rev-parse", "FETCH_HEAD", token=token).stdout.strip()

--- a/core/agent/control_plane/workspace_publish.py
+++ b/core/agent/control_plane/workspace_publish.py
@@ -30,6 +30,7 @@ from typing import Callable, Optional
 from shared.adapters import GitPushError, push_with_token
 from shared.gitenv import scrubbed_git_env
 
+from control_plane.repo_ref import assert_fetchable
 from control_plane.workspace_attach import SEED_SLOT, _safe_subject_dir, attached_workspaces
 
 log = logging.getLogger(__name__)
@@ -209,6 +210,9 @@ def publish_workspace(
     created = False
     if remote_url:
         remote_url = remote_url.strip()
+        # A caller-supplied push target is the same instruction-to-this-server as a clone source: it
+        # carries the caller's PAT to whatever host it names. RepoRefError is a ValueError → API 400.
+        assert_fetchable(remote_url)
     else:
         name = (repo_name or "").strip()
         if not _REPO_NAME_RE.match(name):

--- a/core/agent/shared/adapters.py
+++ b/core/agent/shared/adapters.py
@@ -28,7 +28,7 @@ from typing import Protocol
 
 import yaml
 
-from shared.gitenv import scrubbed_git_env
+from shared.gitenv import pinned_git_env, scrubbed_git_env
 from shared.models import WorkspaceWrite
 from shared.ports import IdentityPort, RuntimePort, SchedulerPort, StreamReader, VcsPort, WorkspacePort
 
@@ -56,12 +56,17 @@ def parse_entity(text: str) -> tuple[dict, str]:
 
 # ── git helpers ──────────────────────────────────────────────────────────────
 
-def _git(cwd: Path, *args: str, token: str | None = None) -> str:
+def _git(cwd: Path, *args: str, token: str | None = None, url: str | None = None) -> str:
     """Run a git command in ``cwd``; return trimmed stdout. ``token`` (if given) is passed via env
     for the duration of the call only and is NEVER placed on the argv (which can leak via ps).
     Always runs on a scrubbed env — a hook-exported GIT_DIR must never re-point the workspace op
-    at the hook's repo (see shared/gitenv.py)."""
-    env = scrubbed_git_env(GIT_ASKPASS="true") if token is not None else scrubbed_git_env()
+    at the hook's repo (see shared/gitenv.py).
+
+    ``url`` marks this call as a NETWORK op against that remote and pins git's transport allow-list
+    to what the URL legitimately needs, so a remote reference can never reach a transport that runs a
+    command (``ext::``) or reads this host's disk (``file://``)."""
+    overrides = {"GIT_ASKPASS": "true"} if token is not None else {}
+    env = pinned_git_env(url, **overrides) if url is not None else scrubbed_git_env(**overrides)
     proc = subprocess.run(
         ["git", *args],
         cwd=str(cwd),
@@ -160,7 +165,8 @@ def push_with_token(work_dir: str | Path, remote_url: str, ref: str, token: str 
         except RuntimeError:
             _git(work, "remote", "add", remote, auth_url, token=token)
         try:
-            _git(work, "push", remote, ref, token=token)
+            # The push is the network op — pin the transports to what ``remote_url`` needs.
+            _git(work, "push", remote, ref, token=token, url=remote_url)
             return _git(work, "rev-parse", "HEAD", token=token)
         finally:
             # Strip the token from the persisted remote so it can't leak to the repo/object store.
@@ -190,10 +196,11 @@ class RealGitWorkspace(WorkspacePort):
         if (self.work_dir / ".git").exists():
             _git(self.work_dir, "checkout", ref)
             return
-        # Local clone (file path or file:// URL) — derived from parent git_clone_init.
+        # Local clone (file path or file:// URL) — derived from parent git_clone_init. The transport
+        # allow-list is pinned to what this reference needs; `--` keeps a leading `-` a repository.
         subprocess.run(
-            ["git", "clone", repo_url, str(self.work_dir)],
-            capture_output=True, text=True, check=True, env=scrubbed_git_env(),
+            ["git", "clone", "--", repo_url, str(self.work_dir)],
+            capture_output=True, text=True, check=True, env=pinned_git_env(repo_url),
         )
         name, email = self._identity
         _git(self.work_dir, "config", "user.name", name)

--- a/core/agent/shared/gitenv.py
+++ b/core/agent/shared/gitenv.py
@@ -19,6 +19,7 @@ from product code so it stays liftable, the same stance as its local ``_git``.)
 from __future__ import annotations
 
 import os
+import re
 
 # Every env var that redirects git's repo/worktree/index/object discovery away from cwd.
 GIT_REPO_DISCOVERY_VARS = (
@@ -36,4 +37,61 @@ def scrubbed_git_env(**overrides: str) -> dict[str, str]:
     plus ``overrides`` (e.g. ``GIT_ASKPASS="true"``). Guarantees cwd-based repo discovery."""
     env = {k: v for k, v in os.environ.items() if k not in GIT_REPO_DISCOVERY_VARS}
     env.update(overrides)
+    return env
+
+
+# ── transport pinning ─────────────────────────────────────────────────────────────────────────────
+# A git URL names a TRANSPORT, and two of git's transports are not network fetches at all: ``ext::``
+# runs a shell command, and ``file://`` (or a bare path) reads this host's disk. Neither is disabled
+# by default, so a caller-supplied repository reaches them unless we say otherwise.
+#
+# ``GIT_ALLOW_PROTOCOL`` is the mechanism, and it is deliberately the ONLY one used here. The
+# ``protocol.<name>.allow`` config keys express the same intent, but git ignores them entirely when
+# ``GIT_ALLOW_PROTOCOL`` is set (verified: an allow-list of ``https:ssh`` still refuses ``file`` with
+# ``protocol.file.allow=always`` injected via ``GIT_CONFIG_*``), so injecting both adds no protection
+# and would clobber the ``GIT_CONFIG_*`` slots this module promises to leave to its callers.
+#
+# The list is derived from the URL's OWN transport rather than fixed, which is what lets the fixtures
+# keep cloning from a local path while a remote URL can never silently downgrade to one: an
+# ``https://`` clone that redirects to ``file://`` or ``ext::`` is refused by git itself.
+_URL_SCHEME = re.compile(r"^([A-Za-z][A-Za-z0-9+.-]*)://")
+_HELPER_SCHEME = re.compile(r"^[A-Za-z][A-Za-z0-9+.-]*::")
+_SCP_LIKE = re.compile(r"^[A-Za-z0-9._-]+@(?:\[[0-9A-Fa-f:.]+\]|[A-Za-z0-9._-]+):")
+
+#: What a remote fetch may ever use. ``file`` is added only for a reference that is itself a local
+#: path; ``ext`` and ``git`` appear in no list at all.
+REMOTE_TRANSPORTS = ("https", "ssh")
+
+
+def git_transports_for(url: str | None) -> tuple[str, ...]:
+    """The transports git may use to fetch ``url`` — the narrowest set that still lets it succeed."""
+    v = (url or "").strip()
+    if not v or _HELPER_SCHEME.match(v):
+        return REMOTE_TRANSPORTS            # a helper (``ext::``) is named by nothing we allow
+    m = _URL_SCHEME.match(v)
+    if m:
+        scheme = m.group(1).lower()
+        # A transport is carried only when the reference ITSELF named it — never as a downgrade
+        # target. So an ``https`` URL that redirects to ``http`` or ``file://`` is refused by git,
+        # while a reference that was always ``http://`` or ``file://`` still works.
+        #
+        # This is deliberately NOT the gate on what a caller may ask for: that is
+        # ``control_plane.repo_ref.assert_allowed_scheme``, which refuses ``file://`` and ``ext::``
+        # outright at every route. The two do different jobs — this one narrows git to what THIS
+        # reference needs, that one decides which references a caller may name at all.
+        if scheme in ("http", "file"):
+            return (*REMOTE_TRANSPORTS, scheme)
+        return REMOTE_TRANSPORTS
+    if _SCP_LIKE.match(v):
+        return REMOTE_TRANSPORTS            # ``git@host:owner/repo`` → ssh
+    return (*REMOTE_TRANSPORTS, "file")     # a scheme-less LOCAL path (an opted-in local repo root)
+
+
+def pinned_git_env(url: str | None, **overrides: str) -> dict[str, str]:
+    """:func:`scrubbed_git_env` plus a transport allow-list pinned to what ``url`` legitimately needs.
+
+    Pass this — not ``scrubbed_git_env`` — to every git subprocess that performs a NETWORK op with a
+    URL that came, however indirectly, from a caller."""
+    env = scrubbed_git_env(**overrides)
+    env.setdefault("GIT_ALLOW_PROTOCOL", ":".join(git_transports_for(url)))
     return env

--- a/core/agent/tests/test_api.py
+++ b/core/agent/tests/test_api.py
@@ -1015,6 +1015,10 @@ def test_workspace_swap_attaches_custom_repo_and_swaps_back(tmp_path, monkeypatc
     seed.mkdir()
     (seed / "CLAUDE.md").write_text("SEED\n")
     monkeypatch.setenv("VEXA_WORKSPACE_SEED_DIR", str(seed))
+    # A scheme-less path is refused by default (it is a location on the SERVER, not a repository a
+    # caller may name — see control_plane/repo_ref). A self-hoster opts local roots back in; so does
+    # this fixture, which clones from a local bare repo to stay off the network.
+    monkeypatch.setenv("VEXA_ALLOW_LOCAL_REPO_ROOT", str(tmp_path))
 
     origin = tmp_path / "origin"
     origin.mkdir()
@@ -1047,6 +1051,46 @@ def test_workspace_swap_attaches_custom_repo_and_swaps_back(tmp_path, monkeypatc
     assert (workspaces / "u_jane" / "CLAUDE.md").read_text() == "SEED\n"
 
 
+def test_workspace_swap_refuses_a_repo_this_server_alone_could_fetch(tmp_path, monkeypatch):
+    """``repo`` is an instruction to THIS SERVER to go and fetch something, so the route settles the
+    host and the transport before anything reaches git (see control_plane/repo_ref).
+
+    The assertion that matters is the 400 AND that no git process ran: ``subprocess.run`` is replaced
+    with a bomb for the duration, so a gate that fired after git started would fail the test loudly
+    instead of passing on the status code."""
+    import subprocess as _sp
+    from control_plane.workspace_reader import WorkspaceReader
+
+    seed = tmp_path / "seed"; seed.mkdir(); (seed / "CLAUDE.md").write_text("SEED\n")
+    monkeypatch.setenv("VEXA_WORKSPACE_SEED_DIR", str(seed))
+    monkeypatch.delenv("VEXA_ALLOW_LOCAL_REPO_ROOT", raising=False)
+
+    c = TestClient(create_app(
+        Dispatcher(load_settings(), _FakeRuntime(), _FakeIdentity()),
+        reader=WorkspaceReader(str(tmp_path / "ws")),
+    ))
+    h = {"X-User-Id": "u_jane"}
+    c.post("/api/workspace/init", headers=h)
+
+    monkeypatch.setattr(_sp, "run", lambda *a, **k: pytest.fail(f"git started despite the gate: {a!r}"))
+    monkeypatch.setattr(_sp, "Popen", lambda *a, **k: pytest.fail(f"git started despite the gate: {a!r}"))
+
+    refused = [
+        "http://169.254.169.254/latest/meta-data",   # the cloud metadata service
+        "http://admin-api:8001/owner/repo.git",      # a deployment neighbour (a bare label)
+        "http://127.0.0.1:8000/owner/repo.git",
+        "https://[::ffff:127.0.0.1]/owner/repo.git",
+        "ext::sh -c whoami",                         # a git URL that runs a command
+        "file:///etc",                               # …and one that reads this host's disk
+        "git://github.com/owner/repo.git",
+        str(tmp_path / "origin"),                    # a path on the server is not a caller's to name
+    ]
+    for route in ("/api/workspace/swap", "/api/workspace/activate"):
+        for repo in refused:
+            r = c.post(route, headers=h, json={"repo": repo})
+            assert r.status_code == 400, f"{route} accepted {repo!r}: {r.status_code} {r.text}"
+
+
 def test_workspace_activate_adds_without_parking_then_deactivate_parks(tmp_path, monkeypatch):
     """POST /api/workspace/activate ADDS a repo to the active set without parking the private baseline;
     GET /api/workspace/active lists the ordered set; deactivate parks it; the baseline can be switched off."""
@@ -1055,6 +1099,7 @@ def test_workspace_activate_adds_without_parking_then_deactivate_parks(tmp_path,
 
     seed = tmp_path / "seed"; seed.mkdir(); (seed / "CLAUDE.md").write_text("SEED\n")
     monkeypatch.setenv("VEXA_WORKSPACE_SEED_DIR", str(seed))
+    monkeypatch.setenv("VEXA_ALLOW_LOCAL_REPO_ROOT", str(tmp_path))   # local clone source (see above)
     origin = tmp_path / "origin"; origin.mkdir()
     run = lambda *a: subprocess.run(["git", *a], cwd=origin, check=True, capture_output=True)
     run("init", "-q", "-b", "main"); run("config", "user.email", "t@t"); run("config", "user.name", "t")

--- a/core/agent/tests/test_repo_ref_host.py
+++ b/core/agent/tests/test_repo_ref_host.py
@@ -154,6 +154,45 @@ def test_a_self_hoster_can_opt_local_paths_back_in(tmp_path, monkeypatch):
         assert_allowed_scheme(str(allowed / ".." / "elsewhere"))
 
 
+def test_a_dotdot_escape_is_refused_before_the_filesystem_is_touched(tmp_path, monkeypatch):
+    """``<root>/../secrets`` names a place outside the root. The ``..`` is collapsed lexically and the
+    containment check runs on the collapsed value, so the escape is refused rather than resolved."""
+    allowed = tmp_path / "mirrors"
+    allowed.mkdir()
+    outside = tmp_path / "secrets"
+    outside.mkdir()
+    monkeypatch.setenv(repo_ref.LOCAL_ROOTS_ENV, str(allowed))
+
+    for escape in (f"{allowed}/../secrets", f"{allowed}/proj/../../secrets", f"{allowed}/.."):
+        with pytest.raises(RepoRefError) as exc:
+            repo_ref.contained_local_path(escape)
+        assert exc.value.kind == "local"
+
+
+def test_a_symlink_out_of_the_root_is_refused(tmp_path, monkeypatch):
+    """A path that is lexically inside the root but resolves outside it — the case the lexical pass
+    cannot see. The second check runs on the symlink-resolved path, so the link is followed by the
+    GATE before it is followed by anything else."""
+    allowed = tmp_path / "mirrors"
+    allowed.mkdir()
+    outside = tmp_path / "secrets"
+    outside.mkdir()
+    (allowed / "escape").symlink_to(outside, target_is_directory=True)
+    inside = allowed / "proj"
+    inside.mkdir()
+
+    monkeypatch.setenv(repo_ref.LOCAL_ROOTS_ENV, str(allowed))
+
+    with pytest.raises(RepoRefError) as exc:
+        repo_ref.contained_local_path(str(allowed / "escape"))
+    assert exc.value.kind == "local"
+    with pytest.raises(RepoRefError):
+        assert_allowed_scheme(str(allowed / "escape" / "repo.git"))
+
+    # …and the value that survives is the RESOLVED path, never the string the caller sent.
+    assert repo_ref.contained_local_path(str(allowed / "." / "proj")) == inside.resolve()
+
+
 def test_empty_repo_is_not_a_reference(monkeypatch):
     """``repo`` omitted means "swap back to the seed" — it never reaches git, so it is not refused."""
     monkeypatch.delenv(repo_ref.LOCAL_ROOTS_ENV, raising=False)

--- a/core/agent/tests/test_repo_ref_host.py
+++ b/core/agent/tests/test_repo_ref_host.py
@@ -1,0 +1,254 @@
+"""What a caller-supplied "Repository" may be — the gate that runs BEFORE git does.
+
+``POST /api/workspace/swap`` and ``POST /api/workspace/activate`` hand the ``repo`` field to
+``git clone``, which is a fetch THIS SERVER performs. Two things follow, and each has its own half of
+this file:
+
+* the HOST must be one the caller could have reached themselves — otherwise the attach dialog is a
+  server-side request forge against the deployment's own network (R-D15);
+* the TRANSPORT must be one we named — ``ext::`` runs a shell command and ``file://`` reads this
+  host's disk, and both are well-formed git URLs.
+
+The load-bearing assertion in the first half is not the error: it is that **no subprocess ever ran**.
+A validator that fires after git has already been told where to go has not protected anything, so
+every refusal test monkeypatches ``subprocess.run``/``Popen`` and asserts the call count is zero.
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from control_plane import repo_ref
+from control_plane import workspace_attach
+from control_plane.repo_ref import (
+    RepoRefError,
+    assert_allowed_scheme,
+    assert_fetchable,
+    assert_public_host,
+    _host_is_internal,
+)
+from shared.gitenv import git_transports_for, pinned_git_env
+
+
+@pytest.fixture
+def no_subprocess(monkeypatch):
+    """Every way a git process could be started, replaced by a counter. The refusal tests assert this
+    stays at zero — the whole point of the gate is that it runs first."""
+    calls: list[tuple] = []
+
+    def _boom(*args, **kwargs):
+        calls.append((args, kwargs))
+        raise AssertionError(f"a subprocess was started despite the gate: {args!r}")
+
+    monkeypatch.setattr(subprocess, "run", _boom)
+    monkeypatch.setattr(subprocess, "Popen", _boom)
+    return calls
+
+
+# ── the host half: a fetch the caller could not have made themselves ──────────────────────────────
+
+INTERNAL = [
+    "http://127.0.0.1/a/b",                  # loopback
+    "https://127.0.0.1:8080/a/b",            # …with a port
+    "http://10.0.0.5/a/b",                   # RFC1918
+    "http://192.168.1.10/a/b",
+    "http://172.16.0.1/a/b",
+    "http://169.254.169.254/latest/meta-data",   # the cloud metadata service
+    "http://[::1]/a/b",                      # loopback, IPv6, bracketed
+    "http://[::ffff:127.0.0.1]/a/b",         # loopback written as IPv4-mapped IPv6
+    "https://[::ffff:169.254.169.254]/a/b",  # metadata written as IPv4-mapped IPv6
+    "http://0.0.0.0/a/b",                    # unspecified
+    "http://admin-api:8001/a/b",             # a compose neighbour — a BARE LABEL
+    "http://redis/a/b",
+    "http://localhost/a/b",
+    "https://localhost:3000/x/y",
+    "git@admin-api:owner/repo.git",          # the scp-like form reaches the same network
+    "ssh://git@localhost/owner/repo.git",
+]
+
+PUBLIC = [
+    "https://github.com/owner/repo.git",
+    "https://gitlab.com/group/sub/repo.git",
+    "http://git.example.com/owner/repo.git",
+    "git@github.com:owner/repo.git",
+    "ssh://git@github.com/owner/repo.git",
+    "https://git.internal.example.com:8080/owner/repo.git",   # dotted: somebody configured this
+    "https://token@github.com/owner/repo.git",                # userinfo is not the host
+]
+
+
+@pytest.mark.parametrize("url", INTERNAL)
+def test_internal_host_is_refused(url):
+    with pytest.raises(RepoRefError) as exc:
+        assert_public_host(url)
+    assert exc.value.kind == "host"
+
+
+@pytest.mark.parametrize("url", PUBLIC)
+def test_public_host_is_accepted(url):
+    assert_public_host(url)          # does not raise
+
+
+def test_ipv4_mapped_ipv6_is_not_trusted_by_its_flags():
+    """REGRESSION: ``IPv6Address('::ffff:127.0.0.1').is_loopback`` is False — the flag describes ``::1``,
+    not what the address maps to. The check unwraps the mapping before asking."""
+    assert _host_is_internal("::ffff:127.0.0.1")
+    assert _host_is_internal("[::ffff:10.0.0.1]:9000")
+
+
+def test_a_dotted_private_name_is_left_alone():
+    """A name with a dot is one somebody configured (a self-hosted mirror). Refusing it would break the
+    self-host case and close nothing: the deployment's own neighbours answer to bare labels."""
+    assert not _host_is_internal("git.internal.example.com")
+    assert _host_is_internal("git-internal")
+
+
+# ── the transport half: ext:: runs a command, file:// reads the disk ──────────────────────────────
+
+REFUSED_TRANSPORTS = [
+    "ext::sh -c 'curl http://169.254.169.254'",
+    "ext::sh -c whoami",
+    "file:///etc",
+    "file:///etc/passwd",
+    "git://github.com/owner/repo.git",
+    "ftp://example.com/repo.git",
+    "ftps://example.com/repo.git",
+    "transport::whatever",
+]
+
+
+@pytest.mark.parametrize("url", REFUSED_TRANSPORTS)
+def test_transport_we_did_not_name_is_refused(url):
+    with pytest.raises(RepoRefError) as exc:
+        assert_allowed_scheme(url)
+    assert exc.value.kind == "scheme"
+
+
+def test_a_server_path_is_not_a_repository_a_caller_may_name(tmp_path, monkeypatch):
+    """A scheme-less path is a location on THIS server. Cloning one reads whatever git repo lives
+    there — including another subject's workspace out of the shared store."""
+    monkeypatch.delenv(repo_ref.LOCAL_ROOTS_ENV, raising=False)
+    for value in (str(tmp_path), "/etc", "../../etc", "./repo", "owner/repo"):
+        with pytest.raises(RepoRefError) as exc:
+            assert_allowed_scheme(value)
+        assert exc.value.kind == "local"
+
+
+def test_a_self_hoster_can_opt_local_paths_back_in(tmp_path, monkeypatch):
+    """The one legitimate scheme-less case — a self-hosted deployment attaching from a local mirror —
+    is an explicit opt-in naming the roots, not the default."""
+    allowed = tmp_path / "mirrors"
+    allowed.mkdir()
+    (allowed / "proj").mkdir()
+    monkeypatch.setenv(repo_ref.LOCAL_ROOTS_ENV, str(allowed))
+
+    assert_allowed_scheme(str(allowed / "proj"))          # inside the configured root → fine
+    with pytest.raises(RepoRefError):                     # …and only inside it
+        assert_allowed_scheme(str(tmp_path / "elsewhere"))
+    with pytest.raises(RepoRefError):                     # …traversal out of it is still out of it
+        assert_allowed_scheme(str(allowed / ".." / "elsewhere"))
+
+
+def test_empty_repo_is_not_a_reference(monkeypatch):
+    """``repo`` omitted means "swap back to the seed" — it never reaches git, so it is not refused."""
+    monkeypatch.delenv(repo_ref.LOCAL_ROOTS_ENV, raising=False)
+    assert_fetchable(None)
+    assert_fetchable("")
+    assert_fetchable("   ")
+
+
+# ── the gate runs before any process exists ───────────────────────────────────────────────────────
+
+@pytest.mark.parametrize("url", INTERNAL)
+def test_clone_refuses_an_internal_host_before_any_subprocess(url, tmp_path, no_subprocess):
+    """The reported sink. ``_git_clone`` refuses without starting git — asserted by the absence of a
+    subprocess, not by the message."""
+    with pytest.raises(RepoRefError):
+        workspace_attach._git_clone(url, "main", tmp_path / "dest")
+    assert no_subprocess == []
+
+
+@pytest.mark.parametrize("url", REFUSED_TRANSPORTS + ["http://127.0.0.1/a/b", "file:///etc"])
+def test_the_api_gate_refuses_before_any_subprocess(url, no_subprocess, monkeypatch):
+    """``assert_fetchable`` is what the routes call. Both halves, one entry point, no process."""
+    monkeypatch.delenv(repo_ref.LOCAL_ROOTS_ENV, raising=False)
+    with pytest.raises(RepoRefError):
+        assert_fetchable(url)
+    assert no_subprocess == []
+
+
+# ── the second enforcement, inside git itself ─────────────────────────────────────────────────────
+
+def test_transports_are_pinned_to_what_the_url_needs():
+    """A transport is carried only when the reference ITSELF named it, so nothing can be reached as a
+    downgrade target — and ``ext`` is named by nothing, so it appears in no list at all.
+
+    This is not the gate on what a CALLER may ask for (that is ``assert_allowed_scheme``, which
+    refuses ``file://`` outright); it is the narrowing applied to whatever reference we did accept."""
+    assert git_transports_for("https://github.com/o/r.git") == ("https", "ssh")
+    assert git_transports_for("git@github.com:o/r.git") == ("https", "ssh")
+    assert git_transports_for("ssh://git@github.com/o/r.git") == ("https", "ssh")
+    assert git_transports_for("http://git.example.com/o/r.git") == ("https", "ssh", "http")
+    assert git_transports_for("file:///srv/mirror.git") == ("https", "ssh", "file")
+    assert git_transports_for("ext::sh -c whoami") == ("https", "ssh")
+    assert "file" in git_transports_for("/srv/mirrors/proj")
+    for url in ("https://github.com/o/r.git", "git@github.com:o/r.git", "ext::sh -c whoami"):
+        assert "ext" not in git_transports_for(url)
+        assert "file" not in git_transports_for(url)
+
+
+def test_pinned_env_sets_the_allow_list_and_keeps_the_scrub():
+    """``GIT_ALLOW_PROTOCOL`` is git's own enforcement of the same list — and it overrides any
+    ``protocol.<name>.allow`` config, which is why this is the single mechanism used."""
+    env = pinned_git_env("https://github.com/o/r.git", GIT_ASKPASS="true")
+    assert env["GIT_ALLOW_PROTOCOL"] == "https:ssh"
+    assert env["GIT_ASKPASS"] == "true"
+    assert "GIT_DIR" not in env                     # the scrub still happens
+
+
+def test_git_itself_refuses_the_unnamed_transports(tmp_path):
+    """End-to-end against the real ``git``: the pinned env is what stops a transport, not our regex.
+
+    An ``https`` reference cannot reach ``ext`` (a shell command) or ``file`` (this host's disk), so a
+    redirect into either is refused by git before anything is fetched."""
+    real = tmp_path / "real.git"          # a REAL repo, so the refusal is the transport and not "no such repo"
+    subprocess.run(["git", "init", "-q", "--bare", "-b", "main", str(real)], check=True, capture_output=True)
+
+    env = pinned_git_env("https://github.com/o/r.git")
+    for url in ("ext::sh -c whoami", "file:///etc", f"file://{real}", str(real)):
+        proc = subprocess.run(["git", "clone", "--quiet", "--", url, str(tmp_path / "out")],
+                              capture_output=True, text=True, env=env)
+        assert proc.returncode != 0
+        assert "not allowed" in (proc.stderr or ""), f"{url} was not refused: {proc.stderr!r}"
+
+
+def test_ext_is_refused_even_under_a_local_references_pin(tmp_path):
+    """The widest pin any reference can produce still carries no ``ext`` — the transport that runs a
+    shell command is reachable from nothing."""
+    env = pinned_git_env(str(tmp_path))
+    proc = subprocess.run(["git", "clone", "--quiet", "--", "ext::sh -c whoami", str(tmp_path / "o")],
+                          capture_output=True, text=True, env=env)
+    assert proc.returncode != 0 and "not allowed" in (proc.stderr or "")
+
+
+def test_a_local_path_still_clones_under_its_own_pin(tmp_path):
+    """The fixtures clone from a local bare repo. The pin is derived from the URL, so that keeps
+    working while a REMOTE url can never downgrade into it."""
+    origin = tmp_path / "origin"
+    origin.mkdir()
+    run = lambda *a: subprocess.run(["git", *a], cwd=origin, check=True, capture_output=True)
+    run("init", "-q", "-b", "main")
+    run("config", "user.email", "t@t")
+    run("config", "user.name", "t")
+    (origin / "MARK").write_text("x")
+    run("add", "-A")
+    run("commit", "-q", "-m", "seed")
+
+    dest = tmp_path / "dest"
+    workspace_attach._git_clone(str(origin), "main", dest)
+    assert (dest / "MARK").read_text() == "x"

--- a/core/agent/tests/test_workspace_publish.py
+++ b/core/agent/tests/test_workspace_publish.py
@@ -48,6 +48,15 @@ def _bare(path: Path) -> Path:
     return path
 
 
+@pytest.fixture(autouse=True)
+def _local_push_targets_allowed(tmp_path, monkeypatch):
+    """This file pushes to a LOCAL bare repo so the suite never touches the network. A scheme-less
+    path is refused as a push target by default — it is a location on the SERVER, and a caller who
+    can name one can make this process carry their PAT to it (see control_plane/repo_ref). The
+    self-host opt-in is what makes the local-bare-repo fixture legal; every test here inherits it."""
+    monkeypatch.setenv("VEXA_ALLOW_LOCAL_REPO_ROOT", str(tmp_path))
+
+
 def test_publish_creates_repo_and_pushes_full_history(tmp_path):
     """The create path: the injected creator is called with the caller's args and its returned URL is
     pushed to — full history, head sha returned, repo_url token-free."""
@@ -131,12 +140,15 @@ def test_token_never_persisted_and_errors_redacted(tmp_path):
     _run(ws, "remote", "add", "origin", "https://example.com/keep.git")
     bare = _bare(tmp_path / "remote.git")
 
-    publish_workspace(root, "u1", token=TOKEN, remote_url=f"file://{bare}")
+    # A plain path, not `file://…`: an explicit file transport is refused everywhere now (it is one of
+    # the two git "URLs" that are not network fetches at all), while a path under an opted-in local
+    # root is exactly the self-host case this fixture stands in for.
+    publish_workspace(root, "u1", token=TOKEN, remote_url=str(bare))
 
     cfg = (ws / ".git" / "config").read_text()
     assert TOKEN not in cfg
     assert _run(ws, "remote", "get-url", "origin") == "https://example.com/keep.git"
-    assert _run(ws, "remote", "get-url", PUBLISH_REMOTE) == f"file://{bare}"
+    assert _run(ws, "remote", "get-url", PUBLISH_REMOTE) == str(bare)
 
     # a failing push (bogus remote) surfaces a token-free error
     with pytest.raises(PublishError) as ei:

--- a/docs/docs/configuration.mdx
+++ b/docs/docs/configuration.mdx
@@ -158,6 +158,7 @@ Point the agent at your own model so no inference leaves the network.
 | `ANTHROPIC_MODEL` · `ANTHROPIC_DEFAULT_OPUS_MODEL` · `…_SONNET_MODEL` · `…_HAIKU_MODEL` | — | Per-tier model overrides. |
 | `HOST_CLAUDE_CREDENTIALS` | — | Host path to Claude credentials mounted into agent containers (see below). |
 | `VEXA_AGENT_DEFAULT_SUBJECT` | `u_live` | Fallback subject before the gateway fronts agent-api. |
+| `VEXA_ALLOW_LOCAL_REPO_ROOT` | — | `os.pathsep`-separated directories a workspace repo may be attached from as a local path (`POST /agent/workspace/swap`). Unset refuses local paths. |
 
 ### Claude subscription credentials (`HOST_CLAUDE_CREDENTIALS`)
 

--- a/docs/docs/how-to/workspace-files.mdx
+++ b/docs/docs/how-to/workspace-files.mdx
@@ -94,10 +94,11 @@ curl -X POST "$API_BASE/agent/workspace/swap" \
   -d '{"repo":"https://github.com/acme/knowledge.git","ref":"main","token":"<git-token>"}'
 ```
 
-`repo` must be an `https://`, `ssh://` or `git@host:owner/repo` URL. Addresses that resolve to
-loopback, private, link-local or reserved ranges are refused, as are unqualified host names.
-Local filesystem paths are refused too, unless the operator sets `VEXA_ALLOW_LOCAL_REPO_ROOT` to an
-`os.pathsep`-separated list of directories (`:` on Linux and macOS) that a local path must sit under.
+`repo` must be an `https://`, `ssh://` or `git@host:owner/repo` URL pointing at a public or company
+git host. A host inside the deployment is refused: a loopback, private, link-local, reserved or
+multicast address, or an unqualified name with no dot. Local filesystem paths are refused too,
+unless the operator sets `VEXA_ALLOW_LOCAL_REPO_ROOT` to an `os.pathsep`-separated list of
+directories (`:` on Linux and macOS) that a local path must resolve inside.
 
 Omit `repo` to swap back to the seed workspace. Check what's attached:
 

--- a/docs/docs/how-to/workspace-files.mdx
+++ b/docs/docs/how-to/workspace-files.mdx
@@ -94,6 +94,11 @@ curl -X POST "$API_BASE/agent/workspace/swap" \
   -d '{"repo":"https://github.com/acme/knowledge.git","ref":"main","token":"<git-token>"}'
 ```
 
+`repo` must be an `https://`, `ssh://` or `git@host:owner/repo` URL. Addresses that resolve to
+loopback, private, link-local or reserved ranges are refused, as are unqualified host names.
+Local filesystem paths are refused too, unless the operator sets `VEXA_ALLOW_LOCAL_REPO_ROOT` to an
+`os.pathsep`-separated list of directories (`:` on Linux and macOS) that a local path must sit under.
+
 Omit `repo` to swap back to the seed workspace. Check what's attached:
 
 ```bash


### PR DESCRIPTION
`POST /api/workspace/swap` and `POST /api/workspace/activate` take a repository from the caller and
hand it to `git clone`. `git clone` is a fetch **this server** performs, so the field is not only a
name for something the caller owns — it is an instruction to this process to go somewhere and come
back with the result, and neither the host nor the transport was checked.

Two consequences on `main` today:

* **the host.** `http://169.254.169.254/a/b` (the cloud metadata service) and
  `http://admin-api:8001/a/b` (a deployment neighbour) are well-formed repository URLs. The server
  performs the request and the outcome comes back to the caller in the (token-redacted) clone error —
  a server-side request to internal hosts.
* **the transport.** `ext::sh -c <command>` is a git URL that runs a shell command; `file:///etc` and
  a bare path are git URLs that read this host's disk, including another subject's workspace out of
  the shared store. `scrubbed_git_env` set no protocol allow-list, so only the host git's defaults
  stood between a caller and either.

## What changed

**`control_plane/repo_ref.py`** (new) — the gate, which runs before any subprocess exists.

* `assert_public_host` refuses a literal IP that is loopback / private / link-local / reserved /
  multicast / unspecified in any notation (`127.0.0.1`, `10.0.0.5`, `169.254.169.254`, `::1`,
  `::ffff:127.0.0.1`, `[::1]:8080`), and any **bare label** — an unqualified name resolves only inside
  the deployment, which is the class `admin-api`, `redis` and `localhost` belong to. A **dotted** name
  is left alone even when it looks internal: `git.internal.example.com:8080` is a legitimate
  self-hosted mirror, and refusing it would break that case to close nothing.
* `assert_allowed_scheme` refuses every transport we did not name — the whole `<helper>::` family
  (`ext::`), `file://`, `git://`, `ftp://` — and a scheme-less path.

**`shared/gitenv.py`** — `pinned_git_env(url, …)` sets `GIT_ALLOW_PROTOCOL` to the narrowest list the
reference legitimately needs, so git itself enforces the same decision a second time. A transport is
carried only when the reference **itself** named it, so nothing is reachable as a downgrade target: an
`https://` clone that redirects to `file://` or `ext::` is refused by git. `ext` appears in no list at
all.

Wired into every git network op that can be reached with a caller-influenced URL: the clone in
`workspace_attach._git_clone`, the push in `adapters.push_with_token` (so `GitHubVcs.push` and
publish both), the fetch in `workspace_git_sync.pull_origin`, and `RealGitWorkspace.clone`.
`workspace_publish` validates a caller-supplied `remote_url` the same way the clone routes validate
`repo` — it carries the caller's PAT to whatever host it names.

`git clone` also gained `--`, so a repository beginning with `-` stays a repository.

### `GIT_ALLOW_PROTOCOL` rather than `protocol.<name>.allow`

Both express the same intent, but git **ignores** the config keys entirely when `GIT_ALLOW_PROTOCOL`
is set — verified: an allow-list of `https:ssh` still refuses `file` with `protocol.file.allow=always`
injected via `GIT_CONFIG_*`. Setting both would add no protection and would clobber the `GIT_CONFIG_*`
slots `gitenv` documents as belonging to its callers.

## Behaviour change for self-hosters

A scheme-less path is now refused as a repository. That closes a real hole —
`git clone /var/lib/vexa/workspaces/<someone-else>` was a read of another subject's workspace — but
attaching from a local path or an NFS mount is a legitimate self-host configuration, so it is an
opt-in rather than a removal: `VEXA_ALLOW_LOCAL_REPO_ROOT` (an `os.pathsep`-separated list of roots)
re-enables it for paths under those roots. **Unset by default**, which is every hosted deployment.

## What this does not close

A DNS name that resolves to an internal address (`localtest.me`, a rebinding record) passes the host
check, because the check is on the name and the resolution happens inside git. Closing that needs
resolution-time enforcement — resolve, check every answer, pin the connection — which is a different
mechanism, and is stated in the module docstring rather than left implied.

## Rows

* **R-D15** — server-side request to internal hosts via the workspace repository field: closed on
  `main`. (The same row is closed on the `minutes-mcp-viewer` line by #1428; this is the targeted port
  to `main`, which had neither `repo_ref.py` nor the guard.)
* **R-A07** — identity default: **out of scope here**, deliberately. It is not reached by this code
  path and folding it in would put an unrelated change behind the same review.

## Tests

`core/agent/tests/test_repo_ref_host.py` (new, 67 cases). The load-bearing assertion in the refusal
tests is not the error — it is that **no subprocess ever ran**: `subprocess.run` and `subprocess.Popen`
are replaced with a bomb, so a gate that fired after git started would fail loudly rather than pass on
the message. Covers 16 internal-host forms and 7 public ones through `_git_clone` and through the
route gate; `ext::`, `file://`, `git://`, `ftp://` and server paths; the IPv4-mapped-IPv6 regression
(`IPv6Address('::ffff:127.0.0.1').is_loopback` is **False** — the flag describes `::1`, not what the
address maps to, so the check unwraps the mapping first); the opt-in local root and traversal out of
it; and end-to-end proof against the real `git` that the pinned env is what stops a transport.

`tests/test_api.py` gains a route-level case asserting `/api/workspace/swap` and
`/api/workspace/activate` return 400 for all eight shapes with git bombed out.

```
$ cd core/agent && uv run pytest -q
587 passed, 1 warning in 35.76s
```

```
$ node scripts/check-isolation-py.mjs --mode=isolation      ✅ 131 src/*.py across 8 packages
$ node scripts/check-isolation-py.mjs --mode=graph          ✅ 2 cross-package edges acyclic + allow-listed
$ node scripts/check-isolation-py.mjs --mode=test-isolation ✅ 147 tests/*.py across 8 packages
```

14 pre-push static gates green. No container workload was run for this change.

Three existing tests needed a one-line opt-in rather than a rewrite: `test_api.py`'s swap/activate
round-trips and `test_workspace_publish.py` clone from and push to a local bare repo to stay off the
network, which is exactly the case `VEXA_ALLOW_LOCAL_REPO_ROOT` names. One assertion in
`test_workspace_publish.py` moved from `file://<path>` to `<path>`, since an explicit file transport
is now refused as a caller-supplied push target.

Refs DmitriyG228/biz#451

## Contribution rights

- [x] **Independent:** I created this contribution, or otherwise have the right to submit it
  under Apache-2.0, and it is not owned or controlled by an employer, client, or other entity.
  <!-- rights:independent -->
- [ ] **Employer/client authorization required.** <!-- rights:corporate -->
- [ ] **Unsure.** <!-- rights:uncertain -->

<!-- vexa-agent -->

