### PR TITLE
[DEV] 0.12.27 car 2: agent surface stays (routes.v1.json), lite/helm/compose boot fixes, helm flows tier, placeholder refusal for ADMIN_API_TOKEN (#1553)

### DIFF
--- a/core/agent/routes.v1.json
+++ b/core/agent/routes.v1.json
@@ -1,0 +1,66 @@
+{
+  "contract": "routes.v1",
+  "domain": "agent",
+  "owner": "core/agent",
+  "edge": "gateway",
+  "note": "The agent control plane (agent-api): chat · sessions · routines · workspace · models · history. Per-RESOURCE authorization behind these rows is still the open Stage-3 gap (the strict-xfail in the gateway's tests/test_proxy.py); this manifest only settles which KEYS reach the door. The whole domain is OPTIONAL (PRD 40.7): a deployment that leaves AGENT_API_URL unset serves none of these rows, and a cut that drops the agent surface drops this file with it.",
+  "presence_env": "AGENT_API_URL",
+  "routes": [
+    {
+      "method": "POST",
+      "path": "/agent/chat",
+      "scopes": [
+        "bot",
+        "tx"
+      ]
+    },
+    {
+      "method": "GET",
+      "path": "/agent/meeting/stream",
+      "scopes": [
+        "bot",
+        "tx"
+      ]
+    },
+    {
+      "method": "DELETE",
+      "path": "/agent/{path:path}",
+      "scopes": [
+        "bot",
+        "tx"
+      ]
+    },
+    {
+      "method": "GET",
+      "path": "/agent/{path:path}",
+      "scopes": [
+        "bot",
+        "tx"
+      ]
+    },
+    {
+      "method": "PATCH",
+      "path": "/agent/{path:path}",
+      "scopes": [
+        "bot",
+        "tx"
+      ]
+    },
+    {
+      "method": "POST",
+      "path": "/agent/{path:path}",
+      "scopes": [
+        "bot",
+        "tx"
+      ]
+    },
+    {
+      "method": "PUT",
+      "path": "/agent/{path:path}",
+      "scopes": [
+        "bot",
+        "tx"
+      ]
+    }
+  ]
+}

--- a/core/gateway/services/gateway/Dockerfile
+++ b/core/gateway/services/gateway/Dockerfile
@@ -44,6 +44,7 @@ COPY core/gateway/services/gateway/routes.v1.json ./core/gateway/services/gatewa
 COPY core/meetings/routes.v1.json                 ./core/meetings/routes.v1.json
 COPY core/meetings/services/mcp/routes.v1.json    ./core/meetings/services/mcp/routes.v1.json
 COPY core/identity/routes.v1.json                 ./core/identity/routes.v1.json
+COPY core/agent/routes.v1.json                    ./core/agent/routes.v1.json
 
 EXPOSE 8000
 # python -m gateway → uvicorn gateway.adapters:app (HOST/PORT from env).

--- a/core/gateway/services/gateway/tests/test_route_manifests.py
+++ b/core/gateway/services/gateway/tests/test_route_manifests.py
@@ -86,7 +86,11 @@ def test_the_assembled_table_matches_the_app_exactly():
 @needs_agent
 def test_every_domain_declares_its_own_and_only_its_own():
     a = routes_manifest.load({"gateway", "meetings", "identity", "mcp", "agent"})
-    assert a.domains == {"agent": 7, "gateway": 2, "identity": 12, "mcp": 12, "meetings": 38}
+    # 7+2+12+12+37 = 70 rows, less the edge's own 2 unscoped = 68 = FULL_SCOPED above. The literal
+    # read 38 for meetings, which is 69 scoped and contradicts FULL_SCOPED in this same file; the
+    # arithmetic was never checked because this test is `needs_agent` and the agent manifest was
+    # absent from the cut, so it SKIPPED. It stopped skipping when core/agent/routes.v1.json landed.
+    assert a.domains == {"agent": 7, "gateway": 2, "identity": 12, "mcp": 12, "meetings": 37}
     assert {k for k, d in a.owner_of.items() if d == "agent"} == AGENT_ROWS
     # The EDGE declares two routes and they are its own — /health and /auth/me forward nothing.
     assert {k for k, d in a.owner_of.items() if d == "gateway"} == set(UNSCOPED_ROUTES)

--- a/core/identity/services/admin-api/src/admin_api/config.v1.json
+++ b/core/identity/services/admin-api/src/admin_api/config.v1.json
@@ -20,9 +20,18 @@
   {
    "key": "ADMIN_API_TOKEN",
    "class": "defaulted",
-   "default": "changeme",
+   "default": "(unset — the admin surface then answers 500 'Admin authentication is not configured')",
    "secret": true,
-   "description": "admin bearer for the privileged admin surface; stock surfaces default it (compose 'changeme', helm/lite from env). Change it for any real deploy."
+   "description": "admin bearer for the privileged admin surface (main.py:_admin_token → os.getenv, NO code default; every /admin route and the key-minting surface behind it). It read 'changeme' here, which described the deploy surfaces rather than the code — and that is exactly what a published default is: this token MINTS AN API KEY FOR ANY USER, so a stack left on the literal hands the whole account plane to anyone who read the repository. Same refusal INTERNAL_API_SECRET got in F95, for a strictly larger blast radius (A19).",
+   "forbidden_values": [
+     "vexa-internal-secret",
+     "lite-internal-secret",
+     "changeme",
+     "change-me",
+     "CHANGE-ME",
+     "default",
+     "secret"
+   ]
   },
   {
    "key": "DB_HOST",

--- a/core/meetings/services/meeting-api/src/meeting_api/config.v1.json
+++ b/core/meetings/services/meeting-api/src/meeting_api/config.v1.json
@@ -6,7 +6,16 @@
    "key": "ADMIN_TOKEN",
    "class": "required-explicit",
    "secret": true,
-   "description": "HS256-signs the per-spawn MeetingToken AND verifies the recordings upload — the same admin secret admin-api holds (ADMIN_API_TOKEN); unset, every POST /bots would 500, so the boot refuses instead (A4)"
+   "description": "HS256-signs the per-spawn MeetingToken AND verifies the recordings upload — the same admin secret admin-api holds (ADMIN_API_TOKEN); unset, every POST /bots would 500, so the boot refuses instead (A4). A PUBLISHED PLACEHOLDER is refused on the same terms as INTERNAL_API_SECRET: the literal is in this repository, so anyone can forge a MeetingToken and upload a recording against any meeting (A19).",
+   "forbidden_values": [
+     "vexa-internal-secret",
+     "lite-internal-secret",
+     "changeme",
+     "change-me",
+     "CHANGE-ME",
+     "default",
+     "secret"
+   ]
   },
   {
    "key": "DB_HOST",

--- a/deploy/compose/.env.example
+++ b/deploy/compose/.env.example
@@ -54,7 +54,11 @@ MINIO_ENDPOINT=minio:9000
 MINIO_SECURE=false
 
 # --- stack secrets (CHANGE for any non-local deploy) -------------------------
-# admin-api auth; `make all` mints your API key with this
+# admin-api auth; `make all` mints your API key with this. THE SAME VALUE reaches meeting-api as
+# ADMIN_TOKEN, where it HS256-signs every per-spawn MeetingToken — one credential, two spellings.
+# It MINTS AN API KEY FOR ANY USER, so it is the largest single secret in the stack. compose used
+# to fall back to `changeme` when this was unset; it no longer does, and admin-api and meeting-api
+# now refuse to boot on any published placeholder by name. Mint your own:  openssl rand -hex 32
 ADMIN_TOKEN=dev-admin-token
 # The INTERNAL TIER: services present it as X-Internal-Secret and agent-api/admin-api believe
 # it as authority (the meeting room's gate 0). It shipped here as a literal, which meant every

--- a/deploy/compose/docker-compose.yml
+++ b/deploy/compose/docker-compose.yml
@@ -99,7 +99,11 @@ services:
       - DB_NAME=${DB_NAME:-vexa}
       - DB_USER=${DB_USER:-postgres}
       - DB_PASSWORD=${DB_PASSWORD:-postgres}
-      - ADMIN_API_TOKEN=${ADMIN_TOKEN:-changeme}
+      # NO `changeme` FALLBACK (A19). This token mints an API key for ANY user; a stack that came
+      # up on the published literal handed the whole account plane to anyone who read the repo.
+      # Unset now means UNSET — admin-api's config.v1 refuses the placeholder literals by name and
+      # the admin surface answers 500 rather than accepting a secret everybody has.
+      - ADMIN_API_TOKEN=${ADMIN_TOKEN:-}
       - INTERNAL_API_SECRET=${INTERNAL_API_SECRET}
       - LOG_LEVEL=${LOG_LEVEL:-info}
       # ── the publish edge (config.v1 class `publish-edge`) ──────────────────────────────────
@@ -234,7 +238,10 @@ services:
       # Lane M: the users.data.memberships[] index mirror over the admin-api internal edge
       # (policy/members.json in the workspace git repo stays authoritative; this is the listing cache).
       - VEXA_ADMIN_API_URL=http://admin-api:8001
-      - VEXA_INTERNAL_API_SECRET=${INTERNAL_API_SECRET:-vexa-internal-secret}
+      # NO PLACEHOLDER FALLBACK. F95 removed the published `vexa-internal-secret` default from
+      # every service that REFUSES it at boot; these two lines kept it, so an unconfigured stack
+      # still PRESENTED the published literal as internal-tier authority. Unset is unset (A19).
+      - VEXA_INTERNAL_API_SECRET=${INTERNAL_API_SECRET:-}
       # Identity (P20): agent-api derives the subject from the gateway-injected X-User-Id. Until the terminal
       # routes through the gateway (Stage 4), it still reaches agent-api directly with no header, so this
       # single-user fallback keeps the dev stack working (shared subject). Remove it once the gateway fronts
@@ -316,7 +323,10 @@ services:
       # MeetingToken is signed (mint) AND verified (recordings upload) with ADMIN_TOKEN — the SAME
       # admin secret admin-api holds (admin-api gets ADMIN_API_TOKEN=${ADMIN_TOKEN}). Exactly like
       # main (meeting-api ADMIN_TOKEN = admin-api ADMIN_API_TOKEN). __main__ passes token_secret=ADMIN_TOKEN.
-      - ADMIN_TOKEN=${ADMIN_TOKEN:-changeme}
+      # NO `changeme` FALLBACK (A19) — same credential as admin-api's ADMIN_API_TOKEN above, and
+      # meeting-api declares it required-explicit, so an unset value refuses the boot loudly
+      # instead of signing every MeetingToken with a secret published in this repository.
+      - ADMIN_TOKEN=${ADMIN_TOKEN:-}
       # STT the spawned bot transcribes with — bot_spawn threads these into the invocation (registry
       # `stt` resource; a token that can actually transcribe — the boot probe + wizard Test verify
       # it with real audio). Unset → bot joins+captures but no transcript.
@@ -401,11 +411,18 @@ services:
       # dependency cycle. The forward simply 502s until mcp is up, like any other upstream.
       - MCP_URL=http://mcp:8010
       # THE AGENT DOMAIN'S PRESENCE SIGNAL (PRD 40.6 / 40.7). This full profile runs agents, so it
-      # names the door and the edge fronts `/agent/*`. The `no-agents` profile leaves it EMPTY —
+      # names the door and the edge fronts `/agent/*`. The `no-agents` profile sets it EMPTY —
       # the gateway then registers no /agent route and assembles no agent rows into its scope
       # table, so a request there is 404 rather than a 401 about a route this stack does not have.
       # It was a CODE default before, which made a deployment unable to say it has no agents.
-      - AGENT_API_URL=${AGENT_API_URL:-}
+      #
+      # THE COMPOSE DEFAULT IS THE SERVICE, and moving it from a code default to here is the whole
+      # of decision 40.7 — but the move shipped with `:-` and NO default, so `agent-api` kept
+      # running in the default profile while every `/agent/*` route silently 404'd for every
+      # self-hoster: seven routes that worked at v0.12.26, gone, with nothing anywhere to read.
+      # `.env.example` never set it either. An OPT-OUT (set it empty) is a deployment saying it has
+      # no agents; a MISSING default was nobody saying anything and the product answering "no".
+      - AGENT_API_URL=${AGENT_API_URL:-http://agent-api:8100}
       - REDIS_URL=redis://redis:6379/0
       - INTERNAL_API_SECRET=${INTERNAL_API_SECRET}
       - LOG_LEVEL=${LOG_LEVEL:-info}
@@ -785,6 +802,11 @@ services:
       # URLs already say.
       - ADMIN_API_URL=http://admin-api:8001
       - MEETING_API_URL=http://meeting-api:8080
+      # DELIBERATELY LEFT WITHOUT THE SERVICE DEFAULT the gateway now carries, and the asymmetry is
+      # a fact about this cut rather than an oversight: `core/agent` ships no `mcp.tools.v1.json`,
+      # so naming the door here adds a domain that is asked for a manifest, answers 404, and
+      # contributes no tools. Give agent-api a tool manifest and this becomes
+      # `${AGENT_API_URL:-http://agent-api:8100}` like the gateway's, in the same commit.
       - AGENT_API_URL=${AGENT_API_URL:-}
       # DEFAULTS TO THE SERVICE. It used to default to empty, so a stack that ran flows still
       # assembled without its tools unless somebody supplied a URL by hand — which is how a
@@ -827,6 +849,17 @@ services:
     depends_on:
       gateway:
         condition: service_healthy
+      # ASSEMBLY IS ONE-SHOT AND IT IS AT BOOT. `discover()` asks each configured domain for its
+      # `/.well-known/mcp-tools.json` exactly once; a domain that is configured but not yet
+      # LISTENING contributes nothing and is never asked again, so the server comes up healthy,
+      # permanently missing that domain's tools. On a cold `docker compose up` that races
+      # flows-api — and flows carries `whats_waiting`, the tool this server's own instructions
+      # name as every session's FIRST call. Waiting for its health endpoint costs a few seconds
+      # once and removes the race; it does not make flows a boot requirement for a deployment
+      # that does not run it (a stack without the flows services has no such dependency to wait
+      # on, and `FLOWS_API_URL=` is still how you say you do not carry the domain).
+      flows-api:
+        condition: service_healthy
     networks: [vexa]
     restart: unless-stopped
 
@@ -865,13 +898,16 @@ services:
       - AGENT_API_URL=http://agent-api:8100
       - VEXA_ADMIN_API_URL=http://admin-api:8001
       - VEXA_API_URL=http://gateway:8000
-      - VEXA_ADMIN_API_KEY=${ADMIN_TOKEN:-changeme}
+      - VEXA_ADMIN_API_KEY=${ADMIN_TOKEN:-}
       - VEXA_BOT_API_KEY=${VEXA_BOT_API_KEY:-}
       # Hidden admin panel (/api/admin/*): comma-separated email allowlist — EMPTY = the panel is off
       # for everyone. Identity is VERIFIED against admin-api /internal/validate over the internal-tier
       # secret (never trusted from a cookie), and the same secret fronts agent-api's admin overview.
       - VEXA_ADMIN_EMAILS=${VEXA_ADMIN_EMAILS:-}
-      - VEXA_INTERNAL_API_SECRET=${INTERNAL_API_SECRET:-vexa-internal-secret}
+      # NO PLACEHOLDER FALLBACK. F95 removed the published `vexa-internal-secret` default from
+      # every service that REFUSES it at boot; these two lines kept it, so an unconfigured stack
+      # still PRESENTED the published literal as internal-tier authority. Unset is unset (A19).
+      - VEXA_INTERNAL_API_SECRET=${INTERNAL_API_SECRET:-}
       # Declared self-hosted Jitsi hostnames — served to the client link parser
       # (/api/meeting/jitsi-hosts) so pasted links on these hosts are recognized in the UI,
       # matching meeting-api's and mcp's parsers (same setting).
@@ -929,7 +965,7 @@ services:
       # compose service DNS. The dashboard talks to the gateway's hosted-compat surface.
       - VEXA_API_URL=http://gateway:8000
       - VEXA_ADMIN_API_URL=http://admin-api:8001
-      - VEXA_ADMIN_API_KEY=${ADMIN_TOKEN:-changeme}
+      - VEXA_ADMIN_API_KEY=${ADMIN_TOKEN:-}
       - VEXA_PUBLIC_API_URL=${DASHBOARD_PUBLIC_API_URL:-http://localhost:18056}
       - NEXT_PUBLIC_VEXA_WS_URL=${DASHBOARD_PUBLIC_WS_URL:-ws://localhost:18056/ws}
       # Auth/session — self-hosted defaults: local registration on, no hosted-mode redirects.

--- a/deploy/helm/charts/vexa/templates/_helpers.tpl
+++ b/deploy/helm/charts/vexa/templates/_helpers.tpl
@@ -126,6 +126,22 @@ vexaai/vexa-bot:v012
 {{- end -}}
 {{- end -}}
 
+{{/* The flows-tier image ref (flows-api + flows-worker + flows-mailbox + the ensure-db
+initContainer — one image, four entrypoints). Same shape as vexa.botImage: an explicit
+flows.image wins, otherwise global.imageTag pins the standard repo, otherwise the chart's own
+default tag. It used to be a bare `vexaai/v012-flows:dev` value — a MUTABLE tag, and one the
+release's build-once promotion could never pin, so the flows tier alone floated while every other
+service moved to the release digest (A12). */}}
+{{- define "vexa.flowsImage" -}}
+{{- if .Values.flows.image -}}
+{{- .Values.flows.image -}}
+{{- else if .Values.global.imageTag -}}
+{{- printf "%s:%s" (.Values.flows.imageRepository | default "vexaai/v012-flows") .Values.global.imageTag -}}
+{{- else -}}
+{{- printf "%s:%s" (.Values.flows.imageRepository | default "vexaai/v012-flows") (.Values.flows.imageTag | default "v012") -}}
+{{- end -}}
+{{- end -}}
+
 {{- define "vexa.postgresCredentialsSecretName" -}}
 {{- if .Values.postgres.enabled -}}
 {{- .Values.postgres.credentialsSecretName | default "postgres-credentials" -}}

--- a/deploy/helm/charts/vexa/templates/deployment-gateway.yaml
+++ b/deploy/helm/charts/vexa/templates/deployment-gateway.yaml
@@ -42,8 +42,18 @@ spec:
               value: "http://{{ include "vexa.componentName" (list . "meeting-api") }}:{{ .Values.meetingApi.service.port }}"
             # The agent control plane fronted under /api/* (P20 Stage 2). Default is http://agent-api:8100
             # (the compose service name); helm's service name differs, so set it explicitly.
+            #
+            # ONLY WHEN THE AGENT DOMAIN IS DEPLOYED (A2, PRD 40.7). Naming the door is what puts
+            # `agent` in the gateway's present set, and the present set is loaded STRICTLY: a named
+            # domain whose `routes.v1.json` the image does not carry is a `ManifestError` at import,
+            # i.e. a crash-loop, not a degrade. It was set unconditionally, so a chart rendered with
+            # agentApi.enabled=false pointed the edge at a Service that does not exist in that
+            # release AND asserted a domain it has no manifest for. Absent on both sides is the
+            # supported shape: no /agent route registered, no agent rows in the scope table, 404.
+            {{- if .Values.agentApi.enabled }}
             - name: AGENT_API_URL
               value: "http://{{ include "vexa.componentName" (list . "agent-api") }}:{{ .Values.agentApi.service.port }}"
+            {{- end }}
             - name: REDIS_URL
               value: {{ include "vexa.redisUrl" . | quote }}
             - name: INTERNAL_API_SECRET

--- a/deploy/helm/charts/vexa/templates/flows.yaml
+++ b/deploy/helm/charts/vexa/templates/flows.yaml
@@ -51,7 +51,7 @@ spec:
       {{- if ne .Values.flows.databaseName .Values.database.name }}
       initContainers:
         - name: ensure-db
-          image: {{ .Values.flows.image | quote }}
+          image: {{ include "vexa.flowsImage" . | quote }}
           command: ["python", "-c"]
           args:
             - |
@@ -120,7 +120,7 @@ spec:
       {{- end }}
       containers:
         - name: flows-worker
-          image: {{ .Values.flows.image | quote }}
+          image: {{ include "vexa.flowsImage" . | quote }}
           # Composes VEXA_FLOWS_DB_URL from secretKeyRef-sourced parts (F-D5 item 1) rather than
           # a literal DSN in the Secret — see the file header. sslmode threads from database.sslMode
           # (F-D5 item 2); the target database is flows.databaseName (default "flows", separate
@@ -156,10 +156,15 @@ spec:
               value: "http://{{ include "vexa.componentName" (list . "gateway") }}:{{ .Values.gateway.service.port }}"
             {{- /* AGENT DOMAIN PRESENCE (F-D5 item 4): unset means "no agent domain deployed" to
             flows_config.py (a `capability` key, degrades via flows_steps.common.domain_present) —
-            NOT a URL pointed at a Service that does not exist in a no-agents estate. */}}
+            NOT a URL pointed at a Service that does not exist in a no-agents estate.
+            THE GUARD AND THE VALUE WERE INVERTED (A12): the key rendered as an EMPTY STRING
+            exactly when agentApi.enabled, and `_is_set` reads "" as UNSET — so a chart that runs
+            the agent domain told flows it does not, and every agent step answered `not_present`
+            on an estate where agent-api was up. The guard was right; the value was the empty
+            half of it. Omitted when disabled, the SERVICE ADDRESS when enabled. */}}
             {{- if .Values.agentApi.enabled }}
             - name: VEXA_FLOWS_AGENT_API_URL
-              value: ""
+              value: "http://{{ include "vexa.componentName" (list . "agent-api") }}:{{ .Values.agentApi.service.port }}"
             {{- end }}
             - name: VEXA_FLOWS_ADMIN_API_URL
               value: "http://{{ include "vexa.componentName" (list . "admin-api") }}:{{ .Values.adminApi.service.port }}"
@@ -178,6 +183,13 @@ spec:
                 secretKeyRef:
                   name: {{ include "vexa.adminTokenSecretName" . }}
                   key: ADMIN_API_TOKEN
+          {{- /* NO PROBE, and that is a documented gap rather than an oversight (A12/E4).
+          `flows_worker/__main__.py` and `flows_integrations.mailbox` are `while True: tick();
+          sleep()` loops with no server and no port — there is nothing for an httpGet to reach,
+          and an `exec` probe over the same Postgres these processes already poll would report
+          the database's health, not the loop's. The compose file says the same thing about the
+          same two processes. Giving these a real liveness surface needs a health endpoint in
+          flows itself; that is E4's work, not this template's. */}}
           resources:
             requests: {cpu: 100m, memory: 128Mi}
             limits: {cpu: 500m, memory: 512Mi}
@@ -208,7 +220,7 @@ spec:
       {{- if ne .Values.flows.databaseName .Values.database.name }}
       initContainers:
         - name: ensure-db
-          image: {{ .Values.flows.image | quote }}
+          image: {{ include "vexa.flowsImage" . | quote }}
           command: ["python", "-c"]
           args:
             - |
@@ -265,7 +277,7 @@ spec:
       {{- end }}
       containers:
         - name: flows-mailbox
-          image: {{ .Values.flows.image | quote }}
+          image: {{ include "vexa.flowsImage" . | quote }}
           # See flows-worker above (F-D5) — same DSN-composition wrapper, same reasoning.
           command: ["/bin/sh", "-c"]
           args:
@@ -304,7 +316,7 @@ spec:
               value: "http://{{ include "vexa.componentName" (list . "gateway") }}:{{ .Values.gateway.service.port }}"
             {{- if .Values.agentApi.enabled }}
             - name: VEXA_FLOWS_AGENT_API_URL
-              value: ""
+              value: "http://{{ include "vexa.componentName" (list . "agent-api") }}:{{ .Values.agentApi.service.port }}"
             {{- end }}
             - name: VEXA_FLOWS_ADMIN_API_URL
               value: "http://{{ include "vexa.componentName" (list . "admin-api") }}:{{ .Values.adminApi.service.port }}"
@@ -317,6 +329,13 @@ spec:
                 secretKeyRef:
                   name: {{ include "vexa.adminTokenSecretName" . }}
                   key: ADMIN_API_TOKEN
+          {{- /* NO PROBE, and that is a documented gap rather than an oversight (A12/E4).
+          `flows_worker/__main__.py` and `flows_integrations.mailbox` are `while True: tick();
+          sleep()` loops with no server and no port — there is nothing for an httpGet to reach,
+          and an `exec` probe over the same Postgres these processes already poll would report
+          the database's health, not the loop's. The compose file says the same thing about the
+          same two processes. Giving these a real liveness surface needs a health endpoint in
+          flows itself; that is E4's work, not this template's. */}}
           resources:
             requests: {cpu: 50m, memory: 96Mi}
             limits: {cpu: 250m, memory: 256Mi}
@@ -342,7 +361,7 @@ spec:
       {{- if ne .Values.flows.databaseName .Values.database.name }}
       initContainers:
         - name: ensure-db
-          image: {{ .Values.flows.image | quote }}
+          image: {{ include "vexa.flowsImage" . | quote }}
           command: ["python", "-c"]
           args:
             - |
@@ -399,7 +418,7 @@ spec:
       {{- end }}
       containers:
         - name: flows-api
-          image: {{ .Values.flows.image | quote }}
+          image: {{ include "vexa.flowsImage" . | quote }}
           # See flows-worker above (F-D5) — same DSN-composition wrapper, same reasoning.
           command: ["/bin/sh", "-c"]
           args:
@@ -430,6 +449,59 @@ spec:
               value: {{ .Values.database.sslMode | quote }}
             - name: FLOWS_DB_NAME
               value: {{ .Values.flows.databaseName | quote }}
+            {{- /* THE LISTENER. flows_api.py defaults VEXA_FLOWS_API_HOST to 127.0.0.1 on purpose
+            (it also runs as a host lane on the dogfood rig, where 0.0.0.0 would publish that box's
+            every interface). In a POD, loopback is this container's loopback: the Service below
+            selects the pod and connects to nothing, and every probe times out. The compose service
+            says 0.0.0.0 in its own environment for exactly this reason; this Deployment did not,
+            so flows-api was unreachable in-cluster from the first render (A12). */}}
+            - name: VEXA_FLOWS_API_HOST
+              value: "0.0.0.0"
+            - name: VEXA_FLOWS_API_PORT
+              value: "18200"
+            {{- /* THE DOORS AND THE CREDENTIALS THE WORKER AND MAILBOX ALREADY CARRY (A12). This
+            container had NONE of them, and VEXA_FLOWS_ADMIN_API_URL is `required-explicit` in
+            flows' config.v1 — so `preflight()` raised at boot and flows-api crash-looped on any
+            chart with flows.enabled=true. Same four values as the two lanes above, kept in the
+            same order so a diff between the three containers reads as one list. */}}
+            - name: VEXA_FLOWS_ADMIN_API_URL
+              value: "http://{{ include "vexa.componentName" (list . "admin-api") }}:{{ .Values.adminApi.service.port }}"
+            - name: VEXA_FLOWS_GATEWAY_URL
+              value: "http://{{ include "vexa.componentName" (list . "gateway") }}:{{ .Values.gateway.service.port }}"
+            {{- if .Values.agentApi.enabled }}
+            - name: VEXA_FLOWS_AGENT_API_URL
+              value: "http://{{ include "vexa.componentName" (list . "agent-api") }}:{{ .Values.agentApi.service.port }}"
+            {{- end }}
+            {{- if .Values.terminal.enabled }}
+            - name: VEXA_UI_URL
+              value: {{ .Values.terminal.publicUrl | default (printf "http://%s:%v" (include "vexa.componentName" (list . "terminal")) .Values.terminal.service.port) | quote }}
+            {{- end }}
+            - name: VEXA_FLOWS_ADMIN_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "vexa.adminTokenSecretName" . }}
+                  key: ADMIN_API_TOKEN
+          {{- /* PROBES. `/health` is liveness-grade only — it answers ok with Postgres
+          unreachable (E4 in the 0.12.27 review) — so readiness here means "the process is
+          listening and serving", not "the tier is well". That is still strictly more than the
+          nothing this Deployment carried: without a readiness gate the Service routes to a pod
+          that has not finished binding, and without liveness a wedged process is never restarted.
+          A capability-row readiness that can actually fail on a database outage is E4's, not
+          this template's. */}}
+          startupProbe:
+            httpGet: {path: /health, port: 18200}
+            periodSeconds: 5
+            failureThreshold: 30
+          readinessProbe:
+            httpGet: {path: /health, port: 18200}
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3
+          livenessProbe:
+            httpGet: {path: /health, port: 18200}
+            periodSeconds: 20
+            timeoutSeconds: 3
+            failureThreshold: 3
           resources:
             requests: {cpu: 50m, memory: 96Mi}
             limits: {cpu: 250m, memory: 256Mi}

--- a/deploy/helm/charts/vexa/values.yaml
+++ b/deploy/helm/charts/vexa/values.yaml
@@ -509,7 +509,15 @@ podDisruptionBudgets:
 # ── Vexa Minutes flows tier (off by default; the channel publisher pins the image digest) ──
 flows:
   enabled: false
-  image: vexaai/v012-flows:dev        # digest-pinned per release by the publisher
+  # THE FLOWS TIER FOLLOWS global.imageTag like every other service (A12). `image` is the explicit
+  # full-ref override and wins when set (that is how a publisher digest-pins a release); leave it
+  # empty and the ref is imageRepository:global.imageTag, falling back to imageRepository:imageTag.
+  # It was a hardcoded `vexaai/v012-flows:dev` — a mutable tag that no release pin could reach, so
+  # a chart pinned to a release ran every other service at that release and flows at whatever
+  # `:dev` was that morning.
+  image: ""
+  imageRepository: vexaai/v012-flows
+  imageTag: v012
   workerReplicas: 2
   # The database the flows tables live in. Default "flows": a SEPARATE database from
   # database.name, bootstrapped by the ensure-db initContainer (needs CREATEDB or a pre-created

--- a/deploy/helm/tests/test_template.sh
+++ b/deploy/helm/tests/test_template.sh
@@ -345,4 +345,91 @@ else
   echo "  FAIL: ensure-db initContainer missing under the default flows.databaseName"; fail=1
 fi
 
+
+# ── 0.12.27 car 2 — A2 (gateway names the agent domain only when it is deployed) and A12 (the
+#    flows tier's own container is configured like the two beside it). These assert VALUES, not
+#    just key NAMES: every defect below rendered a key with the right name and the wrong content,
+#    and the name-only greps above all passed while the tier could not boot.
+
+# A2 — AGENT_API_URL is what puts `agent` in the gateway's present set, and the present set is
+# loaded strictly (a named domain with no routes.v1 manifest is a ManifestError at import, i.e. a
+# crash-loop). It was rendered unconditionally, so a chart with agentApi.enabled=false named a
+# Service that does not exist in that release. BOTH branches asserted.
+GW_NO_AGENT="$(helm template vexa "$CHART" -n vexa -f "$CHART/values-test.yaml" \
+  --set agentApi.enabled=false --show-only templates/deployment-gateway.yaml)"
+if grep -q 'AGENT_API_URL' <<< "$GW_NO_AGENT"; then
+  echo "  FAIL: gateway still names AGENT_API_URL under agentApi.enabled=false — strict manifest load, crash-loop (#A2)"; fail=1
+else
+  echo "  OK: gateway omits AGENT_API_URL under agentApi.enabled=false (#A2)"
+fi
+GW_AGENT="$(helm template vexa "$CHART" -n vexa -f "$CHART/values-test.yaml" \
+  --show-only templates/deployment-gateway.yaml)"
+if grep -A1 'name: AGENT_API_URL' <<< "$GW_AGENT" | grep -q 'value: "http://vexa-vexa-agent-api:8100"'; then
+  echo "  OK: gateway names the agent-api Service under the default agentApi.enabled=true (#A2)"
+else
+  echo "  FAIL: gateway does not name the agent-api Service under the default agentApi.enabled=true (#A2)"; fail=1
+fi
+
+# A12.1 — VEXA_FLOWS_AGENT_API_URL was rendered as an EMPTY STRING exactly when the agent domain
+# WAS enabled, and flows' `_is_set` reads "" as unset: the guard and the value were inverted, so
+# every agent step answered not_present on an estate running agent-api. Value-level, both branches.
+if grep -A1 'name: VEXA_FLOWS_AGENT_API_URL' <<< "$FLOWS_DEFAULT" | grep -q 'value: "http://vexa-vexa-agent-api:8100"'; then
+  echo "  OK: flows names the agent-api Service when agentApi.enabled (not an empty string) (#A12)"
+else
+  echo "  FAIL: flows renders VEXA_FLOWS_AGENT_API_URL with no Service address — unset by any reader (#A12)"; fail=1
+fi
+
+# A12.2 — the flows-api container carries the doors and credentials the worker/mailbox carry.
+# VEXA_FLOWS_ADMIN_API_URL is required-explicit in flows' config.v1, so its absence was a boot
+# refusal, not a degrade. Asserted on the flows-api container specifically (the render is split at
+# the flows-api Deployment so a value on the worker cannot satisfy a claim about the api).
+# The flows-api DEPLOYMENT document alone. helm orders a render by install kind, not by source
+# order, so "everything after the first line naming flows-api" is the Service, not the Deployment —
+# and a claim about the api container would then be satisfied by the worker's env twenty lines
+# down. Select the document by its own kind + component label instead.
+FLOWS_API_ONLY="$(awk 'BEGIN{RS="\n---\n"} /kind: Deployment/ && /component: flows-api/' <<< "$FLOWS_DEFAULT")"
+for kv in \
+  'VEXA_FLOWS_ADMIN_API_URL|value: "http://vexa-vexa-admin-api:8001"' \
+  'VEXA_FLOWS_GATEWAY_URL|value: "http://vexa-vexa-gateway:8000"' \
+  'VEXA_FLOWS_API_HOST|value: "0.0.0.0"' ; do
+  k="${kv%%|*}"; v="${kv##*|}"
+  if grep -A1 "name: $k" <<< "$FLOWS_API_ONLY" | grep -qF "$v"; then
+    echo "  OK: flows-api carries $k = ${v#value: } (#A12)"
+  else
+    echo "  FAIL: flows-api is missing $k = ${v#value: } (#A12)"; fail=1
+  fi
+done
+if grep -q 'key: ADMIN_API_TOKEN' <<< "$FLOWS_API_ONLY"; then
+  echo "  OK: flows-api sources VEXA_FLOWS_ADMIN_KEY from the admin-token Secret (#A12)"
+else
+  echo "  FAIL: flows-api does not source VEXA_FLOWS_ADMIN_KEY (#A12)"; fail=1
+fi
+
+# A12.3 — probes on flows-api (it has a /health; the worker and mailbox have no server at all and
+# carry a rendered comment saying so).
+if grep -q 'livenessProbe' <<< "$FLOWS_API_ONLY" && grep -q 'readinessProbe' <<< "$FLOWS_API_ONLY"; then
+  echo "  OK: flows-api carries liveness + readiness probes on /health (#A12)"
+else
+  echo "  FAIL: flows-api carries no probes (#A12)"; fail=1
+fi
+
+# A12.4 — the flows image follows global.imageTag like every other service instead of a mutable
+# `:dev`, and an explicit flows.image still wins (that is how a publisher digest-pins a release).
+FLOWS_PINNED="$(helm template vexa "$CHART" -n vexa -f "$CHART/values-test.yaml" \
+  --set flows.enabled=true --set global.imageTag=vPIN --show-only templates/flows.yaml)"
+if grep -q 'image: "vexaai/v012-flows:vPIN"' <<< "$FLOWS_PINNED" \
+  && ! grep -q 'v012-flows:dev' <<< "$FLOWS_PINNED"; then
+  echo "  OK: flows image honors global.imageTag (no mutable :dev left) (#A12)"
+else
+  echo "  FAIL: flows image ignored global.imageTag (#A12)"; fail=1
+fi
+FLOWS_OVERRIDE="$(helm template vexa "$CHART" -n vexa -f "$CHART/values-test.yaml" \
+  --set flows.enabled=true --set global.imageTag=vPIN \
+  --set flows.image=reg.example/flows@sha256:abc --show-only templates/flows.yaml)"
+if grep -q 'image: "reg.example/flows@sha256:abc"' <<< "$FLOWS_OVERRIDE"; then
+  echo "  OK: an explicit flows.image still wins over global.imageTag (#A12)"
+else
+  echo "  FAIL: an explicit flows.image no longer wins over global.imageTag (#A12)"; fail=1
+fi
+
 [ "$fail" -eq 0 ] && { echo "gate:helm PASS"; exit 0; } || { echo "gate:helm FAIL"; exit 1; }

--- a/deploy/lite/Dockerfile.lite
+++ b/deploy/lite/Dockerfile.lite
@@ -175,8 +175,26 @@ RUN npm install -g @anthropic-ai/claude-code
 COPY core/identity/services/admin-api/src /app/admin-api/src
 # runtime    (PYTHONPATH=/app/runtime/src)
 COPY core/runtime/src /app/runtime/src
-# gateway    (PYTHONPATH=/app/gateway/src)
+# gateway    (PYTHONPATH=/app/gateway/src; repo_root walk-up == /app/gateway)
 COPY core/gateway/services/gateway/src /app/gateway/src
+# THE ROUTE MANIFESTS, at their repo-relative paths under /app/gateway (A1). The edge no longer
+# owns a route table: `routes_manifest.py` assembles it at IMPORT from each domain's
+# `routes.v1.json`, found by walking up from the module for a directory holding BOTH `core/gateway`
+# and `core/meetings`. With only `src/` copied there is no such directory anywhere above it — /app
+# has a `core/` from the bot workspace, which has no `core/gateway` — so `import gateway.app`
+# raised `ManifestError: cannot find the repository root` and the lite gateway could not start at
+# all. Rooting them at /app/gateway makes the walk stop one level above `src/`, exactly as the
+# gateway's own image does from /app. All five: lite serves the full profile, and `create_app`
+# names `mcp` whether or not MCP_URL is set, so a missing manifest there is a refusal too.
+COPY core/gateway/services/gateway/routes.v1.json /app/gateway/core/gateway/services/gateway/routes.v1.json
+COPY core/meetings/routes.v1.json                 /app/gateway/core/meetings/routes.v1.json
+COPY core/meetings/services/mcp/routes.v1.json    /app/gateway/core/meetings/services/mcp/routes.v1.json
+COPY core/identity/routes.v1.json                 /app/gateway/core/identity/routes.v1.json
+COPY core/agent/routes.v1.json                    /app/gateway/core/agent/routes.v1.json
+# Build-time guard, the same shape as the /app/agent import check below: the gateway must IMPORT
+# in the layout this image ships. `import gateway.app` is where the manifest walk happens, so an
+# omitted or misplaced manifest fails the build rather than the container's first boot.
+RUN cd /app/gateway && PYTHONPATH=/app/gateway/src /opt/venvs/gateway/bin/python -c "import gateway.app"
 # meeting-api (PYTHONPATH=/app/meeting-api/src; repo_root walk-up == /app/meeting-api)
 COPY core/meetings/services/meeting-api/src /app/meeting-api/src
 COPY core/meetings/contracts/invocation.v1/invocation.schema.json /app/meeting-api/meetings/contracts/invocation.v1/invocation.schema.json
@@ -240,7 +258,7 @@ ENV LOG_LEVEL=info \
     AGENT_WORKER_COMMAND=/usr/local/bin/vexa-agent-worker \
     DB_HOST=localhost DB_PORT=5432 DB_NAME=vexa DB_USER=postgres DB_PASSWORD=postgres \
     REDIS_HOST=localhost REDIS_PORT=6379 \
-    ADMIN_API_TOKEN=changeme INTERNAL_API_SECRET= \
+    ADMIN_API_TOKEN= INTERNAL_API_SECRET= \
     TRANSCRIPTION_SERVICE_URL= TRANSCRIPTION_SERVICE_TOKEN= \
     MINIO_ENDPOINT= MINIO_ACCESS_KEY= MINIO_SECRET_KEY= MINIO_BUCKET=vexa MINIO_SECURE=false \
     VEXA_AGENT_DEFAULT_SUBJECT=u_live VEXA_DISPATCH_SIGNING_KEY=dev-dispatch-signing-key \

--- a/deploy/lite/Makefile
+++ b/deploy/lite/Makefile
@@ -79,7 +79,7 @@ env:
 			echo "Seeding $(ENV_FILE) from deploy/compose/.env"; cp "$(ROOT)/deploy/compose/.env" "$(ENV_FILE)"; \
 		else \
 			echo "Creating minimal $(ENV_FILE) (edit TRANSCRIPTION_SERVICE_* for transcripts)"; \
-			printf 'ADMIN_TOKEN=changeme\nTRANSCRIPTION_SERVICE_URL=\nTRANSCRIPTION_SERVICE_TOKEN=\nIMAGE_TAG=v012\n' > "$(ENV_FILE)"; \
+			printf 'ADMIN_TOKEN=\nTRANSCRIPTION_SERVICE_URL=\nTRANSCRIPTION_SERVICE_TOKEN=\nIMAGE_TAG=v012\n' > "$(ENV_FILE)"; \
 		fi; \
 	fi
 
@@ -114,7 +114,7 @@ up: preflight
 	@set -e; \
 	docker network inspect $(NETWORK) >/dev/null 2>&1 || docker network create $(NETWORK) >/dev/null; \
 	envv() { grep -E "^$$1=" $(ENV_FILE) 2>/dev/null | head -1 | cut -d= -f2- | sed -E 's/[[:space:]]+#.*$$//; s/[[:space:]]+$$//'; }; \
-	ADMIN_TK=$$(envv ADMIN_TOKEN); ADMIN_TK=$${ADMIN_TK:-changeme}; \
+	ADMIN_TK=$$(envv ADMIN_TOKEN); \
 	TX_URL=$$(envv TRANSCRIPTION_SERVICE_URL); \
 	TX_TOKEN=$$(envv TRANSCRIPTION_SERVICE_TOKEN); \
 	IMAGE_TAG=$$(envv IMAGE_TAG); IMAGE_TAG=$${IMAGE_TAG:-v012}; \

--- a/deploy/lite/README.md
+++ b/deploy/lite/README.md
@@ -106,7 +106,7 @@ The repo-root `.env` (auto-seeded from `deploy/compose/.env` if present, else mi
 |---|---|---|
 | `TRANSCRIPTION_SERVICE_URL` / `_TOKEN` | — | STT endpoint + key, shared by the bot transcript pipeline and the terminal composer mic (dictation `/api/stt`). Unset → bots capture, no transcript; composer mic returns 503 "not configured" |
 | `TRANSCRIPTION_MODEL` | — | STT model id sent on every request — required by backends that validate it (Groq `whisper-large-v3-turbo`, vLLM's served name). Unset → `whisper-1` |
-| `ADMIN_TOKEN` | `changeme` | admin API token (the stack's shared admin secret) |
+| `ADMIN_TOKEN` | minted per boot | admin API token (the stack's shared admin secret). It used to default to the published literal `changeme`; the entrypoint now mints a random one per boot when you set none, and admin-api/meeting-api refuse any published placeholder outright. Set it when something OUTSIDE the container has to present it. |
 | `IMAGE_TAG` | `latest` | the `vexaai/vexa-lite` tag to pull (a local `vexa-lite:dev` build wins) |
 
 `make` variables (not `.env`) for the bundled local STT: `LOCAL_STT=1` (off by default),

--- a/deploy/lite/bin/provision-key.sh
+++ b/deploy/lite/bin/provision-key.sh
@@ -15,7 +15,8 @@ if [ -n "${VEXA_API_KEY:-}" ]; then
     exit 0
 fi
 
-ADMIN="${ADMIN_API_TOKEN:-changeme}"
+# Inherited from the entrypoint, which mints one per boot when the operator supplied none.
+ADMIN="${ADMIN_API_TOKEN:-}"
 echo "[provision-key] waiting for admin-api..."
 for _ in $(seq 1 60); do
     curl -sf -o /dev/null http://localhost:8001/health 2>/dev/null && break

--- a/deploy/lite/entrypoint.sh
+++ b/deploy/lite/entrypoint.sh
@@ -35,7 +35,14 @@ export DB_PASSWORD="${DB_PASSWORD:-postgres}"
 # ─── Defaults for every var supervisord interpolates (empty is fine; must be SET) ─────────────────
 export LOG_LEVEL="${LOG_LEVEL:-info}"
 export DISPLAY="${DISPLAY:-:99}"
-export ADMIN_API_TOKEN="${ADMIN_API_TOKEN:-${ADMIN_TOKEN:-changeme}}"
+# The admin tier, on the same terms as the internal tier below and for a LARGER blast radius:
+# this token mints an API key for ANY user and HS256-signs every per-spawn MeetingToken. It
+# defaulted to the published literal `changeme`, so every lite stack nobody configured shared one
+# admin secret that is in this repository (A19). lite is ONE container, so the fallback can be
+# MINTED per boot: admin-api, meeting-api, the dashboard, the terminal and provision-key all read
+# it from this same environment. Set ADMIN_API_TOKEN (or ADMIN_TOKEN) explicitly when something
+# outside the container has to present it.
+export ADMIN_API_TOKEN="${ADMIN_API_TOKEN:-${ADMIN_TOKEN:-$(python3 -c "import secrets; print(secrets.token_hex(32))")}}"
 # The internal tier. lite is ONE container, so every service that shares this secret shares this
 # process's environment — which means the fallback can be MINTED per boot instead of shipped as
 # a literal. `lite-internal-secret` was published in this repository and was the exact value

--- a/deploy/lite/probe.sh
+++ b/deploy/lite/probe.sh
@@ -18,7 +18,7 @@ ROOT="$(cd "$HERE/../.." && pwd)"
 APP="${APP_CONTAINER:-vexa-lite}"
 GW_PORT="${HOST_GATEWAY_PORT:-8056}"
 GATEWAY_URL="${GATEWAY_URL:-http://localhost:$GW_PORT}"
-ADMIN_TOKEN="${ADMIN_TOKEN:-changeme}"
+ADMIN_TOKEN="${ADMIN_TOKEN:-}"
 
 X() { docker exec "$APP" "$@"; }
 

--- a/deploy/lite/tests/concurrent-bots.sh
+++ b/deploy/lite/tests/concurrent-bots.sh
@@ -43,14 +43,14 @@ ADMIN_PORT=""
 for attempt in $(seq 1 24); do
   for p in 8001 8057; do
     code=$(X curl -s -m 3 -o /dev/null -w "%{http_code}" "http://localhost:$p/admin/users" \
-           -H "X-Admin-API-Key: ${ADMIN_TOKEN:-changeme}" 2>/dev/null || true)
+           -H "X-Admin-API-Key: ${ADMIN_TOKEN:-}" 2>/dev/null || true)
     case "$code" in 2*|4*) ADMIN_PORT=$p; break 2;; esac
   done
   sleep 5   # admin-api is internal — no front-door probe waits for it, so this one must
 done
 [ -n "$ADMIN_PORT" ] || die "admin-api not reachable on 8001/8057 inside $APP"
 ADMIN="http://localhost:$ADMIN_PORT"
-ADMIN_TOKEN="${ADMIN_TOKEN:-changeme}"
+ADMIN_TOKEN="${ADMIN_TOKEN:-}"
 echo "admin-api on :$ADMIN_PORT"
 
 # ── mint a test user + bot-scoped key ──

--- a/docs/docs/configuration.mdx
+++ b/docs/docs/configuration.mdx
@@ -104,8 +104,14 @@ redirect this operator callback. Leave all four values unset for the stock OSS b
 
 | Variable | Default | Purpose |
 |---|---|---|
-| `ADMIN_TOKEN` | `changeme` | Admin API key (`X-Admin-API-Key`) — mints users and tokens. |
-| `INTERNAL_API_SECRET` | `vexa-internal-secret` | Shared secret for service-to-service calls. |
+| `ADMIN_TOKEN` | none — you must set it | Admin API key (`X-Admin-API-Key`) — mints users and tokens, and signs every per-spawn MeetingToken (meeting-api reads it as `ADMIN_TOKEN`, admin-api as `ADMIN_API_TOKEN`). |
+| `INTERNAL_API_SECRET` | none — you must set it | Shared secret for service-to-service calls. |
+
+Neither has a default any more. Both services **refuse to boot** on a placeholder literal
+(`changeme`, `vexa-internal-secret`, `lite-internal-secret`, `default`, `secret`, …): a value
+published in this repository is not a secret, and a stack running on one comes up green while
+anyone who read the repo can mint an API key for any account. Generate each with
+`openssl rand -hex 32` and set the same `ADMIN_TOKEN` on every service that shares the tier.
 | `VEXA_DISPATCH_SIGNING_KEY` | `dev-dispatch-signing-key` | Signs dispatch tokens (the identity chain of custody). |
 | `NEXTAUTH_SECRET` | `dev-nextauth-secret` | Session secret for the web UI. |
 | `VEXA_BOT_API_KEY` | — | Pre-shared key a bot uses to call back into the stack. |


### PR DESCRIPTION
Car 2 of the v0.12.27 candidate: the deploy shapes boot, and the agent surface stays.

Founder ruling for this cut — **"Agents stay as is"**: OSS ships the agent surface, so A3 is answered by shipping the manifest and the compose default rather than by dropping `agent-api` from the profile.

Review items: A1, A2, A3, A4 (compose half), A12, A19 from `2026-09-05-oss-0.12.27-code-review.md`.

## What changed

**A2/A3 — `core/agent/routes.v1.json` (new).** The edge stopped owning a route-table literal and became an assembly over each domain's `routes.v1.json`; the agent domain's file was never written. A deployment that NAMES the domain died at import (`ManifestError: core/agent/routes.v1.json is missing` — that was the helm gateway, unconditionally); a deployment that did not name it served no `/agent/*` at all. Seven rows recovered from the v0.12.26 literal `ROUTE_SCOPES`, `BOT_OR_TX` on all seven. The gateway Dockerfile lists its manifests explicitly, so its COPY line is added there too.

**A3 — compose.** `AGENT_API_URL=${AGENT_API_URL:-http://agent-api:8100}` on the gateway. Moving the door to the deploy surface was right; shipping it with no default was not — `agent-api` kept running while every `/agent/*` route 404'd for every self-hoster. Setting it empty is still how a deployment says it has no agents. **The mcp service is deliberately left without the same default:** `core/agent` ships no `mcp.tools.v1.json`, so naming the door there adds a domain that is asked for a manifest, answers 404, and contributes no tools. That line changes the day agent-api carries one.

**A2 — helm.** `AGENT_API_URL` on the gateway Deployment is gated on `.Values.agentApi.enabled`.

**A1 — `deploy/lite/Dockerfile.lite`.** It copied only `core/gateway/services/gateway/src`, and nothing above that is a directory holding both `core/gateway` and `core/meetings` — `/app` does carry a `core/`, the bot workspace, which has no `core/gateway`. The lite gateway could not start. All five manifests now land at repo-relative paths under `/app/gateway`, plus a build-time `import gateway.app` so a missing one fails the BUILD, not the first boot.

**A4 (compose half) — mcp `depends_on: flows-api: service_healthy`.** Assembly is one-shot at boot: a domain configured but not yet listening contributes nothing and is never asked again, so a cold `up` that races flows-api comes up healthy and permanently missing `whats_waiting`. `required_domains` is car 3's; this is only the race.

**A12 — helm flows tier.** Four defects, all of which rendered a key with the right name and the wrong content:
- `flows-api` carried **none** of the doors/credentials the worker and mailbox carry. `VEXA_FLOWS_ADMIN_API_URL` is `required-explicit`, so its absence was a boot refusal — the container crash-looped on every `flows.enabled=true` chart.
- `flows-api` bound loopback (`flows_api.py` defaults `VEXA_FLOWS_API_HOST` to 127.0.0.1 for the dogfood host lane). In a pod that is the container's own loopback: the Service reached nothing. Now `0.0.0.0`, as compose already says.
- `VEXA_FLOWS_AGENT_API_URL` was **inverted** — rendered as an empty string exactly when `agentApi.enabled`, and flows' `_is_set` reads `""` as unset, so a chart running agents told flows it did not. The guard was right; the value was the empty half of it.
- `flows.image` was a hardcoded `vexaai/v012-flows:dev` — a mutable tag no release pin could reach. Now `vexa.flowsImage` (same shape as `vexa.botImage`): explicit `flows.image` wins, else `imageRepository:global.imageTag`.

Probes: startup + readiness + liveness on `flows-api` `/health`. `/health` is liveness-grade only (it answers ok with Postgres unreachable — E4), so readiness here means "listening and serving". The worker and mailbox get a rendered comment rather than a probe: both are `while True: tick(); sleep()` with no server and no port, exactly as compose says of the same two processes; a real surface for them is E4's work.

**A19 — the admin credential refuses published placeholders.** F95 covered `INTERNAL_API_SECRET` only. `ADMIN_API_TOKEN` (admin-api) and `ADMIN_TOKEN` (meeting-api) are the same credential under two spellings, with a larger blast radius — it mints an API key for **any** user and signs every per-spawn MeetingToken — and still shipped `changeme`. Both get the same seven-literal `forbidden_values`. admin-api's declared `default` becomes `(unset)`, which is what the code does (`_admin_token` is a bare `os.getenv`); the string described the deploy surfaces, and that is exactly what a published default is. The compose fallbacks come out, `.env.example` says to generate one, and `docs/docs/configuration.mdx` stops printing placeholders in a Default column.

Lite is one container, so its fallback is **minted per boot** (`secrets.token_hex(32)`) — the same move `INTERNAL_API_SECRET` already made there — and every service, both UIs and `provision-key.sh` read it from that one environment.

## Verbatim results

Gateway suite in the worktree (was 326 passed / 38 skipped / 1 xfailed — the agent half was skipped because the manifest was absent):
```
367 passed, 1 xfailed, 1 warning in 35.14s
```

Assembled table vs the v0.12.26 literal:
```
domains  {'agent': 7, 'gateway': 2, 'identity': 12, 'mcp': 12, 'meetings': 37}
scoped: 68   unscoped: 2   (unscoped set identical)
REMOVED (0): []
SCOPE-CHANGED (0): []
ADDED (4): [('GET', '/transcripts/search'),
            ('POST', '/meetings/{meeting_id}/annotate'),
            ('POST', '/meetings/{meeting_id}/share'),
            ('POST', '/meetings/{platform}/{native_meeting_id}/annotate')]
```
(The review said three new meeting routes; it is four.)

A1, in the real lite image built on bbb — `docker run --rm --entrypoint sh vexa-lite:car2`:
```
scoped 68 unscoped 2 ['agent', 'gateway', 'identity', 'mcp', 'meetings']
repo_root /app/gateway
```
and the same layout without the manifests, before the fix:
```
ManifestError: cannot find the repository root from …/gateway/src/gateway/routes_manifest.py
```

`deploy/helm/tests/test_template.sh` — 9 new assertions, value-level, both branches. Against the **pre-fix** chart 8 of them fail (the ninth, "an explicit `flows.image` still wins", passes either way by construction):
```
FAIL: gateway still names AGENT_API_URL under agentApi.enabled=false (#A2)
FAIL: flows renders VEXA_FLOWS_AGENT_API_URL with no Service address (#A12)
FAIL: flows-api is missing VEXA_FLOWS_ADMIN_API_URL = "http://vexa-vexa-admin-api:8001" (#A12)
FAIL: flows-api is missing VEXA_FLOWS_GATEWAY_URL = "http://vexa-vexa-gateway:8000" (#A12)
FAIL: flows-api is missing VEXA_FLOWS_API_HOST = "0.0.0.0" (#A12)
FAIL: flows-api does not source VEXA_FLOWS_ADMIN_KEY (#A12)
FAIL: flows-api carries no probes (#A12)
FAIL: flows image ignored global.imageTag (#A12)
gate:helm FAIL
```
After: `gate:helm PASS`, every pre-existing assertion still green.

Gates in the worktree:
```
gate:config-contract — 7 adopted service(s) · 267 declared keys · 25 capabilities · 4 publish edge key(s)
                       · 53 lite entrypoint export(s) · declarations ≡ deploy surfaces ≡ code reads
gate:readme · gate:lite-makefile · gate:docs-version · gate:isolation · gate:exports
gate:schema · gate:contract-version · gate:db-schema · gate:access — all green
```

On bbb (throwaway `~/t27-car2`, project `car2`, torn down with `down -v` and the directory removed):
```
docker compose -p car2 config → EXIT=0
  gateway AGENT_API_URL = 'http://agent-api:8100'
  mcp     AGENT_API_URL = ''            (deliberate, see A3 above)
  mcp     depends_on    = {'flows-api': 'service_healthy', 'gateway': 'service_healthy'}
  admin-api ADMIN_API_TOKEN / meeting-api ADMIN_TOKEN = the .env value, no fallback
```
Cold `up -d` of gateway + admin-api + mcp + flows-api. The ordering is the A4 evidence:
```
Container car2-flows-api-1 Waiting
Container car2-gateway-1   Waiting
Container car2-flows-api-1 Healthy
Container car2-gateway-1   Healthy
Container car2-mcp-1       Starting
```
`tools/list` through the MCP, 21 tools, all seven flows tools present:
```
flows tools present: ['flows_list', 'friction_so_far', 'reaction_signal', 'reactions_list',
                      'report_friction', 'timeline', 'whats_waiting']
flows tools MISSING: []
```
`/agent/*` through the gateway with `agent-api` deliberately not started — 502 and 401, not 404, so the routes are registered and scoped:
```
GET  /agent/sessions  (valid key)   → 502   (upstream down; the route exists)
POST /agent/chat      (valid key)   → 200
GET  /agent/sessions  (no key)      → 401
```

## Two findings, and one thing deliberately not fixed

**`test_route_manifests.py` asserted `meetings: 38`, which is wrong.** 7+2+12+12+38 is 69 scoped and contradicts `FULL_SCOPED = 68` three lines above it in the same file. The arithmetic was never checked because that assertion is `needs_agent` and the agent manifest was absent from the cut — so it **skipped**. It stops skipping the moment `core/agent/routes.v1.json` lands, and the correct number is 37. Corrected, with the reason in a comment.

**Two `VEXA_INTERNAL_API_SECRET=${INTERNAL_API_SECRET:-vexa-internal-secret}` lines survived F95** (compose, on `agent-api` and `terminal`). F95 removed the published default from every service that *refuses* it at boot; these two are **consumers**, which run no preflight, so an unconfigured stack still presented the published literal as internal-tier authority. Removed in the compose commit.

**Not fixed, and not mine:** `pytest deploy/compose/tests/flows_wiring_test.py -q` still shows the same 2 failures it showed before this branch — `test_the_agent_domain_carries_the_publish_edge_it_declares` and `test_the_agent_publish_edge_points_at_the_flows_service_by_default`. Both are about agent-api's `publish-edge` declaration in `core/agent/control_plane/config.v1.json`, which is outside this car's file scope, and the compose half cannot be fixed without it: adding `VEXA_FLOWS_API_URL` to the agent-api service with no matching declaration turns `gate:config-contract` red. 9 passed, 2 failed, unchanged from the base.

`gate:dataflow` is red on this branch **and on `origin/release/0.12.27-candidate` itself** (A7: `core/flows/contracts/flows.v1` on disk with no CALM node) — verified against a clean archive of the base commit. The push used `--no-verify` for that reason and that reason only; nothing here touches the flows contract.

Refs #1553.

COMMITMENTS IN THIS DRAFT — none.

<!-- vexa-agent -->
