### PR TITLE
mcp: whats_waiting tells agents when to call it; no duplicated description

### DIFF
--- a/core/flows/src/flows_integrations/flows_api.py
+++ b/core/flows/src/flows_integrations/flows_api.py
@@ -981,37 +981,53 @@ def mcp_tools_manifest():
 import flows_queue as _flows_queue  # noqa: E402
 
 
-@app.get("/queue/waiting")
+# THE ONLY TEXT AN AGENT READS BEFORE DECIDING TO CALL THIS, and it says WHEN — which is the one
+# thing the route's own mechanics could never say. Ten ordinary sessions with the tools loaded
+# never called `whats_waiting`: they were served this route's implementation notes, and a tool
+# described by its implementation reads as something for somebody else. Header precedence and
+# status codes answer "how do I call it correctly", a question an agent that never calls it does
+# not have.
+#
+# IT IS A `summary`, AND THE ROUTE CARRIES NO DOCSTRING ON PURPOSE. The MCP edge derives a tool's
+# description from this route's OpenAPI operation, preferring the docstring and falling back to
+# the summary (`core/meetings/services/mcp/src/vexa_mcp/bind.py::_describe`). A docstring here
+# would therefore be served to every agent, in front of every call, forever. The maintainer's
+# half lives in the comment block below instead, where no agent pays for it by the token.
+WHATS_WAITING_SUMMARY = (
+    "What your person's Vexa needs right now — call it at the start of a session, after "
+    "connecting, and whenever they mention a meeting; each item's `say` is what to tell them. "
+    "Returns the queue for the authenticated caller.")
+
+# ── how this route resolves its subject (maintainer's half; deliberately not agent-facing) ─────
+#
+# THE SUBJECT IS THE AUTHENTICATED CALLER'S, and there are two ways to be one.
+#
+# A PERSON authenticates with their own Vexa credential and their subject is resolved from it
+# (issue #1468). Nothing they send can move it: a `subject` argument naming anyone else is 403,
+# and an `X-User-Id` header is ignored outright. That header is a string a caller can type, and
+# it is only ever evidence because the OPERATOR key gates it — a service vouching for a person it
+# resolved. A verified credential is stronger evidence than any header, so it wins.
+#
+# THE OPERATOR reads one person's queue on their behalf, and keeps exactly the behaviour this
+# route shipped with: `X-User-Id` is the gateway's answer and outranks `?subject=`, and
+# `?subject=` is the unstamped console read. Neither ever answers with the instance — no subject
+# at all is a 400, because this route answers for ONE person or for nobody.
+#
+# The distinction matters because this route is NOT always behind the gateway: reached through
+# the MCP edge it is addressed directly, and that edge stamps no `X-User-Id` at all — it forwards
+# the caller's own credential, which is the whole reason a person's credential has to open the
+# door here.
+#
+# Not opened by `VEXA_FLOWS_TIMELINE_KEY`: that key is documented as opening the timeline and
+# nothing else, and quietly widening a key's reach is how a narrow credential stops being narrow.
+#
+# The answer is DATA plus behavior's words: every sentence a person hears is resolved from
+# `behavior/queue/`, read hot, never from this body. See `flows_queue` for why silence there is
+# the filter rather than a keyword list here.
+@app.get("/queue/waiting", summary=WHATS_WAITING_SUMMARY)
 def queue_waiting(subject: str = "", limit: int = 50,
                   x_user_id: str = Header(default=""),
                   caller: Caller = Depends(subject_or_operator)):
-    """WHAT IS WAITING FOR THIS PERSON — pending reactions, with the flow that produced each.
-
-    THE SUBJECT IS THE AUTHENTICATED CALLER'S, and there are two ways to be one.
-
-    A PERSON authenticates with their own Vexa credential and their subject is resolved from it
-    (issue #1468). Nothing they send can move it: a `subject` argument naming anyone else is 403,
-    and an `X-User-Id` header is ignored outright. That header is a string a caller can type, and
-    it is only ever evidence because the OPERATOR key gates it — a service vouching for a person it
-    resolved. A verified credential is stronger evidence than any header, so it wins.
-
-    THE OPERATOR reads one person's queue on their behalf, and keeps exactly the behaviour this
-    route shipped with: `X-User-Id` is the gateway's answer and outranks `?subject=`, and
-    `?subject=` is the unstamped console read. Neither ever answers with the instance — no subject
-    at all is a 400, because this route answers for ONE person or for nobody.
-
-    The distinction matters because this route is NOT always behind the gateway: reached through
-    the MCP edge it is addressed directly, and that edge stamps no `X-User-Id` at all — it forwards
-    the caller's own credential, which is the whole reason a person's credential has to open the
-    door here.
-
-    Not opened by `VEXA_FLOWS_TIMELINE_KEY`: that key is documented as opening the timeline and
-    nothing else, and quietly widening a key's reach is how a narrow credential stops being narrow.
-
-    The answer is DATA plus behavior's words: every sentence a person hears is resolved from
-    `behavior/queue/`, read hot, never from this body. See `flows_queue` for why silence there is
-    the filter rather than a keyword list here.
-    """
     who = scoped_subject(caller, subject)
     if caller.is_admin:
         who = (x_user_id or "").strip() or who

