### PR TITLE
deps: floor undici to 7.29.0 — last five Dependabot alerts on the lockfile

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,7 @@ overrides:
   brace-expansion@1: '>=1.1.18'
   sharp@<0.35.0: '>=0.35.0'
   protobufjs@>=7.5.0 <7.6.5: ^7.6.5
+  undici@>=7.0.0 <7.29.0: ^7.29.0
 
 importers:
 
@@ -3124,8 +3125,8 @@ packages:
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
-  undici@7.28.0:
-    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
+  undici@7.29.0:
+    resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==}
     engines: {node: '>=20.18.1'}
 
   unified@11.0.5:
@@ -4822,7 +4823,7 @@ snapshots:
       saxes: 6.0.0
       symbol-tree: 3.2.4
       tough-cookie: 6.0.1
-      undici: 7.28.0
+      undici: 7.29.0
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
@@ -6047,7 +6048,7 @@ snapshots:
 
   undici-types@6.21.0: {}
 
-  undici@7.28.0: {}
+  undici@7.29.0: {}
 
   unified@11.0.5:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -52,3 +52,6 @@ overrides:
   # protobufjs >=7.5.0 <=7.6.4: DoS via infinite loop. Enters via onnxruntime-web under
   # @huggingface/transformers. Held to ^7 — 8.x is a major bump transformers has not adopted.
   "protobufjs@>=7.5.0 <7.6.5": "^7.6.5"
+  # undici >=7.0.0 <7.29.0: one high + four moderate advisories. Dev-only here (jsdom under
+  # vitest in the terminal and join packages), but Dependabot scores the lockfile, not the scope.
+  "undici@>=7.0.0 <7.29.0": "^7.29.0"


### PR DESCRIPTION
**COMMITMENTS IN THIS DRAFT — none.**

Follows #1541 / #1542. After those merged, Dependabot on the default branch still reported five alerts, all `undici` 7.28.0 (GHSA-4cwx-7wf7-3272 high; GHSA-m8rv-5g2x-5cg5, GHSA-v3r7-h72x-cjcm, GHSA-jr45-8vmc-qm54, GHSA-8xcm-r25x-g524 moderate). Dev-only (jsdom under vitest in `@vexa/terminal` and `@vexa/join`), so `pnpm audit --prod` was already clean, but Dependabot scores the lockfile, not the scope — and FINOS's pre-transfer scan reads the same lockfile.

One override in `pnpm-workspace.yaml` (same style as the existing block), lockfile refreshed.

- `pnpm why undici` → 7.29.0
- `pnpm audit` (all scopes) → No known vulnerabilities found
- `pnpm gate:licenses` → 459 deps OSS-clean, same two Cat-B exceptions

`docs: none` — lockfile-only, no surface change.

Refs DmitriyG228/biz#451

## Contribution rights

- [x] **Independent:** I created this contribution, or otherwise have the right to submit it
  under Apache-2.0, and it is not owned or controlled by an employer, client, or other entity.
  <!-- rights:independent -->
- [ ] **Employer/client authorization required.** <!-- rights:corporate -->
- [ ] **Unsure.** <!-- rights:uncertain -->

<!-- vexa-agent -->