### PR TITLE
[BUSINESS] docs: hosted welcome credit $5 -> $2

### DIFF
--- a/docs/docs/how-to/send-a-bot.mdx
+++ b/docs/docs/how-to/send-a-bot.mdx
@@ -25,7 +25,7 @@ curl -X POST "https://api.cloud.vexa.ai/bots" \
 `native_meeting_id` is the id inside the join URL — `abc-defg-hij` in
 `https://meet.google.com/abc-defg-hij`.
 
-New accounts get **$5 of free bot credit and no credit card is required** — about 16 hours of bot
+New accounts get **$2 of free bot credit and no credit card is required** — about 6 hours of bot
 time at $0.30/hr ([pricing](https://vexa.ai/pricing)).
 
 ### Self-hosted

--- a/docs/docs/quickstart.mdx
+++ b/docs/docs/quickstart.mdx
@@ -15,8 +15,8 @@ curl -X POST "https://api.cloud.vexa.ai/bots" \
 ```
 
 `native_meeting_id` is the id inside the join URL — `abc-defg-hij` in
-`https://meet.google.com/abc-defg-hij`. New accounts get **$5 of free bot credit and no credit card
-is required** — about 16 hours of bot time at $0.30/hr ([pricing](https://vexa.ai/pricing)). More
+`https://meet.google.com/abc-defg-hij`. New accounts get **$2 of free bot credit and no credit card
+is required** — about 6 hours of bot time at $0.30/hr ([pricing](https://vexa.ai/pricing)). More
 calls: [Send a bot](/how-to/send-a-bot).
 
 The rest of this page self-hosts the whole stack, which is how you get the agent plane as well.


### PR DESCRIPTION
Founder ruling 2026-09-04: the free PAYG welcome credit drops from **$5 to $2**.

**DRAFT. Not merged. NOT PUBLISHED — publishing docs.vexa.ai is an outbound publication and needs the founder's explicit go on the exact rendered text before this merges.**

## COMMITMENTS IN THIS DRAFT

| # | Kind | Verbatim | Decide |
|---|---|---|---|
| 1 | **Published terms** | Two public docs pages will state **"$2 of free bot credit and no credit card is required — about 6 hours of bot time at $0.30/hr"** (was $5 / about 16 hours) | yes / no |

Nothing else. No money out, no date, no right granted.

## Changed

| File | Old | New |
|---|---|---|
| `docs/docs/quickstart.mdx` | `$5 of free bot credit … about 16 hours of bot time at $0.30/hr` | `$2 … about 6 hours` |
| `docs/docs/how-to/send-a-bot.mdx` | same | same |

## Left unchanged

~20 docs pages carry the shared line *"free credit, no card"* with **no amount** — nothing to change there. `docs/docs/` contains no other statement of the credit amount.

## Reported, not edited

`README.md` line 63 in this repo still reads *"New accounts get **$5 of free bot credit, no card required** — about 16 hours of bot time at…"*. That is a **hosted-pricing statement in the OSS tree** and was deliberately left alone in this pass — it needs its own decision about who owns hosted-pricing copy in the OSS README.

## Publishing mechanics

Mintlify auto-builds on push to its tracked repo+branch+path. Pushing this branch does **not** change the live site; merging to the tracked branch does. Per `vexa-docs`, the tracked config may still be the legacy pre-0.12 site — confirm before assuming a merge publishes.

**NOT VERIFIED:** no local `mint dev` preview run, live site not checked.

<!-- vexa-agent -->