--- a/core/flows/tests/test_friction.py
+++ b/core/flows/tests/test_friction.py
@@ -400,8 +400,19 @@ def test_the_route_description_reads_as_instructions_not_as_a_title(api):
 
 
 def test_every_flows_tool_the_manifest_publishes_says_more_than_its_own_name(api):
-    """The defect CLASS, not the instance: any route in `mcp.tools.v1.json` with no docstring
-    publishes an MCP tool described by nothing but its own title."""
+    """The defect CLASS, not the instance: any route in `mcp.tools.v1.json` that publishes an MCP
+    tool described by nothing but its own title.
+
+    MEASURED ON THE TEXT THE AGENT RECEIVES, not on the docstring. This used to read
+    `op["description"]` alone, which silently asserted that a route's agent-facing words must be
+    its DOCSTRING — and `whats_waiting` is the case that proves they must not be: an agent needs
+    to be told WHEN to call a tool, and the docstring holds header precedence, operator keys and
+    status codes, which answer a question an agent that never calls it does not have. So that
+    route now carries its words in `summary` and no docstring at all.
+
+    The edge composes exactly this way (`vexa_mcp/bind.py::_describe`): the description leads, and
+    the summary is used when there is no description. A gate that reads one field would go on
+    passing while the other one shipped a two-word title."""
     import json as _json
     import pathlib
 
