### PR TITLE
mcp: standing notices ride meeting tool results; flows: notice-flagged queue items

### DIFF
--- a/behavior/queue/README.md
+++ b/behavior/queue/README.md
@@ -34,6 +34,32 @@ So: adding a file is how a situation becomes person-facing, and deleting one is 
 are commits here, and neither is a deploy. The count of silent reactions comes back as `quiet`, so
 an operator can always tell *nothing is happening* from *behavior is saying nothing about it*.
 
+## Front-matter: `notice: true`
+
+A file may open with a fenced block of `key: value` lines. There is one key:
+
+```markdown
+---
+notice: true
+---
+Whatever a person's agent should keep in front of it.
+```
+
+**A notice is something that stays TRUE BETWEEN calls, not something that just happened.** An
+ordinary item is read when an agent asks what is waiting. A notice is read alongside whatever the
+agent was already doing: `GET /queue/notices` returns just these files' words, it is small enough
+to ask on every call, and the MCP edge carries the answer out on the results of the meeting tools
+(`core/meetings/services/mcp/src/vexa_mcp/notices.py`). So the same sentence reaches an agent that
+never asked — which is the point, and also the reason to flag almost nothing.
+
+Everything else stays as it is: a flagged file is still an ordinary item on `GET /queue/waiting`
+(now carrying `notice: true`), the lookup is unchanged, and a file with no front-matter — which is
+every file written before this existed — declares nothing and behaves exactly as it did.
+
+Two behaviours worth knowing: **a value that is not `true`/`yes`/`on`/`1` means no** (a flag nobody
+can read is off, never guessed on), and **an unparseable fence leaves the words intact and the flag
+off** — the failure of a flag must never be the failure of a sentence a person was owed.
+
 ## What is deliberately not here
 
 There is **no first-run friction ask** (ruling 8/9, 2026-09-03): *a flow that fires once per person

--- a/core/flows/src/flows_integrations/flows_api.py
+++ b/core/flows/src/flows_integrations/flows_api.py
@@ -14,6 +14,11 @@
                                     reactions, each naming the flow that produced it and its
                                     typed reason (PRD decision 42.2). The subject is the
                                     authenticated caller's, never an argument.
