### PR TITLE
[DEV] 0.12.27 car 1: gate:dataflow green (flows.v1 + modules registered), CI test fixes, gate blind spots (#1553)

### DIFF
--- a/architecture.calm.json
+++ b/architecture.calm.json
@@ -1260,10 +1260,66 @@
    ]
   },
   {
+   "unique-id": "flows-defs",
+   "node-type": "module",
+   "name": "flows-defs",
+   "description": "product behaviour as DATA: each flow is a typed event trigger plus an ordered list of step FUNCTIONS, one registration per version; in-flight reactions keep the version stamped at admission",
+   "metadata": [
+    {
+     "path": "core/flows/src/flows_defs"
+    }
+   ]
+  },
+  {
+   "unique-id": "flows-steps",
+   "node-type": "module",
+   "name": "flows-steps",
+   "description": "the step implementations a flow names — one function per capability, registered by __name__; the real adapters call domain HTTP surfaces and sit OUTSIDE the engine's import graph, and fakes.py mirrors the same names so every fixture runs with zero domains attached",
+   "metadata": [
+    {
+     "path": "core/flows/src/flows_steps"
+    }
+   ]
+  },
+  {
+   "unique-id": "flows-schema",
+   "node-type": "module",
+   "name": "flows-schema",
+   "description": "the schema source of truth: declarative SQLAlchemy models from which core/flows/schema.sql is generated (scripts/gen_schema.py, drift-tested); lives outside src/flows so the engine stays stdlib-pure at import",
+   "metadata": [
+    {
+     "path": "core/flows/src/flows_schema"
+    }
+   ]
+  },
+  {
+   "unique-id": "flows-timeline",
+   "node-type": "module",
+   "name": "flows-timeline",
+   "description": "one person's day in order: the READ back over reactions and effect receipts along the time axis. It admits nothing, claims nothing and writes nothing — the read model for the timeline and queue surfaces",
+   "metadata": [
+    {
+     "path": "core/flows/src/flows_timeline"
+    }
+   ]
+  },
+  {
    "unique-id": "flows-rows",
    "node-type": "data-asset",
    "name": "flows-rows",
-   "description": "the reaction + effect_receipt tables (core/flows/schema.sql); a retry consults the receipt before touching the outside world again"
+   "description": "the reaction + effect_receipt tables (core/flows/schema.sql); a retry consults the receipt before touching the outside world again. TWO writers: flows-worker runs the steps and stamps the receipts, and flows-api admits facts (POST /events → admit() → INSERT INTO reaction) and registers flow versions (INSERT INTO flow_version) in its own process"
+  },
+  {
+   "unique-id": "flows.v1",
+   "node-type": "contract",
+   "name": "flows.v1",
+   "description": "flows.v1 — the carrier census (flows): one producing domain per event type, with the refs a consumer may rely on and the cardinality it may assume. Read by gate:config-contract (a publish-edge key's carriers must be registered here, owned by that service's domain), by gate:schema and by the flows suite. Unsealed by intent — see the contract's README",
+   "metadata": [
+    {
+     "path": "core/flows/contracts/flows.v1",
+     "domain": "flows"
+    }
+   ]
   },
   {
    "unique-id": "processed-notes.v1",
@@ -2363,9 +2419,14 @@
      "container": "flows",
      "nodes": [
       "flows-engine",
+      "flows-defs",
+      "flows-steps",
+      "flows-schema",
+      "flows-timeline",
       "flows-api",
       "flows-worker",
-      "flows-rows"
+      "flows-rows",
+      "flows.v1"
      ]
     }
    }