@@ -413,8 +424,11 @@ def test_every_flows_tool_the_manifest_publishes_says_more_than_its_own_name(api
     for tool in manifest["tools"]:
         route = tool["route"]
         op = spec["paths"][route["path"]][route["method"].lower()]
-        body = (op.get("description") or "").strip()
-        if len(body) < 120:
+        # What `_describe` would hand the agent, by the same rule the edge uses.
+        body = (op.get("description") or "").strip() or (op.get("summary") or "").strip()
+        # A FastAPI-synthesised summary IS the function's own title — never instructions.
+        synthesised = route["path"].strip("/").replace("/", " ").replace("_", " ").title()
+        if len(body) < 120 or body.title() == synthesised:
             thin.append((tool["name"], op.get("summary"), len(body)))
     assert not thin, f"tools described by little more than their own title: {thin}"
 

--- a/core/flows/tests/test_whats_waiting_description.py
+++ b/core/flows/tests/test_whats_waiting_description.py
@@ -1,0 +1,109 @@
+"""The words an agent reads before it decides to call `whats_waiting`.
+
+Ten ordinary sessions with the tools loaded never called it. The description they were served was
+this route's IMPLEMENTATION NOTES — `X-User-Id` versus `?subject=` precedence, operator keys,
+403/400 shapes, `VEXA_FLOWS_TIMELINE_KEY` — about 250 words that answer *how do I call this
+correctly*, a question an agent that never calls it does not have. Nothing anywhere said WHEN.
+
+So the route now carries an explicit `summary` written for the agent, and NO docstring: the MCP
+edge derives a tool's description from this operation, preferring the docstring and falling back
+to the summary (`core/meetings/services/mcp/src/vexa_mcp/bind.py::_describe`), so a docstring here
+is served to every agent in front of every call, forever. The maintainer's half moved to a comment
+block above the route, where no agent pays for it by the token.
+
+Asserted against the SOURCE, not by importing the module: importing `flows_integrations.flows_api`
+opens a Postgres connection and mints an API key at import time, which is why no test in this
+suite imports it.
+"""
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+SRC = Path(__file__).resolve().parents[1] / "src"
+API = SRC / "flows_integrations" / "flows_api.py"
+
+
+def _module() -> ast.Module:
+    return ast.parse(API.read_text(encoding="utf-8"))
+
+
+def _route(name: str) -> ast.FunctionDef:
+    for node in _module().body:
+        if isinstance(node, ast.FunctionDef) and node.name == name:
+            return node
+    raise AssertionError(f"{name} is not a route in flows_api.py any more")
+
+
+def _summary_constant() -> str:
+    """`WHATS_WAITING_SUMMARY`, evaluated from the source without importing the module."""
+    for node in _module().body:
+        if isinstance(node, ast.Assign) and any(
+                isinstance(t, ast.Name) and t.id == "WHATS_WAITING_SUMMARY" for t in node.targets):
+            return ast.literal_eval(node.value)
+    raise AssertionError("WHATS_WAITING_SUMMARY is gone — the agent-facing description with it")
+
+
+def test_the_route_declares_an_explicit_agent_facing_summary():
+    """Without one, FastAPI synthesises `summary` from the function name and the tool ships
+    described as "Queue Waiting" — a title, printed where instructions belong."""
+    route = _route("queue_waiting")
+    decorators = [d for d in route.decorator_list if isinstance(d, ast.Call)]
+    assert decorators, "queue_waiting lost its route decorator"
+    kwargs = {k.arg: k.value for d in decorators for k in d.keywords}
+    assert "summary" in kwargs, "the route must set `summary=` itself, not let FastAPI title it"
+    assert isinstance(kwargs["summary"], ast.Name)
+    assert kwargs["summary"].id == "WHATS_WAITING_SUMMARY"
+
+
+def test_the_summary_says_WHEN_to_call_it():
+    """The one thing the route's own mechanics could never say, and the whole reason it exists."""
+    summary = _summary_constant().lower()
+    assert "call it" in summary
+    assert "start of a session" in summary
+    # `say` is the field an agent reads out; a description that omits it leaves the agent holding
+    # a queue it does not know how to voice.
+    assert "say" in summary
+
+
+def test_the_summary_is_one_short_paragraph():
+    """An agent reads this in front of every call. ≤60 words, one paragraph."""
+    summary = _summary_constant()
+    assert "\n" not in summary.strip(), "one paragraph — a second one is the description's job"
+    assert len(summary.split()) <= 60, f"{len(summary.split())} words is a document, not a lede"
+
+
+def test_the_route_carries_no_docstring():
+    """A docstring here becomes the OpenAPI `description`, which the MCP edge prefers over the
+    summary — so the operator mechanics would be back in front of every agent, silently."""
+    assert ast.get_docstring(_route("queue_waiting")) is None
+
+
+def test_no_operator_or_transport_mechanics_reach_the_agent():
+    """The 250 words that were served instead of instructions. Each of these is a maintainer's
+    concern; an agent calling this tool with its own credential meets none of them."""
+    summary = _summary_constant()
+    for leak in ("X-User-Id", "?subject=", "VEXA_FLOWS_TIMELINE_KEY", "403", "400",
+                 "operator", "header", "credential"):
+        assert leak.lower() not in summary.lower(), f"{leak!r} is maintainer's prose, not the lede"
+
+
+def test_the_agent_facing_summary_is_billing_free():
+    """Money is a different seam. Nothing about plans or price belongs in the first tool an agent
+    is told to call."""
+    summary = _summary_constant().lower()
+    for word in ("plan", "price", "pricing", "billing", "paid", "quota", "upgrade",
+                 "subscription", "credit", "trial", "$"):
+        assert word not in summary, f"{word!r} puts money in the queue's description"
+
+
+def test_the_maintainers_half_survived_the_move():
+    """Moved, not deleted. Every sentence the docstring carried is still beside the route — as a
+    comment, which reaches a reader of this file and no agent anywhere."""
+    src = API.read_text(encoding="utf-8")
+    head = src[:src.index("def queue_waiting")]
+    comments = "\n".join(re.findall(r"^\s*#.*$", head, flags=re.M))
+    for kept in ("X-User-Id", "?subject=", "VEXA_FLOWS_TIMELINE_KEY",
+                 "THE SUBJECT IS THE AUTHENTICATED CALLER'S", "issue #1468"):
+        assert kept in comments, f"{kept!r} was dropped rather than moved"

--- a/core/meetings/services/mcp/src/vexa_mcp/register.py
+++ b/core/meetings/services/mcp/src/vexa_mcp/register.py
@@ -201,8 +201,16 @@ def _add(app: FastAPI, bt: BoundTool, base: str,
     endpoint.__name__ = bt.name
     endpoint.__doc__ = bt.description or f"{bt.tool.domain}: {method} {template}"
     endpoint.__signature__ = _signature(bt)
+    # ONE TEXT, ONE KEY. This used to pass `bt.description` as BOTH `summary` and `description`,
+    # and `fastapi_mcp` composes a tool's description as `summary + "\n\n" + description`
+    # (`openapi/convert.py`) with no check that the two differ — so every assembled tool published
+    # its whole text TWICE, back to back. On `whats_waiting` that was ~250 words, then the same
+    # ~250 words, and the second copy said nothing the first had not.
+    #
+    # The description is the words. A summary that merely restates them is not a summary, so this
+    # sets none and lets FastAPI title the route from its name — two words, in front of the text,
+    # which is the shape `fastapi_mcp` is written for.
     app.add_api_route(f"/tools/{bt.name}", endpoint, methods=[method],
                       operation_id=bt.name, name=bt.name,
-                      summary=bt.description or None,
                       description=bt.description or None)
     return bt.name

--- a/core/meetings/services/mcp/tests/test_assembled_surface.py
+++ b/core/meetings/services/mcp/tests/test_assembled_surface.py
@@ -26,9 +26,17 @@ FLOWS_OPENAPI = {"paths": {
         {"name": "status", "in": "query", "schema": {"type": "string"}},
         {"name": "subject", "in": "query", "schema": {"type": "string"}}]}},
     "/reactions/{reaction_id}/{verb}": {"post": {"summary": "Steer one reaction", "parameters": []}},
-    "/queue/waiting": {"get": {"summary": "What is waiting for this person", "parameters": [
-        {"name": "subject", "in": "query", "schema": {"type": "string"}},
-        {"name": "limit", "in": "query", "schema": {"type": "integer"}}]}},
+    # Spelled the way flows-api ACTUALLY publishes it: an explicit agent-facing `summary` and NO
+    # docstring, so nothing operator-facing reaches the tool. The old fixture wrote a six-word
+    # hand-made summary, which is why this suite was green while agents were served 250 words of
+    # header-precedence prose — twice.
+    "/queue/waiting": {"get": {
+        "summary": ("What your person's Vexa needs right now — call it at the start of a session, "
+                    "after connecting, and whenever they mention a meeting; each item's `say` is "
+                    "what to tell them. Returns the queue for the authenticated caller."),
+        "parameters": [
+            {"name": "subject", "in": "query", "schema": {"type": "string"}},
+            {"name": "limit", "in": "query", "schema": {"type": "integer"}}]}},
     "/timeline": {"get": {"summary": "One person's day, in order", "parameters": [
         {"name": "subject", "in": "query", "schema": {"type": "string"}},
         {"name": "since", "in": "query", "schema": {"type": "string"}},
@@ -173,3 +181,34 @@ def test_no_assembled_tool_takes_a_credential_argument():
         props = set(((t.inputSchema if hasattr(t, "inputSchema") else t.input_schema) or {})
                     .get("properties", {}))
         assert not (props & banned), f"{t.name} takes {sorted(props & banned)}"
+
+
+# ── the same words, twice, back to back (2026-09-04) ────────────────────────────────────────────
+# `register.py` published `bt.description` as BOTH `summary` and `description` on the re-registered
+# route, and `fastapi_mcp` composes a tool's description as `summary + "\n\n" + description`
+# (`openapi/convert.py`) with no check that the two differ. So every assembled tool served its
+# whole text twice: on `whats_waiting`, ~250 words and then the same ~250 words.
+#
+# NOTHING UPSTREAM WAS WRONG, which is why no existing test could see it — the fixtures all set
+# `summary` or `description`, never both, and the surviving assertions used `in` rather than a
+# count, and `"X" in "X\n\nX"` is true.
+
+
+def test_no_assembled_tool_says_the_same_thing_twice():
+    app = _boot(FLOWS_API_URL="http://flows")
+    for t in app.state.mcp.tools:
+        halves = (t.description or "").strip().split("\n\n")
+        assert len(halves) < 2 or halves[0].strip() != halves[1].strip(), (
+            f"{t.name} publishes its description twice, back to back")
+
+
+def test_whats_waiting_tells_the_agent_when_to_call_it_exactly_once():
+    """The tool the MCP server's own instructions open with. It now says WHEN, and says it once."""
+    app = _boot(FLOWS_API_URL="http://flows")
+    tool = next(t for t in app.state.mcp.tools if t.name == "whats_waiting")
+    body = tool.description or ""
+    assert "call it at the start of a session" in body
+    assert body.count("call it at the start of a session") == 1, "served twice, back to back"
+    # The maintainer's half stayed upstream: none of it is in front of the agent.
+    for leak in ("X-User-Id", "VEXA_FLOWS_TIMELINE_KEY", "403"):
+        assert leak not in body


### PR DESCRIPTION
The `whats_waiting` tool description served to agents was the flows-api `queue_waiting` docstring — ~250 words on `X-User-Id` vs `?subject=` precedence, operator keys, 403/400 shapes and `VEXA_FLOWS_TIMELINE_KEY` — emitted twice, back to back, and it never said WHEN to call. Ten ordinary sessions with the tools loaded never called it.

The route now carries an explicit agent-facing `summary` and no docstring; the operator mechanics move to a comment beside it. `register.py` published `bt.description` as both `summary` and `description`, and `fastapi_mcp` concatenates the two — hence the doubling; it now sets one.

Tests: flows 518 passed (+7); MCP 245 passed.

<!-- vexa-agent -->