+  GET  /queue/notices               THE STANDING NOTICES ONLY — the say text of the waiting items
+                                    whose copy declared itself one (`notice: true` in a
+                                    `behavior/queue/` file's front-matter). Same door as
+                                    /queue/waiting, a much smaller answer: it is built to be asked
+                                    on every call and to ride along with unrelated work.
   GET  /timeline?subject=…          ONE PERSON'S DAY, in order — facts, receipts and the
                                     meetings table merged and scoped to them (PRD decision 31).
                                     Read-only, and it takes the operator key OR the narrower
@@ -23,7 +28,7 @@ AUTH, TWO TIERS — because two different callers reach this surface and only on
 operator (issue #1468):
 
   * THE SUBJECT-SCOPED ROUTES (`GET /flows`, `GET /reactions`, `POST /reactions/{id}/{verb}`,
-    `GET /queue/waiting`, `GET /timeline`) take EITHER the operator key OR a person's own Vexa
+    `GET /queue/waiting`, `GET /queue/notices`, `GET /timeline`) take EITHER the operator key OR a person's own Vexa
     credential, as a bearer or `X-API-Key`. With a person's credential the subject is DERIVED from
     it, through identity's `/internal/validate` — the one resolver, the same one the gateway asks
     (P23) — and a `subject` argument naming anyone else is refused rather than honoured. The MCP
@@ -1024,6 +1029,40 @@ def queue_waiting(subject: str = "", limit: int = 50,
              for f in vocab.flows.values()]
     return _flows_queue.waiting(db, subject=who, flows=flows,
                                 limit=max(1, min(int(limit), 200)))
+
+
+@app.get("/queue/notices")
+def queue_notices(subject: str = "", limit: int = 50,
+                  x_user_id: str = Header(default=""),
+                  caller: Caller = Depends(subject_or_operator)):
+    """THIS PERSON'S STANDING NOTICES — the say text of each waiting item whose copy declared itself
+    one, and nothing else.
+
+    A standing notice is something that stays true BETWEEN calls rather than something that just
+    happened, so a caller is meant to read it alongside whatever it was already doing rather than
+    go looking for it. That is why this answer is the smallest one this surface has: a list of
+    sentences, no reaction ids, no flow names, no steps, no typed reasons — cheap enough to ask on
+    every call. A caller that wants any of those wants `GET /queue/waiting`.
+
+    WHICH ITEMS ARE NOTICES IS BEHAVIOR'S TO DECIDE, not this route's and not any caller's: a
+    say-file under `behavior/queue/` opens with `notice: true` in its front-matter, or it does not.
+    That is an admin's file and an admin's edit with no deploy on either side of it — the same file
+    and the same edit that already decide whether an item is spoken at all (`flows_queue`,
+    `behavior/queue/README.md`). No word of any notice is written here or anywhere in this image.
+
+    Same door as `GET /queue/waiting`, in every particular: a person is resolved from their own
+    credential and cannot name anyone else, an operator passes `?subject=` or the gateway stamps
+    `X-User-Id`, and no subject at all is a 400 because this route answers for ONE person.
+    """
+    who = scoped_subject(caller, subject)
+    if caller.is_admin:
+        who = (x_user_id or "").strip() or who
+    if not who:
+        raise HTTPException(status_code=400, detail=(
+            "no subject — this route answers for ONE person. A person is resolved from their own "
+            "credential; an operator passes ?subject=<uid|email>, or the gateway stamps "
+            "X-User-Id."))
+    return _flows_queue.notices(db, subject=who, limit=max(1, min(int(limit), 200)))
 
 
 # THE ENTRYPOINT GUARD IS THE LAST THING IN THIS MODULE, and that is load-bearing rather than

--- a/core/flows/src/flows_queue.py
+++ b/core/flows/src/flows_queue.py
@@ -158,7 +158,59 @@ def _roots() -> list[pathlib.Path]:
     return out
 
 
-def say(flow: str, reason_type: str) -> str:
+#: The front-matter fence a say-file may open with. Everything about it is deliberately small: one
+#: `key: value` per line, between two `---` rules, at the very top or not at all.
+_FENCE = "---"
+#: The words that mean yes. A value this does not recognise means NO — a flag nobody can read is a
+#: flag that is off, never one that is guessed on.
+_TRUE = frozenset({"true", "yes", "on", "1"})
+
+
+class Say(str):
+    """A say-file's words, plus the attributes its front-matter declared.
+
+    A `str` SUBCLASS rather than a pair, and that is the whole compatibility story: every existing
+    caller of `say()` — the projection, the tests, anything a private tree wires in — keeps getting
+    something that compares, formats and serialises as the text it always was. The attributes ride
+    on it for the callers that ask.
+    """
+
+    notice: bool = False
+
+    def __new__(cls, text: str = "", *, notice: bool = False) -> "Say":
+        self = super().__new__(cls, text)
+        self.notice = bool(notice)
+        return self
+
+
+def parse(raw: str) -> Say:
+    """A say-file's text, with its front-matter read off the top.
+
+    A file with no fence is its own text and declares nothing, which is every file written before
+    this existed — the flag is ADDITIVE by construction, so a behavior tree that never heard of it
+    behaves exactly as it did.
+
+    UNPARSEABLE IS UNFLAGGED, NEVER UNSPOKEN. A fence that never closes, or a line that is not
+    `key: value`, leaves the words intact and the attributes at their defaults: the failure of a
+    flag must never be the failure of the sentence a person was owed.
+    """
+    text = (raw or "").strip()
+    if not text.startswith(_FENCE):
+        return Say(text)
+    lines = text.splitlines()
+    close = next((i for i in range(1, len(lines)) if lines[i].strip() == _FENCE), None)
+    if close is None:                      # a fence that never closes is not front-matter
+        return Say(text)
+    attrs = {}
+    for line in lines[1:close]:
+        key, sep, value = line.partition(":")
+        if sep and key.strip():
+            attrs[key.strip().lower()] = value.strip().strip("\"'")
+    body = "\n".join(lines[close + 1:]).strip()
+    return Say(body, notice=attrs.get("notice", "").lower() in _TRUE)
+
+
+def say(flow: str, reason_type: str) -> Say:
     """What a person hears about this item, or "" when behavior has nothing to say about it.
 
     "" IS AN ANSWER, and it is the filter (see the module docstring): a pending reaction behavior
@@ -169,6 +221,9 @@ def say(flow: str, reason_type: str) -> str:
     The flow-and-type key rather than a flow key: *"the write-up is being prepared"* and *"the
     write-up failed"* are the same flow and opposite sentences, and a file keyed on the flow alone
     would say the first one to somebody the second had happened to.
+
+    The returned :class:`Say` is a string carrying whatever the file's front-matter declared — see
+    `parse`, and `behavior/queue/README.md` for the one attribute there is.
     """
     for name in (f"{flow}.{reason_type}.md", f"_{reason_type}.md"):
         for root in _roots():
@@ -177,10 +232,39 @@ def say(flow: str, reason_type: str) -> str:
                 if f.is_file():
                     text = f.read_text(encoding="utf-8").strip()
                     if text:
-                        return text
+                        return parse(text)
             except OSError:                # an unreadable mount is not a reason to fail a read
                 continue
-    return ""
+    return Say("")
+
+
+def _spoken(rows: list, copy: Optional[Callable]) -> tuple:
+    """``(items, quiet)`` — the rows behavior has words for, and the count of the ones it does not.
+
+    ONE reader of the copy tree for both projections below, so `waiting` and `notices` can never
+    disagree about which items are spoken or about what they say.
+
+    `copy` is the injection seam the tests already use and it may hand back a plain string, which
+    is what every caller wrote before front-matter existed; `Say` normalises it to an unflagged one.
+    """
+    speak = copy or say
+    items, quiet = [], 0
+    for r in rows:
+        words = speak(r["flow"], r["reason"]["type"])
+        if not words:
+            quiet += 1
+            continue
+        words = words if isinstance(words, Say) else Say(words)
+        items.append({"id": r["reaction_id"], "flow": r["flow"],
+                      "flow_version": r["flow_version"], "step": r["step"],
+                      "status": r["status"], "reason": r["reason"],
+                      "since": r["updated_at"], "next_run_at": r["next_run_at"],
+                      "say": str(words),
+                      # DECLARED BY THE COPY, and therefore by an admin's file rather than by a
+                      # deploy — the same place, and the same edit, that decides whether an item is
+                      # spoken at all. See `behavior/queue/README.md`.
+                      "notice": words.notice})
+    return items, quiet
 
 
 def waiting(db, *, subject: str, flows: Optional[list] = None, now: Optional[float] = None,
@@ -197,19 +281,31 @@ def waiting(db, *, subject: str, flows: Optional[list] = None, now: Optional[flo
     if rows is None:
         return {"subject": subject, "unresolved": True, "waiting": 0, "items": [],
                 "quiet": 0, "flows": flows or []}
-    speak = copy or say
-    items, quiet = [], 0
-    for r in rows:
-        words = speak(r["flow"], r["reason"]["type"])
-        if not words:
-            quiet += 1
-            continue
-        items.append({"id": r["reaction_id"], "flow": r["flow"],
-                      "flow_version": r["flow_version"], "step": r["step"],
-                      "status": r["status"], "reason": r["reason"],
-                      "since": r["updated_at"], "next_run_at": r["next_run_at"],
-                      "say": words})
+    items, quiet = _spoken(rows, copy)
     return {"subject": subject, "waiting": len(items), "items": items,
             # COUNTED, NOT HIDDEN: an operator asking why a queue is short must be able to tell
             # "nothing is happening" from "behavior is silent about what is happening".
             "quiet": quiet, "flows": flows or []}
+
+
+def notices(db, *, subject: str, now: Optional[float] = None, limit: int = 50,
+            identity: Optional[Callable] = None, copy: Optional[Callable] = None) -> dict:
+    """THE STANDING NOTICES only — the say text of every waiting item whose copy declared itself one.
+
+    A SEPARATE, SMALLER ANSWER rather than a filter over `waiting`, because of WHO CALLS IT and how
+    often: this is meant to ride along with unrelated work, on every call, so it answers with the
+    least it can — a list of strings — and carries no reaction ids, no flow names, no steps and no
+    typed reasons. A caller that wants any of those wants `waiting`, and should ask for it.
+
+    DEDUPED, IN ORDER. Two reactions of the same flow resolve to the same file and would otherwise
+    say the identical sentence twice in one result, which reads as two different things being true.
+    """
+    rows = pending(db, subject=subject, now=now, limit=limit, identity=identity)
+    if rows is None:
+        return {"subject": subject, "unresolved": True, "notices": []}
+    items, _ = _spoken(rows, copy)
+    out = []
+    for item in items:
+        if item["notice"] and item["say"] not in out:
+            out.append(item["say"])
+    return {"subject": subject, "notices": out}

--- a/core/flows/tests/test_queue_notices.py
+++ b/core/flows/tests/test_queue_notices.py
@@ -1,0 +1,298 @@
+"""STANDING NOTICES — the queue items a person's agent should read without asking for them.
+
+An ordinary waiting item is read when an agent calls `whats_waiting`. Some things stay true BETWEEN
+calls, and an agent that never asks never learns them — so a say-file may flag itself, and the
+flagged ones are served on their own, small, cheap route that a caller can ask on every call.
+
+The contract this file pins, in the order it matters:
+
+  N1  the flag is BEHAVIOR'S — `notice: true` in a say-file's front-matter, an admin's edit, no deploy
+  N2  a file with no front-matter declares nothing and behaves exactly as it always did
+  N3  a malformed flag costs the flag, never the sentence
+  N4  `/queue/waiting` carries `notice` on every item; `/queue/notices` carries the flagged say texts
+  N5  the notices route is the same door as the waiting route — a person reads their own, or nobody's
+
+Offline like the rest of the suite, and reusing `test_queue_waiting.py`'s composition exactly: real
+sqlite rows written the way the engine writes them, and the real app through `TestClient`.
+
+Fixture-local words only. No copy in this file is any deployment's copy.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+import flows_queue  # noqa: E402
+from sqlite_double import SqliteDB  # noqa: E402
+
+T0 = 1_788_000_000.0
+
+MINE = {"uid": "126", "meeting_id": "104", "organizer": "dima@vexa.ai"}
+THEIRS = {"uid": "999", "meeting_id": "7", "organizer": "someone@else.test"}
+
+STANDING = "A fixture sentence that stays true between calls."
+ORDINARY = "A fixture sentence about something that just happened."
+
+
+def _identity(subject):
+    return ("126", "dima@vexa.ai") if str(subject) in ("126", "dima@vexa.ai") else ("999", "")
+
+
+def _row(db, rid, refs, *, flow="post_meeting", step="process_meeting", status_="retrying",
+         reason=None, at=T0):
+    db.execute("""INSERT INTO reaction (reaction_id, source_event_id, event_type, subject_refs,
+                                        flow, flow_version, step, status, attempt, next_run_at,
+                                        reason, created_at, updated_at)
+                  VALUES (:rid,:sid,'meeting.completed',:refs,:flow,4,:step,:st,0,0,:why,:c,:c)""",
+               {"rid": rid, "sid": f"{rid}::{flow}", "refs": json.dumps(refs), "flow": flow,
+                "step": step, "st": status_, "why": reason, "c": at})
+
+
+def _copy(**by_flow):
+    """A behavior tree, injected. `waiting`/`notices` take the reader as a parameter, which is the
+    seam that keeps every test in this file independent of what any real tree happens to say."""
+    def read(flow, reason_type):
+        return by_flow.get(flow, flows_queue.Say(""))
+    return read
+
+
+# ── N1/N2/N3 · the front-matter, read off a say-file ──────────────────────────────────────────
+
+def test_a_file_with_no_front_matter_is_its_own_text_and_declares_nothing():
+    """N2, and it is the compatibility row: every say-file written before this existed."""
+    got = flows_queue.parse("Just the words.\n\nOn two paragraphs.")
+    assert got == "Just the words.\n\nOn two paragraphs."
+    assert got.notice is False
+
+
+def test_front_matter_declares_the_flag_and_is_not_part_of_the_words():
+    got = flows_queue.parse(f"---\nnotice: true\n---\n{STANDING}")
+    assert got.notice is True
+    assert got == STANDING, "the fence must not reach the person"
+
+
+@pytest.mark.parametrize("value", ["true", "TRUE", "yes", "on", "1", " true "])
+def test_the_words_that_mean_yes(value):
+    assert flows_queue.parse(f"---\nnotice: {value}\n---\n{STANDING}").notice is True
+
+
+@pytest.mark.parametrize("value", ["false", "no", "0", "", "maybe", "later"])
+def test_anything_else_means_no(value):
+    """A flag nobody can read is OFF, never guessed on: a notice reaches an agent that did not ask
+    for it, so the failure direction has to be silence."""
+    assert flows_queue.parse(f"---\nnotice: {value}\n---\n{STANDING}").notice is False
+
+
+def test_a_fence_that_never_closes_costs_the_flag_and_not_the_sentence():
+    """N3. The failure of a flag must never be the failure of a sentence a person was owed."""
+    got = flows_queue.parse(f"---\nnotice: true\n{STANDING}")
+    assert got.notice is False
+    assert STANDING in got
+
+
+def test_a_say_is_a_string_everywhere_a_string_was_expected():
+    """The compatibility claim, stated: every existing caller of `say()` keeps working because the
+    thing it gets back still IS the text."""
+    got = flows_queue.parse(f"---\nnotice: true\n---\n{STANDING}")
+    assert isinstance(got, str)
+    assert json.loads(json.dumps({"say": got}))["say"] == STANDING
+
+
+def test_an_empty_body_under_a_flag_is_still_silence():
+    """Silence is the filter (`behavior/queue/README.md`), and a flag does not override it: a file
+    with a fence and no words says nothing, and a notice nobody wrote is not a notice."""
+    assert flows_queue.parse("---\nnotice: true\n---\n") == ""
+
+
+def test_a_private_behavior_tree_flags_its_own_file_with_no_deploy(monkeypatch, tmp_path):
+    """THE SEAM A PRIVATE PACK ACTUALLY USES (`test_flow_packs.py` seam 2): a deployment mounts its
+    own `$VEXA_BEHAVIOR_DIR/queue/`, and one line at the top of one file there is the whole of
+    making an item standing. No code in this repo, and nothing rebuilt."""
+    queue = tmp_path / "queue"
+    queue.mkdir()
+    (queue / "post_meeting.pending.md").write_text(f"---\nnotice: yes\n---\n{STANDING}",
+                                                   encoding="utf-8")
+    monkeypatch.setenv("VEXA_BEHAVIOR_DIR", str(tmp_path))
+
+    got = flows_queue.say("post_meeting", "pending")
+    assert got == STANDING and got.notice is True
+
+    db = SqliteDB()
+    _row(db, "r-mine", MINE)
+    assert flows_queue.notices(db, subject="126", now=T0,
+                              identity=_identity)["notices"] == [STANDING]
+
+
+def test_the_published_showcase_flags_nothing(monkeypatch):
+    """This repo ships the mechanism and uses it for nothing — a notice reaches an agent that did
+    not ask, so the OSS default is that there are none."""
+    monkeypatch.delenv("VEXA_BEHAVIOR_DIR", raising=False)
+    behavior = Path(__file__).resolve().parents[3] / "behavior" / "queue"
+    flagged = [f.name for f in sorted(behavior.glob("*.md"))
+               if f.name != "README.md" and flows_queue.parse(f.read_text(encoding="utf-8")).notice]
+    assert flagged == []
+
+
+# ── N4 · the two projections ──────────────────────────────────────────────────────────────────
+
+def test_waiting_carries_the_flag_on_the_item():
+    db = SqliteDB()
+    _row(db, "r-mine", MINE)
+    out = flows_queue.waiting(db, subject="126", now=T0, identity=_identity,
+                              copy=_copy(post_meeting=flows_queue.Say(STANDING, notice=True)))
+    assert out["items"][0]["notice"] is True
+    assert out["items"][0]["say"] == STANDING
+
+
+def test_an_unflagged_item_says_so_rather_than_omitting_the_field():
+    db = SqliteDB()
+    _row(db, "r-mine", MINE)
+    out = flows_queue.waiting(db, subject="126", now=T0, identity=_identity,
+                              copy=_copy(post_meeting=flows_queue.Say(ORDINARY)))
+    assert out["items"][0]["notice"] is False
+
+
+def test_a_plain_string_from_an_injected_reader_is_an_unflagged_item():
+    """The `copy` seam predates front-matter and callers hand it plain strings. Normalising rather
+    than requiring a `Say` is what keeps this change additive."""
+    db = SqliteDB()
+    _row(db, "r-mine", MINE)
+    out = flows_queue.waiting(db, subject="126", now=T0, identity=_identity,
+                              copy=_copy(post_meeting=ORDINARY))
+    assert out["items"][0]["notice"] is False
+
+
+def test_notices_returns_the_flagged_say_texts_and_nothing_else():
+    """N4. The whole answer is sentences: no reaction id, no flow name, no step, no typed reason.
+    It rides along with unrelated work, so it carries the least it can."""
+    db = SqliteDB()
+    _row(db, "r-mine", MINE)
+    _row(db, "r-live", MINE, flow="live_meeting", status_="running")
+    out = flows_queue.notices(
+        db, subject="126", now=T0, identity=_identity,
+        copy=_copy(post_meeting=flows_queue.Say(STANDING, notice=True),
+                   live_meeting=flows_queue.Say(ORDINARY)))
+    assert out["notices"] == [STANDING]
+    assert "r-mine" not in json.dumps(out) and "post_meeting" not in json.dumps(out)
+
+
+def test_nothing_flagged_is_an_empty_list_not_a_summary_of_the_queue():
+    db = SqliteDB()
+    _row(db, "r-mine", MINE)
+    out = flows_queue.notices(db, subject="126", now=T0, identity=_identity,
+                              copy=_copy(post_meeting=flows_queue.Say(ORDINARY)))
+    assert out["notices"] == []
+
+
+def test_two_reactions_of_one_flow_say_it_once():
+    """One thing that is true twice reads as two things."""
+    db = SqliteDB()
+    _row(db, "r-a", MINE)
+    _row(db, "r-b", MINE, step="another_step")
+    out = flows_queue.notices(db, subject="126", now=T0, identity=_identity,
+                              copy=_copy(post_meeting=flows_queue.Say(STANDING, notice=True)))
+    assert out["notices"] == [STANDING]
+
+
+def test_notices_are_scoped_to_the_subject_like_every_other_read():
+    db = SqliteDB()
+    _row(db, "r-theirs", THEIRS, status_="failed", reason="something on their side")
+    out = flows_queue.notices(db, subject="126", now=T0, identity=_identity,
+                              copy=_copy(post_meeting=flows_queue.Say(STANDING, notice=True)))
+    assert out["notices"] == []
+
+
+def test_an_unresolvable_subject_fails_closed():
+    """Same direction as `pending`/`waiting`: an unresolvable subject never falls through to an
+    unscoped read, which is how a scoping bug becomes the leak the scope was added to close."""
+    out = flows_queue.notices(SqliteDB(), subject="nobody", now=T0,
+                              identity=lambda s: (None, None))
+    assert out["unresolved"] is True and out["notices"] == []
+
+
+# ── N5 · the route — same door as `/queue/waiting` ────────────────────────────────────────────
+
+_ENV = {"VEXA_FLOWS_API_KEY": "test-flows-key",
+        "INTERNAL_API_SECRET": "test-internal-secret",
+        "VEXA_FLOWS_DB_URL": "postgresql+psycopg://queue-notices:unreachable@127.0.0.1:1/flows"}
+
+
+@pytest.fixture(scope="module")
+def api():
+    """`test_queue_waiting.py::api`'s composition, verbatim: the real app against an unreachable
+    Postgres, then handed a working `SqliteDB`."""
+    from fastapi.testclient import TestClient
+
+    saved = {k: os.environ.get(k) for k in _ENV}
+    os.environ.update(_ENV)
+    try:
+        from flows_integrations import flows_api
+    finally:
+        for k, v in saved.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+    flows_api.db = SqliteDB()
+    return flows_api, TestClient(flows_api.app)
+
+
+def _seed(flows_api, monkeypatch, *, flagged: bool):
+    flows_api.db.execute("DELETE FROM reaction")
+    _row(flows_api.db, "r-mine", MINE)
+    _row(flows_api.db, "r-theirs", THEIRS)
+    monkeypatch.setattr(flows_queue, "resolve_identity", _identity)
+    monkeypatch.setattr(flows_queue, "say",
+                        _copy(post_meeting=flows_queue.Say(STANDING, notice=flagged)))
+
+
+def _operator(**extra):
+    return {"X-Flows-Admin-Key": _ENV["VEXA_FLOWS_API_KEY"], **extra}
+
+
+def test_the_route_answers_with_this_person_s_notices(api, monkeypatch):
+    flows_api, client = api
+    _seed(flows_api, monkeypatch, flagged=True)
+    r = client.get("/queue/notices?subject=126", headers=_operator())
+    assert r.status_code == 200
+    assert r.json()["notices"] == [STANDING]
+
+
+def test_an_unflagged_queue_answers_with_no_notices(api, monkeypatch):
+    flows_api, client = api
+    _seed(flows_api, monkeypatch, flagged=False)
+    assert client.get("/queue/notices?subject=126", headers=_operator()).json()["notices"] == []
+
+
+def test_the_stamped_identity_wins_over_a_query_argument(api, monkeypatch):
+    """The security row, and it is the same one `/queue/waiting` carries: a caller who names
+    somebody else reads their OWN notices."""
+    flows_api, client = api
+    _seed(flows_api, monkeypatch, flagged=True)
+    r = client.get("/queue/notices?subject=999", headers=_operator(**{"X-User-Id": "126"}))
+    assert r.json()["subject"] == "126"
+
+
+def test_no_subject_at_all_is_refused_not_answered_with_the_instance(api):
+    _flows_api, client = api
+    assert client.get("/queue/notices", headers=_operator()).status_code == 400
+
+
+def test_the_route_is_behind_a_credential(api):
+    _flows_api, client = api
+    assert client.get("/queue/notices?subject=126").status_code == 401
+
+
+def test_the_route_is_not_a_tool(api):
+    """The mechanism adds a ROUTE, never a verb: an agent does not call this, the edge does. The
+    manifest is what decides the tool list, and it does not name this route."""
+    manifest = json.loads((Path(__file__).resolve().parents[1] / "mcp.tools.v1.json")
+                          .read_text(encoding="utf-8"))
+    paths = {t.get("route", {}).get("path") for t in manifest["tools"]}
+    assert "/queue/notices" not in paths

--- a/core/meetings/services/mcp/src/vexa_mcp/app.py
+++ b/core/meetings/services/mcp/src/vexa_mcp/app.py
@@ -35,6 +35,7 @@ from pydantic import BaseModel, Field, PrivateAttr, model_validator
 
 from . import bind as bind_mod
 from . import discover as discover_mod
+from . import notices as notices_mod
 from . import register as register_mod
 from .link_parser import ParseMeetingLinkResponse, parse_meeting_url
 from .prompts import PROMPTS, get_prompt_result
@@ -1297,5 +1298,10 @@ def create_app(
     # An upstream refusal reaches the agent as ONE string; fastapi-mcp writes it as prose with a JSON
     # document inside. Render it structurally instead — the actionable words first, the body once.
     install_structured_tool_errors(mcp)
+    # STANDING NOTICES ride out on the meeting tools' results (`notices.py`). An agent reads what
+    # it asked for; a fact that stays true between calls has to travel on that, or it travels on a
+    # tool somebody has to remember to call. Never an error, never a new tool: when the deployment
+    # names no flows domain, or it does not answer inside two seconds, the result is the result.
+    notices_mod.install(mcp, transport=transport, env=_assembly_env)
     app.state.mcp = mcp
     return app

--- a/core/meetings/services/mcp/src/vexa_mcp/notices.py
+++ b/core/meetings/services/mcp/src/vexa_mcp/notices.py
@@ -1,0 +1,184 @@
+"""STANDING NOTICES — what stays true between calls, carried out on the results of ordinary work.
+
+An agent reads a tool result. It does not read anything else unless something makes it. So a fact
+that stays true between calls — one a person's agent should be acting on, whatever it happened to
+be doing — reaches it reliably in exactly one place: attached to the result of the call it just
+made. Anything else is a tool somebody has to remember to call.
+
+That is the whole of this module, and none of it knows what a notice SAYS. The words are flows'
+(`GET /queue/notices`, resolved from `behavior/queue/` files that opened with `notice: true`); the
+decision about which situations are notices is an admin's file; this is the ride.
+
+FOUR PROPERTIES, each of them a defect if it were absent:
+
+  * **Never an error.** A notice is something extra. If flows is slow, unreachable, unconfigured,
+    or answers something this module cannot read, the call the agent actually made answers exactly
+    as it would have. There is one `except` here and it catches everything, on purpose.
+  * **Bounded.** :data:`TIMEOUT_S` seconds, once per call. This rides on EVERY meeting tool call,
+    so its worst case is the worst case of the product.
+  * **Both channels.** The field for a caller that parses the body, and a trailing line for one
+    that reads the text. Neither is reliably the one an agent looks at.
+  * **Once.** A body that already carries the field is left alone, and duplicate sentences are
+    dropped — one thing that is true twice reads as two things.
+
+The seam is `FastApiMCP._execute_api_tool`, wrapped exactly the way `tool_errors` wraps `_request`
+and for the same reason: the success path, the headers, the mount and the argument handling all
+stay the library's, and this adds one thing to what comes out.
+"""
+from __future__ import annotations
+
+import json
+from typing import Any, Iterable, List, Optional
+
+import httpx
+
+from .discover import DOMAIN_URL_ENV
+
+#: The route that answers with a subject's standing notices. Its auth is the caller's own
+#: credential, so this hop forwards what the caller sent and holds nothing of its own.
+NOTICES_PATH = "/queue/notices"
+
+#: The field the answer carries them in, and the field a tool result carries them out in — the same
+#: name on both sides, because they are the same thing.
+FIELD = "notices"
+
+#: Seconds. Small on purpose: see the module docstring.
+TIMEOUT_S = 2.0
+
+#: What a notice looks like in the text half of a result.
+PREFIX = "Notice: "
+
+#: THE TOOLS THAT CARRY THEM: the ones an agent calls while working on a person's meetings, which
+#: is where a standing fact about that person's account is worth reading.
+#:
+#: `whats_waiting` is deliberately NOT here even though it is the queue tool: it already answers
+#: with every waiting item, notices among them, so attaching them again would say the same sentence
+#: twice in one result. Nor are the tools that touch no meeting (`parse_meeting_link`,
+#: `report_issue`): a notice on a pure parse is noise on a call that reached nothing.
+CARRIES_NOTICES = frozenset({
+    "request_meeting_bot",
+    "get_meeting_transcript",
+    "list_meetings",
+    "get_bot_status",
+    "stop_bot",
+})
+
+
+def base_url(env: Optional[dict] = None) -> str:
+    """Where to ask, or `""` when this deployment carries no such domain.
+
+    Read from the SAME env key `discover` reads, imported rather than repeated: a second spelling of
+    a deployment fact is a second thing to keep in step, and this one would fail silently — notices
+    would simply never appear, on a deployment that has them.
+    """
+    import os
+    env = os.environ if env is None else env
+    return (env.get(DOMAIN_URL_ENV["flows"]) or "").strip().rstrip("/")
+
+
+def caller_key(headers: Optional[dict]) -> str:
+    """The credential the caller sent, adapted at this boundary exactly as `register._caller_key`
+    does at the assembled-tool boundary: `x-api-key`, else the bearer the MCP transport contract
+    uses. This module never holds a credential of its own and never falls back to one."""
+    if not headers:
+        return ""
+    lower = {str(k).lower(): v for k, v in headers.items()}
+    key = (lower.get("x-api-key") or "").strip()
+    if key:
+        return key
+    auth = (lower.get("authorization") or "").strip()
+    if not auth:
+        return ""
+    scheme, _, token = auth.partition(" ")
+    return (token.strip() if scheme.lower() == "bearer" else auth) or ""
+
+
+def clean(values: Any) -> List[str]:
+    """The notices in an answer, as a list of non-empty strings, deduped in order.
+
+    Defensive about the SHAPE rather than the CONTENT: a body that is not what this expects yields
+    no notices, and never an exception. Nothing here inspects what a notice says.
+    """
+    if not isinstance(values, Iterable) or isinstance(values, (str, bytes, dict)):
+        return []
+    out: List[str] = []
+    for value in values:
+        if not isinstance(value, str):
+            continue
+        text = value.strip()
+        if text and text not in out:
+            out.append(text)
+    return out
+
+
+async def fetch(api_key: str, *, base: str,
+                transport: Optional[httpx.AsyncBaseTransport] = None,
+                timeout: float = TIMEOUT_S) -> List[str]:
+    """This caller's standing notices. `[]` for every reason there could be not to have any —
+    including every reason it could have gone wrong."""
+    if not base or not api_key:
+        return []
+    try:
+        async with httpx.AsyncClient(timeout=timeout, transport=transport) as client:
+            response = await client.get(
+                f"{base}{NOTICES_PATH}",
+                headers={"X-API-Key": api_key, "Content-Type": "application/json"},
+            )
+            if response.status_code != 200 or not response.content:
+                return []
+            return clean((response.json() or {}).get(FIELD))
+    except Exception:  # noqa: BLE001 — a notice is extra; the call the agent made must still answer
+        return []
+
+
+def render(text: str, notices: List[str]) -> str:
+    """The tool result's text, with the notices in it — both halves, or unchanged when there are none.
+
+    The body is re-serialised with the same `indent=2` the library used, so a result with no notices
+    and a result with notices differ by the notices and by nothing else. A body that is not a JSON
+    object (an array, a bare value, a non-JSON string) keeps its shape exactly: the field has nowhere
+    to go there, and inventing a wrapper for it would change what every existing caller parses. The
+    trailing lines are the reason that is safe — they carry the same words either way.
+    """
+    if not notices:
+        return text
+    body = text
+    try:
+        parsed = json.loads(text)
+        if isinstance(parsed, dict) and FIELD not in parsed:
+            body = json.dumps({**parsed, FIELD: notices}, indent=2, ensure_ascii=False)
+    except Exception:  # noqa: BLE001 — a body this cannot parse still gets the trailing lines
+        pass
+    return "\n\n".join([body] + [f"{PREFIX}{n}" for n in notices])
+
+
+def install(mcp: Any, *, transport: Optional[httpx.AsyncBaseTransport] = None,
+            env: Optional[dict] = None) -> None:
+    """Make the mounted MCP surface carry standing notices out on the meeting tools' results.
+
+    Wraps `_execute_api_tool`, which is where a successful call becomes the content an agent reads.
+    A raised call — every refusal, including the ones `tool_errors` renders — passes through
+    untouched: a refusal is not the place to add something the caller did not ask for, and the
+    result an agent must act on should carry one thing.
+    """
+    original = mcp._execute_api_tool
+
+    async def _execute_api_tool(*, client, tool_name, arguments, operation_map,
+                                http_request_info=None):  # noqa: ANN001 — library signature
+        content = await original(
+            client=client, tool_name=tool_name, arguments=arguments,
+            operation_map=operation_map, http_request_info=http_request_info,
+        )
+        if tool_name not in CARRIES_NOTICES or not content:
+            return content
+        key = caller_key(getattr(http_request_info, "headers", None))
+        notices = await fetch(key, base=base_url(env), transport=transport)
+        if not notices:
+            return content
+        for item in content:
+            if getattr(item, "type", None) == "text":
+                item.text = render(item.text, notices)
+                break                       # ONCE PER RESULT, on the body the agent reads first
+        return content
+
+    mcp._execute_api_tool = _execute_api_tool  # type: ignore[method-assign]

--- a/core/meetings/services/mcp/tests/README.md
+++ b/core/meetings/services/mcp/tests/README.md
@@ -13,3 +13,7 @@ path and the fake records each hop (method, path, headers, params, body).
 - **`test_app.py`** — L3 seam: every tool forwards to the right gateway path with the
   caller's `X-API-Key`; missing key fails closed (401); downstream status + detail pass
   through verbatim (incl. the 409 → `already_exists` shape).
+- **`test_standing_notices.py`** — the ride: a standing notice reaches an agent on the
+  result of the meeting tool it just called (field in the body, trailing line in the text,
+  once per result), the tools that touch no meeting carry none, and every way that hop can
+  fail — domain absent, slow, refused, malformed — leaves the result exactly as it was.

--- a/core/meetings/services/mcp/tests/test_standing_notices.py
+++ b/core/meetings/services/mcp/tests/test_standing_notices.py
@@ -1,0 +1,297 @@
+"""STANDING NOTICES ride out on the meeting tools' results — what an agent reads without asking.
+
+An agent reads a tool result and nothing else unless something makes it. So a fact that stays true
+between calls travels attached to the call the agent just made, or it travels on a tool somebody
+has to remember to call. This file pins the ride, and every one of its claims is a failure that
+would otherwise be silent:
+
+  S1  the meeting tools carry them — field in the body, trailing line in the text, once per result
+  S2  the tools that are not about a meeting do not, and `whats_waiting` never does (it already says it)
+  S3  no notices, no flows domain, a slow domain, a broken answer → the result is exactly the result
+  S4  a refusal carries the refusal and nothing else
+  S5  the surface is unchanged: no new tool, no new argument
+
+Autonomous, like the rest of the suite: `create_app` takes the transport as an injected port, so a
+fake stands in for both the gateway and the notices hop and the SHIPPED path runs with no network.
+
+FIXTURE-LOCAL WORDS ONLY. Nothing in this file is any deployment's copy, and this module knows no
+vocabulary at all — a notice is a string it was handed.
+"""
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+from fastapi.testclient import TestClient
+
+from conftest import API_KEY, GATEWAY_URL
+from vexa_mcp import create_app, notices
+
+FLOWS_URL = "http://flows.test"
+STANDING = "A fixture sentence that stays true between calls."
+SECOND = "A second fixture sentence."
+MEETING_URL = "https://meet.google.com/abc-defg-hij"
+
+
+def _app(*, body=None, status=200, flows_url=FLOWS_URL, delay=False, gateway=None):
+    """An MCP app whose flows domain answers `body` on `/queue/notices`.
+
+    ASSEMBLY IS OFF: this test is about the notice ride, and assembly would make the boot fetch a
+    manifest and an OpenAPI from the same fake. `FLOWS_API_URL` still reaches `notices` because it
+    reads the env it was handed, which is the same env assembly reads.
+    """
+    def upstream(request: httpx.Request) -> httpx.Response:
+        if request.url.path == notices.NOTICES_PATH:
+            if delay:
+                raise httpx.TimeoutException("slow", request=request)
+            return httpx.Response(status, json=body if body is not None else {})
+        if gateway is not None:
+            return gateway(request)
+        return httpx.Response(200, json={"ok": True, "path": request.url.path})
+
+    env = {"VEXA_MCP_ASSEMBLY_OFF": "1"}
+    if flows_url:
+        env["FLOWS_API_URL"] = flows_url
+    return create_app(GATEWAY_URL, transport=httpx.MockTransport(upstream), assembly_env=env)
+
+
+@pytest.fixture
+def agent():
+    """A live `/mcp` session against an app whose flows domain has one standing notice — the
+    session shape `test_denial_reaches_the_agent.py` documents."""
+    def session(app):
+        ctx = TestClient(app)
+        client = ctx.__enter__()
+        head = {"Authorization": f"Bearer {API_KEY}",
+                "Accept": "application/json, text/event-stream",
+                "Content-Type": "application/json"}
+        r = client.post("/mcp", headers=head, json={
+            "jsonrpc": "2.0", "id": 1, "method": "initialize",
+            "params": {"protocolVersion": "2025-03-26", "capabilities": {},
+                       "clientInfo": {"name": "test", "version": "0"}}})
+        head["Mcp-Session-Id"] = r.headers["mcp-session-id"]
+        client.post("/mcp", headers=head,
+                    json={"jsonrpc": "2.0", "method": "notifications/initialized"})
+
+        def call(name, **arguments):
+            got = client.post("/mcp", headers=head, json={
+                "jsonrpc": "2.0", "id": 9, "method": "tools/call",
+                "params": {"name": name, "arguments": arguments}})
+            return got.json()["result"]
+        call.close = lambda: ctx.__exit__(None, None, None)
+        return call
+    return session
+
+
+def _text(result) -> str:
+    return "\n".join(c["text"] for c in result["content"] if c.get("type") == "text")
+
+
+# ── S1 · the ride ─────────────────────────────────────────────────────────────────────────────
+
+@pytest.mark.parametrize("tool,arguments", [
+    ("get_bot_status", {}),
+    ("list_meetings", {}),
+    ("stop_bot", {"platform": "google_meet", "native_meeting_id": "abc-defg-hij"}),
+    ("get_meeting_transcript", {"platform": "google_meet", "native_meeting_id": "abc-defg-hij"}),
+    ("request_meeting_bot", {"meeting_url": MEETING_URL}),
+])
+def test_every_meeting_tool_carries_the_notice(agent, tool, arguments):
+    """S1. The list is the point: an agent working on a person's meetings reads a standing fact
+    about that person's account whichever of these it happened to call."""
+    call = agent(_app(body={"notices": [STANDING]}))
+    try:
+        assert STANDING in _text(call(tool, **arguments))
+    finally:
+        call.close()
+
+
+def test_the_notice_is_in_the_body_as_a_field_and_in_the_text_as_a_line(agent):
+    """BOTH CHANNELS, because neither is reliably the one an agent looks at: the field for a caller
+    that parses the body, the trailing line for one that reads the text."""
+    call = agent(_app(body={"notices": [STANDING]}))
+    try:
+        text = _text(call("get_bot_status"))
+        assert f"{notices.PREFIX}{STANDING}" in text, "the trailing line"
+        body = json.loads(text.split(f"\n\n{notices.PREFIX}")[0])
+        assert body["notices"] == [STANDING], "the field"
+    finally:
+        call.close()
+
+
+def test_the_original_answer_survives_intact(agent):
+    """A notice is ADDITIVE. Everything the tool answered is still there, unchanged."""
+    def gateway(request):
+        return httpx.Response(200, json={"running_bots": [{"id": 7}], "count": 1})
+
+    call = agent(_app(body={"notices": [STANDING]}, gateway=gateway))
+    try:
+        body = json.loads(_text(call("get_bot_status")).split(f"\n\n{notices.PREFIX}")[0])
+        assert body["running_bots"] == [{"id": 7}] and body["count"] == 1
+    finally:
+        call.close()
+
+
+def test_a_notice_appears_once_per_result(agent):
+    call = agent(_app(body={"notices": [STANDING]}))
+    try:
+        assert _text(call("get_bot_status")).count(STANDING) == 2, "the field, then the line"
+    finally:
+        call.close()
+
+
+def test_two_notices_are_two_lines_in_order(agent):
+    call = agent(_app(body={"notices": [STANDING, SECOND]}))
+    try:
+        text = _text(call("get_bot_status"))
+        assert text.index(f"{notices.PREFIX}{STANDING}") < text.index(f"{notices.PREFIX}{SECOND}")
+    finally:
+        call.close()
+
+
+def test_the_hop_forwards_the_caller_s_own_credential_and_holds_none(agent):
+    """The notices route is subject-scoped: it answers for whoever the credential resolves to. This
+    edge holds no credential of its own and must never substitute one."""
+    seen = []
+
+    def upstream(request: httpx.Request) -> httpx.Response:
+        if request.url.path == notices.NOTICES_PATH:
+            seen.append(request.headers.get("x-api-key"))
+            return httpx.Response(200, json={"notices": [STANDING]})
+        return httpx.Response(200, json={"ok": True})
+
+    app = create_app(GATEWAY_URL, transport=httpx.MockTransport(upstream),
+                     assembly_env={"VEXA_MCP_ASSEMBLY_OFF": "1", "FLOWS_API_URL": FLOWS_URL})
+    call = agent(app)
+    try:
+        call("get_bot_status")
+        assert seen == [API_KEY]
+    finally:
+        call.close()
+
+
+# ── S2 · which tools, and which do not ────────────────────────────────────────────────────────
+
+@pytest.mark.parametrize("tool,arguments", [
+    ("parse_meeting_link", {"meeting_url": MEETING_URL}),
+])
+def test_a_tool_that_reaches_no_meeting_carries_nothing(agent, tool, arguments):
+    """S2. A notice on a pure parse is noise on a call that touched nothing of the person's."""
+    call = agent(_app(body={"notices": [STANDING]}))
+    try:
+        assert STANDING not in _text(call(tool, **arguments))
+    finally:
+        call.close()
+
+
+def test_the_queue_tool_is_not_in_the_carrying_set():
+    """`whats_waiting` answers with every waiting item, notices among them. Attaching them again
+    would say the same sentence twice in one result."""
+    assert "whats_waiting" not in notices.CARRIES_NOTICES
+
+
+# ── S3 · never an error ───────────────────────────────────────────────────────────────────────
+
+def test_no_notices_means_the_result_is_byte_for_byte_the_result(agent):
+    plain = agent(_app(body={"notices": []}))
+    try:
+        text = _text(plain("get_bot_status"))
+        assert notices.PREFIX not in text
+        assert "notices" not in json.loads(text)
+    finally:
+        plain.close()
+
+
+@pytest.mark.parametrize("kwargs", [
+    {"flows_url": ""},                       # this deployment carries no flows domain
+    {"delay": True},                         # the domain is there and slow
+    {"status": 500},                         # the domain answered badly
+    {"status": 401},                         # the credential does not open that door
+    {"body": {"notices": "not a list"}},     # the answer is not the shape this expects
+    {"body": {"notices": [{"say": "an object"}]}},
+    {"body": {}},                            # no field at all
+])
+def test_nothing_that_can_go_wrong_reaches_the_agent(agent, kwargs):
+    """S3, and it is the whole safety claim: a notice is EXTRA. Whatever happens on that hop, the
+    call the agent actually made answers exactly as it would have."""
+    call = agent(_app(**kwargs))
+    try:
+        result = call("get_bot_status")
+        assert result.get("isError") is not True
+        assert notices.PREFIX not in _text(result)
+    finally:
+        call.close()
+
+
+def test_a_refusal_carries_the_refusal_and_nothing_else(agent):
+    """S4. A result an agent must act on carries one thing."""
+    def gateway(request):
+        return httpx.Response(403, json={"detail": {"reason": "a_fixture_reason"}})
+
+    call = agent(_app(body={"notices": [STANDING]}, gateway=gateway))
+    try:
+        result = call("get_bot_status")
+        assert result.get("isError") is True
+        assert "a_fixture_reason" in _text(result)
+        assert STANDING not in _text(result)
+    finally:
+        call.close()
+
+
+# ── S5 · the surface is unchanged ─────────────────────────────────────────────────────────────
+
+def test_no_new_tool_and_no_new_argument():
+    """A mechanism that added a verb would be a verb an agent has to know to call, which is the
+    thing this exists to avoid."""
+    from test_mcp_surface import EXPECTED_TOOLS
+
+    app = _app(body={"notices": [STANDING]})
+    tools = {t.name: t for t in app.state.mcp.tools}
+    assert set(tools) == EXPECTED_TOOLS
+    for name in notices.CARRIES_NOTICES:
+        schema = tools[name].inputSchema
+        assert notices.FIELD not in (schema.get("properties") or {})
+
+
+# ── the pure parts, driven directly ───────────────────────────────────────────────────────────
+
+def test_render_leaves_a_non_object_body_shaped_exactly_as_it_was():
+    """`list_meetings` answers with an ARRAY. A field has nowhere to go there, and inventing a
+    wrapper for it would change what every existing caller parses — so the trailing line carries it
+    and the body is untouched."""
+    got = notices.render('[\n  {"id": 7}\n]', [STANDING])
+    assert got.startswith('[\n  {"id": 7}\n]')
+    assert got.endswith(f"{notices.PREFIX}{STANDING}")
+    assert json.loads(got.split(f"\n\n{notices.PREFIX}")[0]) == [{"id": 7}]
+
+
+def test_render_leaves_a_body_that_already_carries_the_field_alone():
+    body = json.dumps({"notices": ["already here"]})
+    assert json.loads(notices.render(body, [STANDING]).split(f"\n\n{notices.PREFIX}")[0]) == {
+        "notices": ["already here"]}
+
+
+def test_render_with_no_notices_changes_nothing():
+    assert notices.render('{"a": 1}', []) == '{"a": 1}'
+
+
+def test_clean_dedupes_in_order_and_drops_everything_that_is_not_a_sentence():
+    assert notices.clean([STANDING, "", SECOND, STANDING, None, 7, {"x": 1}]) == [STANDING, SECOND]
+
+
+@pytest.mark.parametrize("value", [None, "a string", {"a": 1}, 7])
+def test_clean_never_raises_on_a_shape_it_did_not_expect(value):
+    assert notices.clean(value) == []
+
+
+@pytest.mark.parametrize("headers,expected", [
+    ({"x-api-key": "k"}, "k"),
+    ({"Authorization": "Bearer k"}, "k"),
+    ({"AUTHORIZATION": "Bearer k"}, "k"),
+    ({"x-api-key": "k", "authorization": "Bearer other"}, "k"),
+    ({}, ""),
+    (None, ""),
+])
+def test_the_caller_key_is_read_the_way_every_other_boundary_reads_it(headers, expected):
+    assert notices.caller_key(headers) == expected


### PR DESCRIPTION
A say-file under `behavior/queue/` may now open with `notice: true` in front-matter.
That marks what stays true **between** calls rather than what just happened — an
admin's edit in the tree that already decides whether an item is spoken at all, with
no deploy on either side of it.

**flows** — `GET /queue/waiting` carries `notice` on each item; `GET /queue/notices`
is a smaller answer behind the same door: only the flagged say texts, deduped, cheap
enough to ask on every call.

**mcp** — the five meeting tools carry the caller's notices out on their results: a
`notices` field plus one `Notice: …` line, once. Bounded at 2s; an absent or slow
domain, a refusal, or an unreadable answer leaves the result exactly as it was.

No new tool (still 21), no new argument, and nothing flagged in this repo.

Draft: opened for review, not for merge.

<!-- vexa-agent -->