@@ -2376,6 +2437,25 @@
     "connects": {
      "source": {
       "node": "flows-worker"
+     },
+     "destination": {
+      "node": "flows-rows"
+     }
+    }
+   },
+   "metadata": [
+    {
+     "access": "write"
+    }
+   ]
+  },
+  {
+   "unique-id": "flows-api-writes-rows",
+   "description": "the second writer, recorded because it is real: POST /events admits a fact in the API process (flows_integrations/flows_api.py → flows.admit → INSERT INTO reaction) and the registry writes flow_version there too. The chart carried only flows-worker, so the one shared carrier in this domain read as single-writer",
+   "relationship-type": {
+    "connects": {
+     "source": {
+      "node": "flows-api"
      },
      "destination": {
       "node": "flows-rows"

--- a/architecture.seal.json
+++ b/architecture.seal.json
@@ -1,3 +1,3 @@
 {
-  "architecture.calm.json": "4a73bc6dad939e95cdc1d07c36d1162507d2d6715e84bbce4c5b6d51ad1154a9"
+  "architecture.calm.json": "694a169f064da425267ead9db7ac6cf85c160a8db258ae6150016159e8b3ed63"
 }

--- a/clients/terminal/package.json
+++ b/clients/terminal/package.json
@@ -2,6 +2,7 @@
   "name": "@vexa/terminal",
   "version": "0.1.0",
   "private": true,
+  "type": "module",
   "description": "Vexa Terminal — an AI-first knowledge-worker terminal (Claude Code × Outlook) on the Vexa meeting-bot + agentic-runtime backend. Self-hostable (VPC / air-gapped) with BYO inference.",
   "scripts": {
     "dev": "PORT=3000 node server.mjs",

--- a/clients/terminal/scripts/check-isolation.js
+++ b/clients/terminal/scripts/check-isolation.js
@@ -3,7 +3,6 @@
 // (a) intra-package — a relative path OR the `@/*` tsconfig alias (→ ./src/*), (b) a Node/
 // browser builtin, or (c) a DECLARED dep in package.json. An undeclared bare/npm import →
 // violation (the app must declare what it pulls in, so it installs + builds standalone).
-// Dynamic `import(`${expr}`)` (template literals) are not static specifiers and are skipped.
 // ESM ("type":"module" not set on this app, but node runs .js as ESM here via the import syntax
 // — the gate invokes `node scripts/check-isolation.js`).
 import { readFileSync, readdirSync } from "node:fs";
@@ -17,6 +16,78 @@ const SRC = join(ROOT, "src");
 const pkg = JSON.parse(readFileSync(join(ROOT, "package.json"), "utf8"));
 const deps = new Set([...Object.keys(pkg.dependencies || {}), ...Object.keys(pkg.devDependencies || {})]);
 const builtins = new Set(builtinModules);
+/** Comments are not code, and this gate reads them as code without this.
+ *
+ *  ⚠ 2026-09-02: the gate failed the whole push on three files whose "undeclared dependencies" were
+ *  `a link was clicked` and `this turn did not come from an arrival` — English, inside doc comments,
+ *  because the specifier regex matches the word `from` followed by anything quoted no matter where
+ *  it sits. Prose about a link, in a file about links, is exactly the prose these files should
+ *  contain, and a gate that forbids it is not protecting the boundary — it is taxing the comments.
+ *
+ *  It is the same shape as the defects this gate exists to catch: it reported a real-looking
+ *  violation, with file names and specifiers, and was wrong. A gate that contradicts observable
+ *  state should be read before it is obeyed.
+ *
+ *  Strips block and line comments, leaving string literals intact (a `//` inside a quote is not a
+ *  comment, and a URL in a string must not eat the rest of its line). Deliberately small: this is a
+ *  boundary check, not a parser, and every import it needs to see survives this.
+ */
+function stripComments(src) {
+  let out = "";
+  let quote = null;          // the quote char we are inside, or null
+  let block = false;         // inside a /* … */
+  for (let i = 0; i < src.length; i++) {
+    const c = src[i], n = src[i + 1];
+    if (block) { if (c === "*" && n === "/") { block = false; i++; } continue; }
+    if (quote) {
+      if (c === "\\") { out += c + (n ?? ""); i++; continue; }   // an escape consumes its pair
+      if (c === quote) quote = null;
+      out += c;
+      continue;
+    }
+    if (c === "/" && n === "*") { block = true; i++; continue; }
+    if (c === "/" && n === "/") { while (i < src.length && src[i] !== "\n") i++; out += "\n"; continue; }
+    if (c === "'" || c === '"' || c === "`") quote = c;
+    out += c;
+  }
+  return out;
+}
+
+/** The import forms this gate must see, and only those.
+ *
+ *  ⚠ 2026-09-02, second occurrence: the specifier regex was `from\s+['"]…['"]` with no anchor, so
+ *  it read the words `from "…"` as an import ANYWHERE they appeared — including inside a string
+ *  literal and inside a regular-expression literal. Stripping comments (below) fixed the prose
+ *  half; a regex literal is code, survives that strip, and failed a push the same day. Both are
+ *  the same defect: a gate reporting a real-looking violation, with a file name and a specifier,
+ *  and being wrong.
+ *
+ *  A static import or re-export is a STATEMENT: it begins a line. Anchoring at line start is what
+ *  separates the keyword from the same six letters quoted inside an expression — and the clause
+ *  may span lines but never crosses a quote or a semicolon, so it cannot run out of its own
+ *  statement into the next one.
+ *
+ *  1. `import … from "x"` / `export … from "x"` — the multi-line `{ a, b }` clause included.
+ *  2. `import "x"` — the side-effect form, which the previous regex did not see at all.
+ *  3. `require("x")`, wherever it sits — a call, not a statement, so it cannot be anchored; the
+ *     preceding-character guard keeps `myrequire(` out.
+ *
+ *  Deliberately NOT a form: a bare `import("x")`. In TypeScript those same characters are also the
+ *  TYPE-QUERY form — `Content: import("mdx/types").MDXContent` (ui-kit/MdxDoc.tsx:268) names a type
+ *  package that is never installed as a runtime dependency and must not be reported as one. Telling
+ *  a type query from a dynamic import needs a parser, which this is deliberately not, and no file in
+ *  src/ loads a runtime module that way.
+ *
+ *  Known and accepted: a multi-line template literal containing a line that itself begins with
+ *  `import … from "…"` (a code sample in a string) still matches form 1. Nothing in this tree does
+ *  that, and separating it needs a real parser, which this is deliberately not.
+ */
+const IMPORT_SPECIFIER = new RegExp([
+  String.raw`^[ \t]*(?:import|export)\b(?:[^;'"\n]|\n)*?\bfrom\s*['"]([^'"\n]+)['"]`,
+  String.raw`^[ \t]*import\s+['"]([^'"\n]+)['"]`,
+  String.raw`(?<![\w$.])require\(\s*['"]([^'"\n]+)['"]\s*\)`,
+].join("|"), "gm");
+
 let files = 0;
 const violations = [];
 (function walk(d) {
@@ -25,9 +96,9 @@ const violations = [];
     if (e.isDirectory()) walk(p);
     else if (e.name.endsWith(".ts") || e.name.endsWith(".tsx")) {
       files++;
-      const src = readFileSync(p, "utf8");
-      for (const m of src.matchAll(/from\s+['"]([^'"]+)['"]|require\(\s*['"]([^'"]+)['"]\s*\)/g)) {
-        const spec = m[1] || m[2];
+      const src = stripComments(readFileSync(p, "utf8"));
+      for (const m of src.matchAll(IMPORT_SPECIFIER)) {
+        const spec = m[1] || m[2] || m[3];
         if (spec.includes("${")) continue;                             // a `from "${x}"` substring inside a template/string literal, not a real import
         if (spec.startsWith(".") || spec.startsWith("@/")) continue;    // intra-package (relative or @/* alias)
         const bare = spec.startsWith("node:") ? spec.slice(5) : spec;

--- a/clients/terminal/scripts/check-isolation.js
+++ b/clients/terminal/scripts/check-isolation.js
@@ -3,8 +3,11 @@
 // (a) intra-package — a relative path OR the `@/*` tsconfig alias (→ ./src/*), (b) a Node/
 // browser builtin, or (c) a DECLARED dep in package.json. An undeclared bare/npm import →
 // violation (the app must declare what it pulls in, so it installs + builds standalone).
-// ESM ("type":"module" not set on this app, but node runs .js as ESM here via the import syntax
-// — the gate invokes `node scripts/check-isolation.js`).
+// ESM — the app declares `"type": "module"`, so node loads this .js as ESM directly. Without that
+// declaration node still reparsed it as ESM, but emitted a ~230-char MODULE_TYPELESS_PACKAGE_JSON
+// warning on stderr, and gate:isolation only forwards the first 300 chars of a failing brick's
+// stderr: the warning pushed the actual violation list out of the diagnostic. A gate whose failure
+// message is a warning about module resolution tells the reader nothing about what it caught.
 import { readFileSync, readdirSync } from "node:fs";
 import { join, relative, dirname } from "node:path";
 import { fileURLToPath } from "node:url";

--- a/core/flows/contracts/flows.v1/README.md
+++ b/core/flows/contracts/flows.v1/README.md
@@ -16,19 +16,27 @@ billing on the paid product, so its stamp is written in the same transaction as 
 describes — the guarantee is the stamp, not the code path, which is why it holds against a replay, a
 restore, and a second producer somebody adds later.
 
+The table below is a rendering of `carriers.json`, in file order — read it off the census, never the
+other way round. It said `meeting.completed | flows` and omitted `meeting.started` entirely until the
+0.12.27 candidate; both carriers had been handed over to **meetings** (F168/F181, meeting-api
+publishes them from its own lifecycle) and the prose here still named the previous producer, which is
+the one thing a census may not get wrong.
+
 | carrier | owner | cardinality |
 |---|---|---|
 | `onboarding.completed` | identity | exactly once per subject |
-| `meeting.completed` | flows | once per occurrence |
+| `meeting.started` | meetings | once per occurrence |
+| `meeting.completed` | meetings | once per occurrence |
 | `invite.received` | flows | once per occurrence |
 | `desk.unscaffolded` | agent | exactly once per subject |
 | `claim.proposed` | agent | once per occurrence |
 | `friction.reported` | flows | once per occurrence |
 
-`meeting.completed` and `invite.received` are recorded from `core/flows/mcp.tools.v1.json`'s own
-`publishes_events`; the two desk carriers from agent-api's `config.v1.json` publish-edge keys. None
-of them is asserted afresh: this file is a reading of what the repository already declares, which is
-what makes it a census rather than a wish.
+`meeting.started` and `meeting.completed` are recorded from meeting-api's `config.v1.json`
+publish-edge keys, `invite.received` from `core/flows/mcp.tools.v1.json`'s own `publishes_events`,
+and the two desk carriers from agent-api's `config.v1.json` publish-edge keys. None of them is
+asserted afresh: this file is a reading of what the repository already declares, which is what makes
+it a census rather than a wish.
 
 `friction.reported` (PRD 40.9 open-decision 8) is owned by **flows**, not agent, even though the
 fact it describes is about using the product: the producer is flows-api's own `POST /friction`
@@ -58,9 +66,16 @@ loses a card and never loses the fact.
 
 ## Registered, not yet sealed
 
-It is registered in `architecture.calm.json` (node `flows.v1`) — `gate:dataflow`'s completeness
-check requires every contract dir on disk to appear in the chart, so registration is not optional
-and not deferrable.
+It is registered in `architecture.calm.json` as node `flows.v1` (`metadata.path`
+`core/flows/contracts/flows.v1`, `domain` `flows`), inside the `flows-composed` container —
+`gate:dataflow`'s completeness check requires every contract dir on disk to appear in the chart, so
+registration is not optional and not deferrable.
+
+⚠ From the commit that created this contract until the 0.12.27 candidate, this paragraph said the
+registration existed and it did not: there was no `flows.v1` node, `gate:dataflow` was RED on exactly
+that, and `gate:arch-report` was red behind it. A README asserting the state a gate is failing on is
+worse than silence — it answers the question a reader would otherwise have gone and checked. Landed
+with the node, so the sentence and the chart move together.
 
 It carries no entry in `contracts.seal.json`, so `gate:contract-version` reports it as *in
 development* — and that part is deliberate. Sealing publishes a frozen `.vN`; freezing a shape on

--- a/docs/views/architecture.dsl
+++ b/docs/views/architecture.dsl
@@ -87,9 +87,14 @@ system platform  # shared infra backing the services
 
 system flows  # the reaction engine; owns the reaction row and its effect receipts
   module flows-engine
+  module flows-defs
+  module flows-steps
+  module flows-schema
+  module flows-timeline
   service flows-api
   service flows-worker
   data-asset flows-rows
+  contract flows.v1
 
 edges:
   bot -write-> segments-stream
@@ -141,6 +146,7 @@ edges:
   slim -req-> gateway  # Python client; REST via gateway
   extension -req-> gateway  # browser extension client; live WS via gateway
   flows-worker -write-> flows-rows
+  flows-api -write-> flows-rows  # the second writer, recorded because it is real: POST /events admits a fact in the API process (flows_integrations/flows_api.py → flows.admit → INSERT INTO reaction) and the registry writes flow_version there too. The chart carried only flows-worker, so the one shared carrier in this domain read as single-writer
   flows-api -read-> flows-rows
   flows-worker -req-> agent-api  # steps reach domains only over their published HTTP surfaces (core/flows/src/flows_steps/common.py) — a domain never knows flows exists
   flows-worker -req-> gateway

--- a/docs/views/ownership.mmd
+++ b/docs/views/ownership.mmd
@@ -46,4 +46,5 @@ flowchart LR
   gateway -.->|read| va_chat
   admin_api -->|write| identity_db
   flows_worker -->|write| flows_rows
+  flows_api -->|write| flows_rows
   flows_api -.->|read| flows_rows

--- a/scripts/check-isolation-py.mjs
+++ b/scripts/check-isolation-py.mjs
@@ -14,9 +14,12 @@
  *
  * GREEN-ON-EMPTY: no Python packages → green (mirrors the other gates).
  *
- * The 7 v0.12 top-level Python packages and their src/ module names:
+ * The v0.12 Python packages and their src/ module names. A package is a pyproject.toml over a src/,
+ * and a package may hold MORE THAN ONE top-level module — every one of them is a sibling name:
  *   runtime_kernel · gateway · gateway_conformance · meeting_api ·
- *   admin_api · identity_core · agent_api
+ *   admin_api · identity_core · agent_api ·
+ *   core/flows, one package over seven: flows · flows_defs · flows_integrations · flows_schema ·
+ *     flows_steps · flows_timeline · flows_worker
  * (P2 folded the standalone transcription_collector INTO meeting_api — that package is gone.)
  *
  * Why a curated allowed-edges table instead of reading pyproject `dependencies`: the only legit
@@ -25,7 +28,7 @@
  * runtime_kernel must import NOTHING from the others (kernel depends on nothing above).
  */
 import { readdirSync, readFileSync, existsSync, statSync } from "node:fs";
-import { join, relative, dirname } from "node:path";
+import { join, relative, dirname, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
@@ -75,14 +78,28 @@ function walkDirs(dir, acc = []) {
   return acc;
 }
 
-// the top-level module of a package = the single dir under src/ holding __init__.py
-function moduleOf(pkgDir) {
+/** EVERY top-level module of a package — each dir under src/ holding an `__init__.py`.
+ *
+ *  ⚠ This returned ONE name (`mods.length === 1 ? mods[0] : (mods[0] || null)`), and the second
+ *  branch of that ternary is the defect: a package with seven modules under src/ was registered by
+ *  its alphabetically-first one and the other six were invisible to all three Python gates. Invisible
+ *  in the direction that matters — a name absent from SIBLINGS is read as stdlib or third-party, so
+ *  an import of `flows_steps` from another package passed as an outside dependency rather than as
+ *  the cross-package edge it is. core/flows is that package: `flows`, `flows_defs`,
+ *  `flows_integrations`, `flows_schema`, `flows_steps`, `flows_timeline`, `flows_worker`.
+ *
+ *  A gate that silently narrows its own subject is the expensive kind: it prints VERIFIED over a
+ *  scan that never looked. Every module is a sibling name now, and the importing module is read from
+ *  the file's own path rather than assumed to be the package's first — so an edge is reported as the
+ *  module that actually took it.
+ */
+function modulesOf(pkgDir) {
   const src = join(pkgDir, "src");
-  if (!existsSync(src)) return null;
-  const mods = readdirSync(src, { withFileTypes: true })
+  if (!existsSync(src)) return [];
+  return readdirSync(src, { withFileTypes: true })
     .filter((e) => e.isDirectory() && existsSync(join(src, e.name, "__init__.py")))
-    .map((e) => e.name);
-  return mods.length === 1 ? mods[0] : (mods[0] || null);
+    .map((e) => e.name)
+    .sort();
 }
 
 // declared pip dependencies (best-effort parse of [project].dependencies) — used to let a future
@@ -102,9 +119,9 @@ function discover() {
     if (!existsSync(base)) continue;
     for (const d of [base, ...walkDirs(base)]) {
       if (!existsSync(join(d, "pyproject.toml")) || !existsSync(join(d, "src"))) continue;
-      const module = moduleOf(d);
-      if (!module) continue;
-      pkgs.push({ dir: d, module, srcDir: join(d, "src"), testsDir: join(d, "tests"), deps: declaredDeps(d) });
+      const modules = modulesOf(d);
+      if (!modules.length) continue;
+      pkgs.push({ dir: d, modules, srcDir: join(d, "src"), testsDir: join(d, "tests"), deps: declaredDeps(d) });
     }
   }
   return pkgs;
@@ -132,7 +149,7 @@ function imports(file) {
 
 // ── the scan ──────────────────────────────────────────────────────────────────────────────────
 const pkgs = discover();
-const SIBLINGS = new Set(pkgs.map((p) => p.module));
+const SIBLINGS = new Set(pkgs.flatMap((p) => p.modules));
 const mode = (process.argv.find((a) => a.startsWith("--mode=")) || "--mode=isolation").split("=")[1];
 
 if (!pkgs.length) {
@@ -152,15 +169,21 @@ for (const pkg of pkgs) {
   if (!existsSync(dir)) continue;
   for (const file of pyFiles(dir)) {
     scanned++;
+    // WHICH module took the edge: the first path segment under the scanned dir, so a multi-module
+    // package reports the importer that actually exists rather than the package's first module.
+    // (For a tests/ scan that segment is a test file or dir, not a module — fall back to the
+    // package's own modules, which is what the whole package's tests are attributed to.)
+    const seg = relative(dir, file).split(sep)[0];
+    const fromMod = pkg.modules.includes(seg) ? seg : pkg.modules[0];
     for (const top of imports(file)) {
-      if (top === pkg.module) continue;          // own module (intra-package)
+      if (pkg.modules.includes(top)) continue;   // own package (intra-package, any of its modules)
       if (!SIBLINGS.has(top)) continue;          // stdlib / third-party — not a sibling package
       // a sibling import. Allowed if a declared pip dep OR a listed allowed-edge.
-      edges.add(`${pkg.module}→${top}`);
+      edges.add(`${fromMod}→${top}`);
       const declared = pkg.deps.has(top) || pkg.deps.has(top.replace(/_/g, "-"));
-      const listed = ALLOWED_EDGES[pkg.module]?.[top];
+      const listed = ALLOWED_EDGES[fromMod]?.[top];
       if (!declared && !listed) {
-        violations.push(`${relative(ROOT, file)} : ${pkg.module} → ${top} (forbidden cross-package import)`);
+        violations.push(`${relative(ROOT, file)} : ${fromMod} → ${top} (forbidden cross-package import)`);
       }
     }
   }
@@ -189,7 +212,7 @@ if (mode === "graph") {
   // 1) every real edge must be a listed allowed-edge (or a declared pip dep).
   for (const e of edges) {
     const [from, to] = e.split("→");
-    const fromPkg = pkgs.find((p) => p.module === from);
+    const fromPkg = pkgs.find((p) => p.modules.includes(from));
     const declared = fromPkg?.deps.has(to) || fromPkg?.deps.has(to.replace(/_/g, "-"));
     if (!ALLOWED_EDGES[from]?.[to] && !declared) bad.push(`unlisted edge: ${from} → ${to}`);
   }

--- a/scripts/gates.mjs
+++ b/scripts/gates.mjs
@@ -942,7 +942,11 @@ function gateDataflow() {
 const CONFIG_CONTRACT_DIR = join(ROOT, "deploy", "contracts", "config.v1");
 // process-plumbing vars a surface may set without a declaration entry (kept TIGHT + documented):
 // interpreter/runtime wiring only, never product config.
-const CONFIG_SURFACE_ALLOW = new Set(["PYTHONUNBUFFERED", "PYTHONPATH", "DISPLAY", "NODE_ENV", "HOSTNAME", "TZ", "PGTZ", "HOME", "TMPDIR"]);
+// An entry here is a hole in the SSOT, so it earns its place by a surface that actually sets it and
+// a service that actually reads it. `HOME` and `TMPDIR` were added by 01-foundation with neither and
+// were removed again on the 0.12.27 candidate: no deploy surface sets them and no adopted service
+// reads them, so all they did was pre-authorise two undeclared reads of values an operator controls.
+const CONFIG_SURFACE_ALLOW = new Set(["PYTHONUNBUFFERED", "PYTHONPATH", "DISPLAY", "NODE_ENV", "HOSTNAME", "TZ", "PGTZ"]);
 // literal env-read spellings the scanner recognizes (Python; `_os` aliases included by substring match)
 const CONFIG_READ_RES = [
   /os\.getenv\(\s*["']([A-Z][A-Z0-9_]*)["']/g,

--- a/scripts/gates.mjs
+++ b/scripts/gates.mjs
@@ -835,10 +835,26 @@ function gateDataflow() {
   // without registering it here and CI goes red.
   const lsdirs = (p) => existsSync(join(ROOT, p)) ? readdirSync(join(ROOT, p)).filter((n) => { try { return statSync(join(ROOT, p, n)).isDirectory(); } catch { return false; } }) : [];
   const required = new Set();
+  const modelPaths = new Set(nodes.flatMap((n) => (n.metadata || []).map((m) => m.path).filter(Boolean)));
   for (const dom of lsdirs("core")) {
     for (const s of lsdirs(`core/${dom}/services`)) required.add(`core/${dom}/services/${s}`);
     for (const m of lsdirs(`core/${dom}/modules`)) required.add(`core/${dom}/modules/${m}`);
     for (const c of lsdirs(`core/${dom}/contracts`)) if (/\.v\d+$/.test(c)) required.add(`core/${dom}/contracts/${c}`);
+    // A domain laid out as a single package — one pyproject.toml over core/<dom>/src/<pkg>… — has
+    // neither services/ nor modules/, so the two loops above ask for NOTHING from it and its modules
+    // could not drift into existence unregistered: they were never required in the first place.
+    // core/flows was exactly that. It holds seven top-level packages and the chart carried three, and
+    // the completeness check — the anti-drift guard — reported nothing, because you cannot detect
+    // drift from a set you never built. Walk core/<dom>/src/* for those domains.
+    //
+    // The one exemption: a domain whose `core/<dom>/src` is ITSELF a registered node (core/runtime,
+    // whose `runtime` service node points there) ships its src as one unit, and asking for its
+    // packages as well would demand a second node for the same code. Registering the dir is the
+    // domain saying "this src is one thing"; not registering it is what leaves the packages
+    // individually accountable.
+    if (lsdirs(`core/${dom}/services`).length || lsdirs(`core/${dom}/modules`).length) continue;
+    if (modelPaths.has(`core/${dom}/src`)) continue;
+    for (const p of lsdirs(`core/${dom}/src`)) required.add(`core/${dom}/src/${p}`);
   }
   for (const c of lsdirs("deploy/contracts")) if (/\.v\d+$/.test(c)) required.add(`deploy/contracts/${c}`);
   // a client that is composed-of (a "mapped" client, e.g. terminal) must register every src/* concern
@@ -850,7 +866,6 @@ function gateDataflow() {
     if (clNode && containers.has(clNode["unique-id"]))
       for (const d of lsdirs(`clients/${cl}/src`)) required.add(`clients/${cl}/src/${d}`);
   }
-  const modelPaths = new Set(nodes.flatMap((n) => (n.metadata || []).map((m) => m.path).filter(Boolean)));
   for (const r of [...required].sort()) if (!modelPaths.has(r)) errs.push(`completeness: '${r}' exists on disk but is not registered in architecture.calm.json`);
   for (const n of nodes) for (const m of (n.metadata || [])) if (m.path && !existsSync(join(ROOT, m.path))) errs.push(`completeness: node '${n["unique-id"]}' points at missing path '${m.path}'`);
 

--- a/scripts/publish-edge.test.mjs
+++ b/scripts/publish-edge.test.mjs
@@ -16,14 +16,16 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { writeFileSync, readFileSync, rmSync, mkdtempSync } from "node:fs";
+import { writeFileSync, readFileSync, readdirSync, mkdirSync, symlinkSync, rmSync, mkdtempSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { tmpdir } from "node:os";
 import { fileURLToPath } from "node:url";
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
 const CONFIG_VALIDATE = join(ROOT, "deploy", "contracts", "config.v1", "validate.mjs");
-const ADMIN_DECL = join(ROOT, "core", "identity", "services", "admin-api", "src", "admin_api", "config.v1.json");
+// Repo-relative + POSIX-separated, because withShadowRepo (below) shadows the tree by that address.
+const ADMIN_DECL_REL = "core/identity/services/admin-api/src/admin_api/config.v1.json";
+const ADMIN_DECL = join(ROOT, ...ADMIN_DECL_REL.split("/"));
 const CENSUS = join(ROOT, "core", "flows", "contracts", "flows.v1", "carriers.json");
 
 // BOTH streams, always. A gate prints its summary to stdout and its REFUSALS to stderr, so a
@@ -31,10 +33,10 @@ const CENSUS = join(ROOT, "core", "flows", "contracts", "flows.v1", "carriers.js
 // an empty string (the exact defect gates.mjs' own errText comment records: an empty Buffer is
 // truthy, so a || chain discards the diagnostic).
 const both = (e) => [e?.stdout, e?.stderr].map((b) => (b ?? "").toString()).join("");
-const gate = (name) => {
+const gate = (name, cwd = ROOT) => {
   try {
     const r = execFileSync("node", [join(ROOT, "scripts", "gates.mjs"), name],
-      { cwd: ROOT, encoding: "utf8", stdio: "pipe" });
+      { cwd, encoding: "utf8", stdio: "pipe" });
     return { ok: true, out: r };
   } catch (e) {
     return { ok: false, out: both(e) };
@@ -68,11 +70,33 @@ const PUBLISH_KEY = {
   targets: ["compose"],
 };
 
-// Restores whatever it replaced, whether the body passes, fails or throws.
-function withReplaced(file, body, fn) {
-  const original = readFileSync(file, "utf8");
-  writeFileSync(file, body);
-  try { return fn(); } finally { writeFileSync(file, original); }
+// Runs `fn(cwd)` against a SHADOW of the repository: a scratch directory whose entries are symlinks
+// back into the real tree, except for `relFile` — a real file, under real directories, holding the
+// sabotaged body. gates.mjs takes its ROOT from `process.cwd()` and reads everything through node's
+// fs (symlinks are transparent to it), so a gate run with the shadow as its cwd sees the sabotage
+// and NOTHING in the checkout is written.
+//
+// The previous shape rewrote the tracked declaration in place and restored it in a `finally`. That
+// is a shared write surface: `node --test scripts/*.test.mjs` runs each file in its OWN process, in
+// parallel, and scripts/gates.test.mjs runs the same gate over the same tree — so it read whichever
+// half of this test's write window it happened to land in and failed, deterministically, on a file
+// it does not own. A test that has to mutate the tree it is asserting about mutates a copy.
+function withShadowRepo(relFile, body, fn) {
+  const shadow = mkdtempSync(join(tmpdir(), "vexa-shadow-"));
+  try {
+    const parts = relFile.split("/");
+    let real = ROOT, here = shadow;
+    for (let i = 0; i < parts.length; i++) {
+      const keep = parts[i];
+      for (const entry of readdirSync(real)) if (entry !== keep) symlinkSync(join(real, entry), join(here, entry));
+      if (i === parts.length - 1) { writeFileSync(join(here, keep), body); break; }
+      mkdirSync(join(here, keep));
+      real = join(real, keep); here = join(here, keep);
+    }
+    return fn(shadow);
+  } finally {
+    rmSync(shadow, { recursive: true, force: true });
+  }
 }
 
 // ── the class exists, and says the one thing the other three cannot ─────────────────────────────
@@ -118,7 +142,7 @@ test("a publish edge whose carrier is in nobody's census is refused", () => {
   // by the publishing domain. Without that check `publishes_events` is a comment.
   const decl = JSON.parse(readFileSync(ADMIN_DECL, "utf8"));
   for (const k of decl.keys) if (k.class === "publish-edge") k.publishes_events = ["nobody.owns.this"];
-  const r = withReplaced(ADMIN_DECL, JSON.stringify(decl, null, 1) + "\n", () => gate("config-contract"));
+  const r = withShadowRepo(ADMIN_DECL_REL, JSON.stringify(decl, null, 1) + "\n", (cwd) => gate("config-contract", cwd));
   assert.equal(r.ok, false, "an unregistered carrier passed the gate");
   assert.match(r.out, /nobody\.owns\.this/);
 });
@@ -131,7 +155,7 @@ test("a publish edge claiming a carrier another domain owns is refused", () => {
   assert.ok(foreign, "the census records no carrier owned by another domain — this test is inert");
   const decl = JSON.parse(readFileSync(ADMIN_DECL, "utf8"));
   for (const k of decl.keys) if (k.class === "publish-edge") k.publishes_events = [foreign.event];
-  const r = withReplaced(ADMIN_DECL, JSON.stringify(decl, null, 1) + "\n", () => gate("config-contract"));
+  const r = withShadowRepo(ADMIN_DECL_REL, JSON.stringify(decl, null, 1) + "\n", (cwd) => gate("config-contract", cwd));
   assert.equal(r.ok, false, `${foreign.event} is owned by ${foreign.owner} and identity published it`);
   assert.match(r.out, new RegExp(foreign.owner));
 });


### PR DESCRIPTION
Car 1 of the v0.12.27 candidate: the three mechanically-red CI items from the code review, plus the two gate blind spots that let one of them stay red without anyone being told what was missing. Review items **A5, A6, A7/B0/C4, A11, E5** from `drafts/2026-09-05-oss-0.12.27-code-review.md`.

## What is in it

- **A7 / B0 / C4 — `gate:dataflow` was RED, and it is a required merge check.** `core/flows/contracts/flows.v1` existed on disk with no CALM node. Registered as a `contract` node (`domain: flows`) inside `flows-composed`; `gate:arch-report` was red behind it and is green again.
- **The same commit closes the wider hole the one line was a symptom of.** `core/flows/src` holds seven top-level packages and the chart carried three. `flows_defs`, `flows_steps`, `flows_schema` and `flows_timeline` are now module nodes in `flows-composed`.
- **`flows-rows` recorded one writer and has two.** `flows-api` admits facts in its own process (`POST /events` → `flows.admit` → `INSERT INTO reaction`) and registers flow versions (`INSERT INTO flow_version`), so the domain's one shared carrier read as single-writer in the chart that exists to say who writes what. Added `flows-api-writes-rows` alongside the existing read edge.
- **The contract's README asserted the registration that did not exist** — "It is registered in `architecture.calm.json`" — for as long as the gate was failing on its absence. Corrected, with what actually happened kept beside it. Its census table was stale the way a census may not be: `meeting.completed` was attributed to flows after F168/F181 handed it to meetings, and `meeting.started` was missing entirely. Regenerated from `carriers.json` (7 carriers), each with the declaration it is read from.
- **E5 — two gates were structurally blind to `core/flows`.** `gate:dataflow` built its completeness set from `core/<dom>/services` and `core/<dom>/modules` only; flows has neither, so the anti-drift guard asked for nothing from it — its four unregistered modules could not drift into existence because they were never required. It now also walks `core/<dom>/src/*` for a domain with no `services/`/`modules/`, exempting only a domain whose `core/<dom>/src` is itself a registered node (`core/runtime`, whose `runtime` service node points there). And `check-isolation-py`'s `moduleOf()` returned one module per package, so a seven-module package was registered by its alphabetically-first module and the other six were not sibling names at all — absent from `SIBLINGS` means read as stdlib or third-party, so an import of `flows_steps` from elsewhere passed as an outside dependency instead of failing as the cross-package edge it is.
- **A5 — CI `static` was red.** `scripts/check-isolation.test.mjs` pins a checker fix (`fb5799a57`, F105) that is not in this range; cherry-picked `-x -s` (it touches only the checker and that test, and the test file in the candidate is byte-identical to the one in that commit, so only the checker moved). Three of the eight rows then still failed: the terminal package declares no `"type"`, node prints a ~230-char `MODULE_TYPELESS_PACKAGE_JSON` warning, and `gate:isolation` forwards only the first 300 chars of a failing brick's stderr — the violation list was pushed out of its own diagnostic. Declared `"type": "module"`; the package holds exactly one `.js` file outside `src/` (that checker) and everything else is already `.mjs`/`.ts`.
- **A6 — CI `static` was red.** `scripts/publish-edge.test.mjs` sabotaged a tracked `config.v1.json` in place and restored it in a `finally`. That is a shared write surface with no owner: `node --test` runs each file in its own process in parallel and `scripts/gates.test.mjs` runs the same gate over the same tree, landing inside the write window. It now builds a shadow of the repository in a tmpdir — symlinks back into the real tree, real directories only along the replaced path — and runs the gate with that as its cwd (`gates.mjs` takes `ROOT` from `process.cwd()`). The checkout is never written.
- **A11** — `HOME` and `TMPDIR` dropped from `CONFIG_SURFACE_ALLOW`. No deploy surface sets them and no adopted service reads them; all they did was pre-authorise two undeclared reads of values an operator controls.

## Negative controls

The gate widening is proved by a planted violation, not by a green run — `import flows_steps` in `core/runtime/src/runtime_kernel/` (planted, then removed):

```
before → ✅ PY-ISOLATION VERIFIED — scanned 184 src/*.py across 9 package(s)
after  → ❌ PY-ISOLATION VIOLATION:
           core/runtime/src/runtime_kernel/zz_probe_tmp.py : runtime_kernel → flows_steps (forbidden cross-package import)
```

No real cross-domain import was surfaced by registering the modules — nothing outside `core/flows` imports a `flows_*` module, and `core/flows` imports no sibling — so nothing was allow-listed to reach green.

## Gate results, verbatim

`node scripts/gates.mjs <gate>` (the runner takes one gate per invocation):

```
▶ gates: readme
  ✓ gate:readme — 347 dirs each carry a README
✅ gates green
▶ gates: isolation
  ✓ gate:isolation — 18 brick(s) checked
✅ gates green
▶ gates: isolation-py
  ✓ gate:isolation-py — every Python sibling import is own-module, declared, or an allowed edge
✅ gates green
▶ gates: graph
  ✓ gate:graph — acyclic + allowed-edges
✅ gates green
▶ gates: graph-py
  ✓ gate:graph-py — Python cross-package edges acyclic + allow-listed
✅ gates green
▶ gates: test-isolation
  ✓ gate:test-isolation — no Python test imports a sibling module's internals (test lane gated, P2)
✅ gates green
▶ gates: exports
  ✓ gate:exports — 14 library package(s) lock their front door
✅ gates green
▶ gates: schema
  ✓ gate:schema — 26 contract(s) conform (goldens ≡ schema)
✅ gates green
▶ gates: contract-version
  ✓ gate:contract-version — 25 sealed contract(s) frozen; 1 unsealed (in development): core/flows/contracts/flows.v1
✅ gates green
▶ gates: config-contract
  ✓ gate:config-contract — 7 adopted service(s) · 267 declared keys · 25 capabilities · 4 publish edge key(s) carrying 3 carrier(s) · 53 lite entrypoint export(s) · declarations ≡ deploy surfaces ≡ code reads (both directions, every surface)
✅ gates green
▶ gates: dataflow
  ✓ gate:dataflow — 98 nodes · 68 edges · 11 carriers · complete + sealed (P23)
     detected writers: bm-status<-{meeting-api,gateway} u-meetings<-{meeting-api}
     shared-writer (review, P23 prefers one): tc-mutable[bot+meeting-api]
     note (advisory, attribution approximate): bm-status<-gateway (declared [meeting-api])
✅ gates green
▶ gates: arch-report
  ✓ gate:arch-report — every modularity principle maps to a green gate (P9)
✅ gates green
```

`node --test scripts/*.test.mjs release/*.test.mjs`, twice in a row, `git status` clean after both:

```
===== RUN 1 =====
ℹ tests 143
ℹ suites 0
ℹ pass 143
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 27116.353166
===== RUN 2 =====
ℹ tests 143
ℹ suites 0
ℹ pass 143
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 25136.847166
```

`node --test scripts/check-isolation.test.mjs` → 8 tests, 8 pass, 0 fail (5 pass / 3 fail before the `"type"` declaration).

Terminal, because `"type": "module"` touches it: `npx vitest run` → 58 files, 462 passed; `npx tsc --noEmit` → clean.

The pre-push hook's static suite ran green; nothing was pushed with `--no-verify`.

## Out of scope for this car

Deliberately untouched (other cars own them): `core/flows/src`, `deploy/`, `core/meetings`, `core/identity`. So A1–A4, C1–C3, A17, E1 and the flows suite's own 23 failures are not addressed here. `flows.v1` remains unsealed by intent — `gate:contract-version` reports it as *in development*, which is what the contract's README says it should be until a consumer exists.

Refs #1553

COMMITMENTS IN THIS DRAFT — none.

<!-- vexa-agent -->
