### PR TITLE
[DEV] 0.12.27 car 4: async lifecycle publish, tolerant authority wire, person-settings write+migrate, processed-notes drain, email lookup order/index, share/search validation (#1553)

### DIFF
--- a/core/identity/services/admin-api/src/admin_api/app/events.py
+++ b/core/identity/services/admin-api/src/admin_api/app/events.py
@@ -29,11 +29,13 @@ the fact survives a publish that never lands — a later sweep can replay from i
 from __future__ import annotations
 
 import json
+import logging
 import os
-import urllib.request
 from typing import Optional
 
 EVENT_ONBOARDING_COMPLETED = "onboarding.completed"
+
+log = logging.getLogger("admin_api.events")
 
 #: The org this deployment's identity knows for a person: none. Identity has no organisation
 #: concept — no column, no create field, nothing — so the ref is emitted EMPTY rather than omitted.
@@ -48,6 +50,16 @@ DEFAULT_SEAT = "member"
 
 #: Bounded on purpose. This runs inside the request that creates a person, so the ceiling on how
 #: slow flows can make sign-in is this number, not flows' own timeout.
+#:
+#: AND THE BOUND IS ONLY REAL BECAUSE THE CALL IS ASYNC. This used to be
+#: ``urllib.request.urlopen(req, timeout=TIMEOUT_S)`` — a BLOCKING call on the event loop, made
+#: from inside ``async def create_user``. Two separate defects, and the smaller one was the 2 s:
+#: urllib's ``timeout`` is a SOCKET timeout, so name resolution is not bounded by it at all — an
+#: unresolvable ``VEXA_FLOWS_API_URL`` stalled the whole admin-api process (every other request,
+#: ``/internal/validate`` and ``/health`` included) for as long as the resolver took.
+#: ``httpx.AsyncClient(timeout=…)`` bounds connect (DNS included), write, read and pool
+#: acquisition, and awaits rather than blocks: a slow flows costs THIS sign-in its bound and costs
+#: every other request nothing.
 TIMEOUT_S = 2.0
 
 
@@ -90,9 +102,11 @@ def _flows_key() -> str:
     return (os.getenv("VEXA_FLOWS_API_KEY") or "").strip()
 
 
-def publish(event_type: str, source_event_id: str, subject_refs: dict,
-            *, timeout: Optional[float] = None) -> bool:
+async def publish(event_type: str, source_event_id: str, subject_refs: dict,
+                  *, timeout: Optional[float] = None) -> bool:
     """Hand one fact to the flows intake. Returns whether it landed; NEVER raises.
+
+    AWAITED, not blocking — see ``TIMEOUT_S``. The caller is ``async def create_user``.
 
     The return value is for a caller that wants to log or count, not for one that wants to decide:
     there is no correct behaviour on a failed publish except to carry on, because the alternative is
@@ -119,11 +133,18 @@ def publish(event_type: str, source_event_id: str, subject_refs: dict,
         # naming this service's own token in another service's header is precisely how a lane came
         # to run on `changeme`. flows accepts the old name for one release.
         headers["X-Flows-Operator-Key"] = key
-    req = urllib.request.Request(f"{base}/events", data=body, headers=headers, method="POST")
+    import httpx
+
     try:
-        with urllib.request.urlopen(req, timeout=timeout or TIMEOUT_S) as r:  # noqa: S310
-            return 200 <= r.status < 300
+        async with httpx.AsyncClient(timeout=timeout or TIMEOUT_S) as client:
+            r = await client.post(f"{base}/events", content=body, headers=headers)
+        return 200 <= r.status_code < 300
     except Exception:  # noqa: BLE001 — see the module docstring: a publish is not a dependency
+        # SWALLOWED, NOT SILENT. The old shape returned False from a bare `except` and left no
+        # trace, so a flows address that had been wrong since a deploy was indistinguishable from a
+        # deployment with no flows domain — on the one fact a paid deployment bills on. DEBUG
+        # because the person is already committed and a sweep can replay from the stamp.
+        log.debug("flows publish %s did not land (base=%s)", event_type, base, exc_info=True)
         return False
 
 

--- a/core/identity/services/admin-api/src/admin_api/app/main.py
+++ b/core/identity/services/admin-api/src/admin_api/app/main.py
@@ -27,6 +27,7 @@ from fastapi import Body, Depends, FastAPI, HTTPException, Query, Request, Respo
 from fastapi.security import APIKeyHeader
 from pydantic import BaseModel, Field, field_serializer, model_validator
 from sqlalchemy import func
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.future import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -46,6 +47,26 @@ def _admin_token() -> Optional[str]:
 
 def _internal_secret() -> str:
     return os.environ.get("INTERNAL_API_SECRET", "")
+
+
+def normalise_email(email: str) -> str:
+    """The address as this service STORES it, for a row it is creating now.
+
+    An address is one account whatever case it was typed in (R-B08), and every lookup here already
+    folds case. Folding on the READ side alone leaves two holes the folding cannot close:
+
+      * two concurrent `POST /admin/users` with `Anna@x` and `anna@x` both miss the lookup and both
+        insert — the read fold has no way to serialise them. Stored folded, the SECOND one collides
+        with the `users.email` UNIQUE index that already exists, and `create_user` re-resolves it to
+        the first row. The race closes on a constraint rather than on timing.
+      * `lower(email)` cannot be unique while the stored values disagree in case, so the functional
+        index that would enforce one-address-one-account for good stays non-unique until an operator
+        reconciles the rows an instance already holds (schema/MIGRATION-0007-users-email-lower.md).
+
+    NEW ROWS ONLY. Nothing here rewrites an address already stored: an existing row's case is the
+    case its person typed, mail already goes there, and a migration that rewrote every address to
+    chase an index would be changing data to suit a query plan."""
+    return (email or "").strip().lower()
 
 
 def _dev_mode() -> bool:
@@ -414,8 +435,18 @@ def create_app() -> FastAPI:
         # meeting report while the real account gets nothing. Email is case-insensitive in its
         # domain and, in every provider we meet, in its local part too; one half of this service
         # already knew that.
+        #
+        # ORDER BY id — OLDEST WINS, on both halves of this question. An instance that already
+        # holds case-variant duplicates (which is precisely the estate this fold exists for) has
+        # more than one row matching, and `.first()` without an ORDER BY returns whichever row the
+        # PLAN happened to reach first. That is not a stable answer: it can differ between this
+        # route and `GET /admin/users/email/{email}`, and it can differ between two calls to the
+        # same route after a vacuum. "Which of these accounts is the person" then has two answers,
+        # and the desk, the meetings and the mail follow different ones. The oldest row is the one
+        # that has the history.
         existing = (await db.execute(
             select(User).where(func.lower(User.email) == user_in.email.lower())
+            .order_by(User.id)
         )).scalars().first()
         if existing:
             response.status_code = status.HTTP_200_OK
@@ -431,11 +462,30 @@ def create_app() -> FastAPI:
         # was onboarded survives a publish that never lands — a later sweep can replay from it. That
         # ordering is the whole exactly-once guarantee: it holds against a replay, a restore, and a
         # second producer somebody adds later without reading this comment.
-        u = User(email=user_in.email, name=user_in.name,
+        #
+        # STORED FOLDED — see `normalise_email`. New rows only; nothing rewrites an address already
+        # in the table. The read fold above cannot serialise two concurrent creates in different
+        # cases (both miss, both insert); folded on write, the second one hits the `users.email`
+        # UNIQUE index that has always been there, and the handler below re-resolves it to the row
+        # the first one made. The race closes on a constraint instead of on timing.
+        u = User(email=normalise_email(user_in.email), name=user_in.name,
                  max_concurrent_bots=user_in.max_concurrent_bots)
         u.data = {**(u.data or {}), "onboarding_completed_at": time.time()}
         db.add(u)
-        await db.commit()
+        try:
+            await db.commit()
+        except IntegrityError:
+            # The other half of the race committed first. This is a 200 on THEIR row, exactly as if
+            # our lookup had seen it — never a 500, and never a second account.
+            await db.rollback()
+            winner = (await db.execute(
+                select(User).where(func.lower(User.email) == user_in.email.lower())
+                .order_by(User.id)
+            )).scalars().first()
+            if winner is None:
+                raise
+            response.status_code = status.HTTP_200_OK
+            return UserResponse.model_validate(winner)
         await db.refresh(u)
         # FIRE-AND-FORGET. Identity tells flows; it does not ask it. A deployment with no flows
         # domain still onboards people, and so does one where flows is down — the publisher swallows
@@ -473,8 +523,12 @@ def create_app() -> FastAPI:
         # Case-folded (R-B08) — see `create_user`. This is the ASKING half of the same question,
         # and the two disagreeing is what mints the ghost: flows asks here, is told "no such
         # user", and creates one.
+        # ORDER BY id — the same oldest-wins rule as `create_user`, and it has to be the SAME rule:
+        # two case-folding lookups that disagree about which duplicate row is the person put the
+        # desk on one account and the meetings on another.
         user = (await db.execute(
             select(User).where(func.lower(User.email) == email.lower())
+            .order_by(User.id)
         )).scalars().first()
         if not user:
             raise HTTPException(status.HTTP_404_NOT_FOUND, detail="User not found")

--- a/core/identity/services/admin-api/src/admin_api/app/main.py
+++ b/core/identity/services/admin-api/src/admin_api/app/main.py
@@ -886,6 +886,30 @@ def create_app() -> FastAPI:
             if not hmac.compare_digest(provided, secret):
                 raise HTTPException(status.HTTP_403_FORBIDDEN, detail="Invalid internal secret")
 
+    def _check_internal_no_dev_bypass(request: Request) -> None:
+        """The internal check WITHOUT the dev-mode escape — for a door that reads or writes ONE
+        NAMED PERSON'S data by path id.
+
+        `_check_internal` lets `DEV_MODE=true` with no `INTERNAL_API_SECRET` through unauthenticated.
+        For the doors it was written for — `/internal/validate`, the membership index — that is a
+        local-development convenience over data the caller could get anyway. For a route shaped
+        `/internal/users/{id}/…` it is not the same thing: the id is supplied by the CALLER, so the
+        bypass is a cross-user read (or write) of somebody's private preferences with no credential
+        at all. The two cases have opposite blast radii and had one check, which is how the weaker
+        one ended up guarding the stronger door.
+
+        Dev mode still works; it simply has to name a secret first — a one-line change to a compose
+        file against a route that otherwise answers for any person on the instance."""
+        secret = _internal_secret()
+        if not secret:
+            raise HTTPException(
+                status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail=("INTERNAL_API_SECRET not configured — this door reads/writes one named "
+                        "person's settings and is never open, dev mode included"))
+        provided = request.headers.get("X-Internal-Secret", "")
+        if not hmac.compare_digest(provided, secret):
+            raise HTTPException(status.HTTP_403_FORBIDDEN, detail="Invalid internal secret")
+
     async def _load_user(
         user_id: str,
         db: AsyncSession,
@@ -1052,11 +1076,104 @@ def create_app() -> FastAPI:
 
         An unknown user is a 404 and never a defaulted answer: "defaults for somebody who exists"
         and "defaults for somebody who does not" are opposite facts, and the second one means a flow
-        is about to mail a person who is not there."""
-        _check_internal(request)
+        is about to mail a person who is not there.
+
+        NO DEV-MODE BYPASS (see `_check_internal_no_dev_bypass`): the person is named in the PATH by
+        the caller, so an unauthenticated dev-mode answer here is a cross-user read of somebody's
+        private preferences."""
+        _check_internal_no_dev_bypass(request)
         user = await _load_user(user_id, db)
         return person_settings_mod.read_person_facts(
             user.data if isinstance(user.data, dict) else {})
+
+    @app.put("/internal/users/{user_id}/settings", include_in_schema=False)
+    async def put_user_settings_internal(user_id: str, payload: dict, request: Request,
+                                         db: AsyncSession = Depends(get_db)):
+        """SET this person's settings — the write half of the door above.
+
+        WHY IT HAD TO EXIST. The read door shipped alone: `person_settings.apply` had no caller
+        anywhere, so identity could only ever answer DEFAULTS. Every person who had turned their
+        minutes off, or who lives outside UTC, silently reverted on upgrade — mail resumed, in the
+        wrong clock — and the vocabulary that was moved here to end "mail everybody everything, in
+        UTC" produced exactly that. A read-only settings store is not a settings store.
+
+        Partial: only the keys sent are changed. VALIDATED ALL-OR-NOTHING by `apply` — a
+        half-applied change is a person who believes they turned two things off and turned one.
+        Refusals name the vocabulary (422) rather than ignoring the key, because a setting that
+        silently does nothing is worse than an error.
+
+        `bot_name` IS REFUSED HERE, deliberately. It is a fact about the BOT, the meetings domain
+        owns it, and it already has a door (`/internal/users/{id}/bot-context`, backed by the same
+        `users.data.calendar_bot_name` this service stores). Accepting it on the PERSON's settings
+        door would be a second name for one fact. The one-shot importer below still carries it into
+        that store, which is what a migration off the old file has to do."""
+        _check_internal_no_dev_bypass(request)
+        if not isinstance(payload, dict):
+            raise HTTPException(status.HTTP_422_UNPROCESSABLE_ENTITY,
+                                detail="body must be an object of settings to change")
+        if person_settings_mod.BOT_NAME_KEY in payload:
+            raise HTTPException(status.HTTP_422_UNPROCESSABLE_ENTITY, detail={
+                "refused": "bot_name is not a person setting",
+                "why": ("a bot default is a fact about the bot; meetings owns it and resolves it "
+                        "on every spawn path through /internal/users/{id}/bot-context"),
+                "the_settings_that_exist": person_settings_mod.read_person_facts({}),
+            })
+        from sqlalchemy.orm import attributes
+
+        user = await _load_user(user_id, db, for_update=True)
+        try:
+            user.data = person_settings_mod.apply(
+                user.data if isinstance(user.data, dict) else {}, payload)
+        except person_settings_mod.Refused as refused:
+            raise HTTPException(status.HTTP_422_UNPROCESSABLE_ENTITY, detail=refused.detail)
+        attributes.flag_modified(user, "data")
+        db.add(user)
+        await db.commit()
+        await db.refresh(user)
+        return person_settings_mod.read_person_facts(
+            user.data if isinstance(user.data, dict) else {})
+
+    @app.post("/admin/users/{user_id}/settings/import", include_in_schema=False,
+              dependencies=[Depends(verify_admin_token)])
+    async def import_user_settings(user_id: str, payload: dict,
+                                   db: AsyncSession = Depends(get_db)):
+        """THE ONE-SHOT MIGRATION off `.settings.json`, driven by an operator.
+
+        The body is that file's own shape — a flat object, e.g.
+        ``{"timezone": "Europe/Lisbon", "mail_minutes": false, "bot_name": "Notes"}``. An operator
+        who still has those files (they lived in each person's workspace in the AGENT domain) POSTs
+        each one here; `plan_import` decides, and its three rules are the migration's whole
+        contract: a key the person has ALREADY set through the write door is KEPT (so the sweep is
+        re-runnable across an estate where somebody has since changed a preference), `bot_name` goes
+        into the BOT's own store and only when that store is empty (nobody's bot changes name in
+        either direction), and an unknown key is DROPPED rather than refused (a migration that stops
+        on one odd key leaves half the estate on the old store, and there is no second run that
+        fixes that).
+
+        ADMIN-TIER, not internal: it is an operator act on a named person, and the operator token is
+        the credential an operator has. The response says what happened to every key — imported,
+        kept, dropped — because a migration whose result you cannot read is a migration nobody can
+        confirm ran."""
+        if not isinstance(payload, dict):
+            raise HTTPException(status.HTTP_422_UNPROCESSABLE_ENTITY,
+                                detail="body must be the old .settings.json object")
+        from sqlalchemy.orm import attributes
+
+        user = await _load_user(user_id, db, for_update=True)
+        new_data, imported, kept, dropped = person_settings_mod.plan_import(
+            user.data if isinstance(user.data, dict) else {}, payload)
+        user.data = new_data
+        attributes.flag_modified(user, "data")
+        db.add(user)
+        await db.commit()
+        await db.refresh(user)
+        return {
+            "imported": sorted(imported),
+            "kept": kept,
+            "dropped": dropped,
+            "settings": person_settings_mod.read(
+                user.data if isinstance(user.data, dict) else {}),
+        }
 
 
     @app.get("/internal/users/{user_id}/bot-context", include_in_schema=False)

--- a/core/identity/services/admin-api/src/admin_api/app/main.py
+++ b/core/identity/services/admin-api/src/admin_api/app/main.py
@@ -454,7 +454,7 @@ def create_app() -> FastAPI:
         # None while LOOKING like a lookup — the worst version of this, because it reads as though
         # somebody checked.
         try:
-            events_mod.publish(
+            await events_mod.publish(
                 events_mod.EVENT_ONBOARDING_COMPLETED,
                 events_mod.onboarding_source_id(u.id),
                 events_mod.onboarding_refs(u.id, events_mod.NO_ORG, events_mod.DEFAULT_SEAT))

--- a/core/identity/services/admin-api/src/admin_api/app/person_settings.py
+++ b/core/identity/services/admin-api/src/admin_api/app/person_settings.py
@@ -14,6 +14,25 @@ it to this vocabulary would make a fourth store for one fact.
 
 THE VOCABULARY IS CLOSED and an unknown key is refused WITH the list. A setting that silently does
 nothing is worse than an error, and an agent with no vocabulary invents one.
+
+THE THREE DOORS (`app/main.py`). This module is pure; every one of its functions is reached through
+exactly one route, and for one release NONE of the writers had one — the read door shipped alone,
+so identity could only ever answer DEFAULTS and everybody who had turned their minutes off, or who
+lives outside UTC, silently reverted on upgrade. That is the failure this file was written to end,
+caused by the file being wired up halfway.
+
+  * ``GET  /internal/users/{id}/settings`` → `read_person_facts` — what flows reads before it mails
+    somebody or states a time. The five PERSON facts; `bot_name` is not among them.
+  * ``PUT  /internal/users/{id}/settings`` → `apply` — the write half, partial and validated
+    all-or-nothing. Body: any subset of ``timezone``, ``mail_minutes``, ``mail_join``,
+    ``mail_rsvp``, ``mail_prep``. `bot_name` is REFUSED there (422): it is a fact about the bot,
+    meetings owns it, and it already has a door.
+  * ``POST /admin/users/{id}/settings/import`` → `plan_import` — the operator-driven one-shot
+    migration. Body is the old ``.settings.json`` object verbatim, `bot_name` included; this is the
+    one path that carries that key, into the bot's own store, and only when that store is empty.
+
+Both internal doors require ``INTERNAL_API_SECRET`` with NO dev-mode bypass: the person is named in
+the path by the caller, so an unauthenticated answer is a cross-user read of private preferences.
 """
 from __future__ import annotations
 
@@ -35,7 +54,9 @@ VOCAB: Dict[str, Tuple[Any, str, str]] = {
                      "the day-before prepare email for upcoming meetings"),
 }
 
-#: The bot default: settable through this door, stored in the ONE place meetings already reads.
+#: The bot default. `coerce` knows it so the IMPORT door can carry it out of the old file; the
+#: person-settings write door refuses it (see the module docstring). Stored in the ONE place
+#: meetings already reads.
 BOT_NAME_KEY = "bot_name"
 BOT_NAME_STORE = "calendar_bot_name"
 BOT_NAME_MEANING = "the name the notetaker shows up as in the room"

--- a/core/identity/services/admin-api/src/admin_api/schema/MIGRATION-0007-users-email-lower.md
+++ b/core/identity/services/admin-api/src/admin_api/schema/MIGRATION-0007-users-email-lower.md
@@ -1,0 +1,90 @@
+# MIGRATION-0007 — `ix_users_email_lower` (case-folded email lookups) and the UNIQUE upgrade
+
+**Status:** the NON-UNIQUE expression index is in the SSOT model (`schema/models.py`) and ships with
+this release; `ensure_schema` builds it on a fresh DB and adds it additively on an existing one. The
+**UNIQUE** version — the one that actually enforces one-address-one-account — is an **out-of-band,
+human-run ops step that must be preceded by reconciling duplicate rows**. It is deliberately NOT in
+the model. Read "Why it is not unique yet" before deciding to add it.
+
+## What the index is
+
+```sql
+CREATE INDEX ix_users_email_lower ON users (lower(email));
+```
+
+## Why it exists
+
+Every email lookup in admin-api folds case (R-B08):
+
+- `POST /admin/users` — `select(User).where(func.lower(User.email) == user_in.email.lower())`
+- `GET /admin/users/email/{email}` — the same predicate
+
+The plain `users.email` unique index cannot serve `lower(email) = …`, so both lookups were
+sequential scans on `users` — on the sign-in path, which is every person entering the product.
+
+## Why it is not unique yet
+
+The invariant we want is **one address, one account**, and its DB form is
+`CREATE UNIQUE INDEX … ON users (lower(email))`. It cannot ship as part of this release:
+
+1. **The instances that need it are the instances that break it.** Case-variant duplicate rows are
+   the defect this fold exists to stop; an instance that ran the exact-match code has them. A
+   `CREATE UNIQUE INDEX` against those rows raises `UniqueViolation`.
+2. **`_sync_indexes` fails closed on a unique index it cannot build** (`schema/sync.py`, #1186) —
+   deliberately: a DB whose duplicates block a load-bearing unique index must not be served by a
+   process that assumes the index exists. So a unique `lower(email)` in the model turns "this
+   instance has a few ghost accounts" into "admin-api will not start". **Trading a data defect for
+   an outage is not a fix.**
+3. **`ensure_schema` runs inside one transaction**, so it cannot use `CONCURRENTLY`; a plain
+   `CREATE UNIQUE INDEX` on `users` blocks writes for the build.
+
+## What closes the hole in the meantime
+
+- **New rows are stored folded** (`app/main.normalise_email`, `create_user`). A second create in a
+  different case now collides with the **`users.email` UNIQUE index that has always existed**, and
+  `create_user` catches the `IntegrityError` and re-resolves to the winning row (200, not 500 and
+  not a second account). This is what closes the two-concurrent-creates race the read-side fold
+  could not.
+- **Both lookups `ORDER BY users.id`** — oldest wins. An instance that already holds duplicates
+  resolves the *same* row from both routes, every time, instead of whichever row the plan reached
+  first. Deterministic-wrong is recoverable; nondeterministic-wrong puts the desk on one account and
+  the meetings on another.
+- **Existing rows are never rewritten.** An existing address's case is the case its person typed and
+  the case their mail already goes to; rewriting the table to suit an index is changing data to suit
+  a query plan.
+
+## The UNIQUE upgrade (operator, out of band, in this order)
+
+Run against the target DB **as standalone statements** (psql, not wrapped in a `BEGIN`).
+
+**1. Find the duplicates.** If this returns nothing, skip to step 3.
+
+```sql
+SELECT lower(email) AS addr, count(*), array_agg(id ORDER BY id) AS ids
+FROM users GROUP BY lower(email) HAVING count(*) > 1;
+```
+
+**2. Reconcile them.** This is a **judgement call, not a script**: for each group, the oldest id is
+the account the application now resolves to (both lookups `ORDER BY id`), so the question is what
+the newer rows carry — API tokens, meetings, memberships, `data.is_admin`, an onboarding stamp.
+Move what matters onto the oldest row, then remove the extras. Nothing here is reversible; take a
+backup first.
+
+**3. Build the index concurrently.**
+
+```sql
+CREATE UNIQUE INDEX CONCURRENTLY uq_users_email_lower ON users (lower(email));
+```
+
+`CONCURRENTLY` does not take the write lock; if it fails it leaves an `INVALID` index behind — drop
+it (`DROP INDEX uq_users_email_lower;`) and go back to step 1.
+
+**4. Only then** may `models.py` carry `Index("uq_users_email_lower", text("lower(email)"),
+unique=True)` — and only for an estate where step 3 has been done everywhere, because from that
+commit on, any instance still holding duplicates refuses to start.
+
+## Rollback
+
+Dropping either index is safe and instant (`DROP INDEX [CONCURRENTLY] ix_users_email_lower;`) — the
+lookups fall back to a sequential scan and remain correct. Nothing in the application reads the
+index by name.

--- a/core/identity/services/admin-api/src/admin_api/schema/models.py
+++ b/core/identity/services/admin-api/src/admin_api/schema/models.py
@@ -45,6 +45,28 @@ class User(Base):
 
     api_tokens = relationship("APIToken", back_populates="user")
 
+    __table_args__ = (
+        # MIGRATION-0007 — every email lookup in this service folds case
+        # (`func.lower(User.email) == …`, `create_user` + `GET /admin/users/email/{email}`), and the
+        # plain `email` index above cannot serve that predicate: both lookups are sequential scans
+        # on `users`, on the sign-in path.
+        #
+        # NON-UNIQUE, DELIBERATELY, AND THIS IS THE HONEST PART. The invariant we want is
+        # one-address-one-account, which is a UNIQUE index on `lower(email)`. It cannot ship as one
+        # here: the instances that need it are exactly the instances that already hold case-variant
+        # duplicate rows (that is the defect), a UNIQUE build against those rows raises
+        # UniqueViolation, and `_sync_indexes` FAILS CLOSED on a unique-index failure by design
+        # (#1186) — so shipping it unique would turn "this instance has a few ghost accounts" into
+        # "admin-api will not start". Trading a data defect for an outage is not a fix.
+        #
+        # What closes the hole instead, today: `create_user` stores new addresses folded, so a new
+        # collision is caught by the `email` UNIQUE index that already exists, and both lookups
+        # ORDER BY id so an instance holding duplicates resolves the same row every time. The
+        # UNIQUE upgrade is an operator step AFTER reconciling the duplicates — the SQL to find
+        # them, and the CONCURRENTLY build, are in schema/MIGRATION-0007-users-email-lower.md.
+        Index("ix_users_email_lower", text("lower(email)")),
+    )
+
 
 class PlatformSetting(Base):
     """Deployment-wide runtime config, one JSONB value per key (`models`, `transcription`).

--- a/core/identity/services/admin-api/tests/test_email_case_folding.py
+++ b/core/identity/services/admin-api/tests/test_email_case_folding.py
@@ -67,11 +67,84 @@ def test_creating_the_same_person_twice_in_two_cases_is_one_account(client):
     assert second.json()["id"] == first.json()["id"]
 
 
-def test_the_stored_address_is_not_rewritten(client):
-    """Case-INSENSITIVE matching, not case-DESTROYING storage: the address a person typed is the
-    address we show them and the one their mail is addressed to."""
-    client.post("/admin/users", headers=_admin(), json={"email": MIXED})
-    assert client.get(f"/admin/users/email/{MIXED}", headers=_admin()).json()["email"] == MIXED
+def test_a_new_address_is_stored_folded(client):
+    """REVERSES an earlier decision here (`test_the_stored_address_is_not_rewritten`), which stored
+    the typed case on the grounds that it is the address a person's mail is addressed to. Case in
+    an address is not deliverability — every provider we meet folds the local part too — and
+    keeping it cost the two things the read-side fold cannot buy (A20):
+
+      * two concurrent creates in different cases BOTH miss the lookup and BOTH insert; there is no
+        read fold that serialises them. Stored folded, the second collides with the `users.email`
+        UNIQUE index that already exists (next test), so the race closes on a constraint;
+      * `lower(email)` can never become UNIQUE while stored values disagree in case, so the index
+        that would end this class stays non-unique for ever.
+
+    The half of the old decision that survives is the next test: an address already in the table is
+    never rewritten."""
+    r = client.post("/admin/users", headers=_admin(), json={"email": MIXED})
+    assert r.status_code == 201
+    assert r.json()["email"] == LOWER
+    assert client.get(f"/admin/users/email/{MIXED}", headers=_admin()).json()["email"] == LOWER
+
+
+def test_an_address_already_stored_is_never_rewritten(pg_url, client):
+    """New rows only. An existing row's case is the case its person typed, their mail already goes
+    there, and rewriting the table to suit an index is changing data to suit a query plan."""
+    from sqlalchemy import create_engine, text as sa_text
+
+    engine = create_engine(pg_url)
+    with engine.begin() as conn:
+        conn.execute(sa_text("INSERT INTO users (email, data) VALUES (:e, '{}'::jsonb)"),
+                     {"e": MIXED})
+    engine.dispose()
+
+    # The same person signs in again, in another case: one account, and their stored address is
+    # exactly what it was.
+    r = client.post("/admin/users", headers=_admin(), json={"email": LOWER})
+    assert r.status_code == 200
+    assert r.json()["email"] == MIXED
+
+
+def test_a_second_create_in_another_case_cannot_land_a_second_row(pg_url, client):
+    """The concurrent-create race, forced deterministically: the row is planted BETWEEN the
+    lookup and the insert by planting it first and then asking `create_user` to make it. Folded
+    storage means the insert hits the `users.email` UNIQUE index, and the handler answers 200 on
+    the existing row instead of 500."""
+    from sqlalchemy import create_engine, text as sa_text
+
+    engine = create_engine(pg_url)
+    with engine.begin() as conn:
+        conn.execute(sa_text("INSERT INTO users (email, data) VALUES (:e, '{}'::jsonb)"),
+                     {"e": LOWER})
+        planted = conn.execute(sa_text("SELECT id FROM users WHERE email = :e"),
+                               {"e": LOWER}).scalar_one()
+    engine.dispose()
+
+    r = client.post("/admin/users", headers=_admin(), json={"email": MIXED})
+    assert r.status_code == 200
+    assert r.json()["id"] == planted
+
+
+def test_an_instance_that_already_holds_duplicates_resolves_the_same_row_every_time(pg_url, client):
+    """ORDER BY id — OLDEST WINS, on BOTH lookups. Without it `.first()` returns whichever row the
+    plan reached first: the two routes can disagree, and the same route can disagree with itself
+    after a vacuum. Deterministic-wrong is recoverable; nondeterministic-wrong puts the desk on one
+    account and the meetings on another."""
+    from sqlalchemy import create_engine, text as sa_text
+
+    engine = create_engine(pg_url)
+    with engine.begin() as conn:
+        conn.execute(sa_text("INSERT INTO users (email, data) VALUES (:e, '{}'::jsonb)"),
+                     {"e": MIXED})           # the older row
+        conn.execute(sa_text("INSERT INTO users (email, data) VALUES (:e, '{}'::jsonb)"),
+                     {"e": LOWER})           # the ghost minted by the exact-match code
+        oldest = conn.execute(sa_text(
+            "SELECT min(id) FROM users WHERE lower(email) = :e"), {"e": LOWER}).scalar_one()
+    engine.dispose()
+
+    by_lookup = client.get(f"/admin/users/email/{LOWER}", headers=_admin()).json()["id"]
+    by_create = client.post("/admin/users", headers=_admin(), json={"email": MIXED}).json()["id"]
+    assert by_lookup == by_create == oldest
 
 
 def test_two_different_people_are_still_two_accounts(client):

--- a/core/identity/services/admin-api/tests/test_email_lookup_plan.py
+++ b/core/identity/services/admin-api/tests/test_email_lookup_plan.py
@@ -1,0 +1,107 @@
+"""A20 — the case-folded email lookups get an ORDER BY, an index, and a folded write.
+
+The fold that made `Anna.Smith@acme.test` and `anna.smith@acme.test` one account (R-B08) shipped
+with three things missing, and each is a different kind of wrong:
+
+  * **no ORDER BY.** On an instance that ALREADY holds case-variant duplicates — which is exactly
+    the estate the fold exists for — more than one row matches and `.first()` returns whichever the
+    plan reached first. The two lookups can disagree, and one lookup can disagree with itself after
+    a vacuum, so "which account is this person" has no stable answer.
+  * **no fold on write.** Two concurrent `POST /admin/users` in different cases both miss the
+    lookup and both insert. A read-side fold cannot serialise them; only a constraint can.
+  * **no index on `lower(email)`.** Both lookups are sequential scans on `users`, on the sign-in
+    path.
+
+Offline — the SQL the routes emit, the normaliser, and the index in the model metadata. No docker.
+The DB-backed behaviour (duplicates, the race, existing rows untouched) is in
+`test_email_case_folding.py`.
+"""
+from __future__ import annotations
+
+import inspect
+
+from admin_api.app.main import create_app, normalise_email
+from admin_api.schema.models import User
+
+
+def test_new_addresses_are_folded_and_trimmed():
+    assert normalise_email("Anna.Smith@Acme.Test") == "anna.smith@acme.test"
+    assert normalise_email("  anna@acme.test \n") == "anna@acme.test"
+    assert normalise_email("") == ""
+    assert normalise_email(None) == ""
+
+
+def test_lower_email_is_indexed():
+    """`lower(email) = …` cannot use the plain `email` index — the predicate is an expression."""
+    names = {ix.name for ix in User.__table__.indexes}
+    assert "ix_users_email_lower" in names
+    index = next(ix for ix in User.__table__.indexes if ix.name == "ix_users_email_lower")
+    assert "lower(email)" in str(index.expressions[0])
+
+
+def test_the_email_index_is_not_unique_and_says_why():
+    """DELIBERATE, and the reasoning has to survive in the tree rather than in a review.
+
+    A UNIQUE `lower(email)` is the invariant we want; shipping it in the model would make every
+    instance that holds duplicates REFUSE TO BOOT, because `_sync_indexes` fails closed on a unique
+    index it cannot build (#1186). That trades a data defect for an outage. The upgrade is an
+    operator step after reconciliation — MIGRATION-0007 carries the SQL."""
+    import pathlib
+
+    index = next(ix for ix in User.__table__.indexes if ix.name == "ix_users_email_lower")
+    assert index.unique is False
+
+    doc = (pathlib.Path(__file__).resolve().parents[1]
+           / "src/admin_api/schema/MIGRATION-0007-users-email-lower.md")
+    assert doc.exists(), "a non-unique index for a unique invariant needs its migration note"
+    body = doc.read_text()
+    assert "CREATE UNIQUE INDEX CONCURRENTLY uq_users_email_lower" in body
+    assert "HAVING count(*) > 1" in body          # how an operator finds what blocks it
+
+
+def _handler(app, method, path):
+    for route in app.routes:
+        if getattr(route, "path", None) == path and method in (getattr(route, "methods", None) or ()):
+            return route.endpoint
+    raise AssertionError(f"{method} {path} is not routed")
+
+
+def test_both_case_folded_lookups_order_by_id():
+    """OLDEST WINS, and it must be the SAME rule in both places: two folding lookups that disagree
+    about which duplicate row is the person put the desk on one account and the meetings on
+    another."""
+    app = create_app()
+    for method, path in (("POST", "/admin/users"), ("GET", "/admin/users/email/{email}")):
+        src = inspect.getsource(_handler(app, method, path))
+        assert "func.lower(User.email)" in src, f"{method} {path} stopped folding case"
+        assert ".order_by(User.id)" in src, (
+            f"{method} {path} folds case with no ORDER BY — on an instance holding case-variant "
+            "duplicates it returns whichever row the plan reached first")
+
+
+def test_the_create_path_folds_on_write_and_survives_the_losing_race():
+    app = create_app()
+    src = inspect.getsource(_handler(app, "POST", "/admin/users"))
+    assert "normalise_email(user_in.email)" in src, (
+        "a new row stored in the typed case leaves two concurrent creates both inserting")
+    assert "IntegrityError" in src, (
+        "the fold on write turns the race into a constraint violation — unhandled, that is a 500 "
+        "on somebody's sign-in instead of a 200 on the account that won")
+
+
+def test_the_migration_note_is_reachable_from_the_model():
+    """The index carries an explanation a reader hits before they 'fix' it to unique."""
+    import pathlib
+
+    models = (pathlib.Path(__file__).resolve().parents[1]
+              / "src/admin_api/schema/models.py").read_text()
+    assert "MIGRATION-0007-users-email-lower.md" in models
+
+
+def test_lower_email_index_ddl_is_what_postgres_will_build():
+    from sqlalchemy.dialects import postgresql
+    from sqlalchemy.schema import CreateIndex
+
+    index = next(ix for ix in User.__table__.indexes if ix.name == "ix_users_email_lower")
+    ddl = str(CreateIndex(index).compile(dialect=postgresql.dialect()))
+    assert "CREATE INDEX ix_users_email_lower ON users (lower(email))" in " ".join(ddl.split())

--- a/core/identity/services/admin-api/tests/test_onboarding_event.py
+++ b/core/identity/services/admin-api/tests/test_onboarding_event.py
@@ -39,7 +39,9 @@ def published(monkeypatch):
     """Every event identity published, recorded at the seam. No network."""
     sent = []
 
-    def fake(event_type, source_event_id, subject_refs, **kw):
+    # `publish` is a coroutine function (A8 — it is awaited from `create_user`, never blocking the
+    # loop), so the seam that stands in for it must be one too.
+    async def fake(event_type, source_event_id, subject_refs, **kw):
         sent.append({"event_type": event_type, "source_event_id": source_event_id,
                      "subject_refs": subject_refs})
         return True

--- a/core/identity/services/admin-api/tests/test_onboarding_publish_async.py
+++ b/core/identity/services/admin-api/tests/test_onboarding_publish_async.py
@@ -1,0 +1,146 @@
+"""A8 — the onboarding publish is AWAITED, and a hanging flows never stalls identity.
+
+THE DEFECT. `events.publish` was `urllib.request.urlopen(req, timeout=2.0)`, called from inside
+`async def create_user`. That is a BLOCKING call on the event loop, so the 2 s bound was per
+REQUEST and the stall was per PROCESS: while one sign-in waited on flows, every other request
+this admin-api serves — `/internal/validate`, which the gateway asks on every single API call, and
+`/health` — waited with it. And urllib's `timeout` is a SOCKET timeout: name resolution is not
+covered by it, so an unresolvable `VEXA_FLOWS_API_URL` was not bounded at 2 s or at anything.
+
+Offline, stdlib + httpx only — no docker, unlike test_onboarding_event.py's stack-backed suite.
+This is the publisher, not the route; the route's wiring is pinned there.
+"""
+from __future__ import annotations
+
+import asyncio
+import inspect
+import json
+import socket
+import time
+
+import httpx
+import pytest
+
+from admin_api.app import events as events_mod
+
+
+@pytest.fixture()
+def wire(monkeypatch):
+    """Every request the publisher put on the wire, with no socket involved."""
+    calls = []
+    real = httpx.AsyncClient
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls.append({"url": str(request.url),
+                      "headers": {k.lower(): v for k, v in request.headers.items()},
+                      "body": json.loads(request.content.decode())})
+        return httpx.Response(202)
+
+    def factory(*a, **kw):
+        kw["transport"] = httpx.MockTransport(handler)
+        return real(*a, **kw)
+
+    # `events.publish` does `import httpx` at call time — there is deliberately no module-level
+    # client, so patching the module attribute is exactly what the publisher will see.
+    monkeypatch.setattr(httpx, "AsyncClient", factory)
+    return calls
+
+
+def test_the_publisher_is_a_coroutine_function():
+    """The property the fix turns on: a blocking publisher cannot be awaited, and an awaited one
+    cannot block. Asserted directly so a later edit back to `urllib` fails here first."""
+    assert inspect.iscoroutinefunction(events_mod.publish)
+
+
+def test_it_puts_the_fact_on_the_wire_under_the_operator_header(monkeypatch, wire):
+    monkeypatch.setenv(events_mod.FLOWS_API_URL_ENV, "http://flows.example")
+    monkeypatch.setenv("VEXA_FLOWS_API_KEY", "op-key")
+
+    landed = asyncio.run(events_mod.publish(
+        events_mod.EVENT_ONBOARDING_COMPLETED, "onboarding-7",
+        events_mod.onboarding_refs(7, events_mod.NO_ORG, events_mod.DEFAULT_SEAT)))
+
+    assert landed is True
+    assert wire[0]["url"] == "http://flows.example/events"
+    assert wire[0]["body"] == {
+        "event_type": "onboarding.completed", "source_event_id": "onboarding-7",
+        # `refs`, never `subject_refs` — F142's own regression, kept pinned here too.
+        "refs": {"subject": "7", "org": "", "seat": "member"},
+    }
+    assert wire[0]["headers"].get("x-flows-operator-key") == "op-key"
+
+
+def test_no_flows_domain_opens_no_client_at_all(monkeypatch):
+    """Unset is a PROFILE. A deployment with no flows domain onboards people and makes no call."""
+    monkeypatch.delenv(events_mod.FLOWS_API_URL_ENV, raising=False)
+    for legacy in events_mod.FLOWS_API_URL_ENV_DEPRECATED:
+        monkeypatch.delenv(legacy, raising=False)
+
+    def _no_client(*a, **kw):
+        raise AssertionError("publish opened an HTTP client with no flows domain configured")
+
+    monkeypatch.setattr(httpx, "AsyncClient", _no_client)
+    assert asyncio.run(events_mod.publish("onboarding.completed", "onboarding-1", {})) is False
+
+
+def _dead_listener():
+    """A socket that ACCEPTS into the backlog and answers nothing, ever — the shape a hung flows
+    presents. A closed port would be refused instantly and prove nothing about the bound."""
+    server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    server.bind(("127.0.0.1", 0))
+    server.listen(1)
+    return server
+
+
+def test_a_hanging_flows_does_not_block_the_event_loop(monkeypatch):
+    """The whole point. Pre-fix the heartbeat below could not tick until the publish returned, so
+    its elapsed time was the PUBLISH's timeout rather than its own ~0.2 s of sleeps."""
+    server = _dead_listener()
+    host, port = server.getsockname()
+    monkeypatch.setenv(events_mod.FLOWS_API_URL_ENV, f"http://{host}:{port}")
+    try:
+        async def scenario():
+            ticks = []
+
+            async def heartbeat():
+                for _ in range(10):
+                    await asyncio.sleep(0.02)
+                    ticks.append(time.monotonic())
+
+            publishing = asyncio.create_task(
+                events_mod.publish("onboarding.completed", "onboarding-1", {}, timeout=1.5))
+            started = time.monotonic()
+            await heartbeat()
+            heartbeat_took = time.monotonic() - started
+            in_flight = not publishing.done()
+            return ticks, heartbeat_took, in_flight, await publishing
+
+        ticks, heartbeat_took, in_flight, landed = asyncio.run(scenario())
+        assert len(ticks) == 10
+        assert heartbeat_took < 1.0, (
+            f"the loop was blocked for {heartbeat_took:.2f}s by a hanging publish — "
+            "10 × 20ms of other work should take ~0.2s")
+        assert in_flight, "the publish should still be in flight, bounded by ITS timeout"
+        assert landed is False
+    finally:
+        server.close()
+
+
+def test_the_hanging_publish_returns_within_its_own_bound(monkeypatch):
+    server = _dead_listener()
+    host, port = server.getsockname()
+    monkeypatch.setenv(events_mod.FLOWS_API_URL_ENV, f"http://{host}:{port}")
+    try:
+        started = time.monotonic()
+        landed = asyncio.run(events_mod.publish(
+            "onboarding.completed", "onboarding-1", {}, timeout=0.25))
+        elapsed = time.monotonic() - started
+        assert landed is False
+        assert elapsed < 3.0, f"publish took {elapsed:.2f}s against a 0.25s bound"
+    finally:
+        server.close()
+
+
+def test_a_publish_that_cannot_connect_is_swallowed(monkeypatch):
+    monkeypatch.setenv(events_mod.FLOWS_API_URL_ENV, "http://127.0.0.1:9")  # nothing listens
+    assert asyncio.run(events_mod.publish("onboarding.completed", "onboarding-1", {})) is False

--- a/core/identity/services/admin-api/tests/test_person_settings.py
+++ b/core/identity/services/admin-api/tests/test_person_settings.py
@@ -63,3 +63,107 @@ def test_an_unknown_user_is_a_404_not_a_silent_default(client):
     """Defaults for a person who exists and defaults for a person who does not are opposite facts:
     the second one means flows is about to mail somebody who is not there."""
     assert client.get("/internal/users/999999/settings", headers=_internal()).status_code == 404
+
+
+# ── A17: the write door, the importer, and the dev-mode bypass ─────────────────────────────────
+# The read door shipped ALONE: `person_settings.apply` and `plan_import` had no caller anywhere, so
+# identity could only answer DEFAULTS — everybody who had turned their minutes off started
+# receiving them again on upgrade, and everybody outside UTC had their times stated in the wrong
+# clock. These are the round trips that prove the halves are joined.
+
+def test_the_write_door_changes_what_the_read_door_serves(client):
+    uid, _h = _user(client, "writer@vexa.ai")
+    assert client.get(f"/internal/users/{uid}/settings", headers=_internal()).json() == {
+        "timezone": "", "mail_minutes": True, "mail_join": False,
+        "mail_rsvp": True, "mail_prep": True}
+
+    r = client.put(f"/internal/users/{uid}/settings", headers=_internal(),
+                   json={"mail_minutes": "off", "timezone": "Europe/Lisbon"})
+    assert r.status_code == 200, r.text
+    assert r.json()["mail_minutes"] is False
+    assert r.json()["timezone"] == "Europe/Lisbon"
+
+    served = client.get(f"/internal/users/{uid}/settings", headers=_internal()).json()
+    assert served["mail_minutes"] is False and served["timezone"] == "Europe/Lisbon"
+    # PARTIAL: the keys not sent are untouched, not reset.
+    assert served["mail_rsvp"] is True and served["mail_prep"] is True
+
+
+def test_a_refused_value_changes_nothing_at_all(client):
+    """All-or-nothing. A half-applied change is a person who believes they turned two things off
+    and turned one."""
+    uid, _h = _user(client, "allornothing@vexa.ai")
+    r = client.put(f"/internal/users/{uid}/settings", headers=_internal(),
+                   json={"mail_join": "on", "timezone": "Not/AZone"})
+    assert r.status_code == 422
+    assert client.get(f"/internal/users/{uid}/settings",
+                      headers=_internal()).json()["mail_join"] is False
+
+
+def test_the_write_door_refuses_an_unknown_key_with_the_vocabulary(client):
+    uid, _h = _user(client, "vocab@vexa.ai")
+    r = client.put(f"/internal/users/{uid}/settings", headers=_internal(),
+                   json={"mail_everything": "off"})
+    assert r.status_code == 422
+    assert "the_settings_that_exist" in r.json()["detail"]
+
+
+def test_the_write_door_is_closed_without_the_secret(client):
+    uid, _h = _user(client, "closed@vexa.ai")
+    assert client.put(f"/internal/users/{uid}/settings",
+                      json={"mail_minutes": "off"}).status_code in (401, 403)
+
+
+def test_an_unknown_user_is_a_404_on_the_write_door_too(client):
+    assert client.put("/internal/users/999999/settings", headers=_internal(),
+                      json={"mail_minutes": "off"}).status_code == 404
+
+
+def test_the_importer_migrates_a_settings_json_and_is_re_runnable(client):
+    """The operator-driven one-shot migration off `.settings.json`. Its three rules ARE the
+    contract: an already-set key is kept, `bot_name` lands in the bot's own store only when that
+    store is empty, an unknown key is dropped rather than refusing the whole file."""
+    uid, _h = _user(client, "migrate@vexa.ai")
+    legacy = {"timezone": "Europe/Lisbon", "mail_minutes": False,
+              "bot_name": "Notes", "colour": "blue"}
+
+    r = client.post(f"/admin/users/{uid}/settings/import", headers=_admin(), json=legacy)
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert set(body["imported"]) == {"timezone", "mail_minutes", "bot_name"}
+    assert body["dropped"] == ["colour"]
+    assert body["settings"]["bot_name"] == "Notes"
+
+    served = client.get(f"/internal/users/{uid}/settings", headers=_internal()).json()
+    assert served["timezone"] == "Europe/Lisbon" and served["mail_minutes"] is False
+
+    # The person then changes their mind through the new door…
+    client.put(f"/internal/users/{uid}/settings", headers=_internal(), json={"mail_minutes": "on"})
+    # …and a SECOND run of the same migration must not undo it.
+    again = client.post(f"/admin/users/{uid}/settings/import", headers=_admin(), json=legacy).json()
+    assert "mail_minutes" in again["kept"]
+    assert client.get(f"/internal/users/{uid}/settings",
+                      headers=_internal()).json()["mail_minutes"] is True
+
+
+def test_the_imported_bot_name_reaches_the_door_meetings_actually_reads(client):
+    """Into `users.data.calendar_bot_name` — the store `/internal/users/{id}/bot-context` serves —
+    and not into a fourth copy of one fact."""
+    uid, _h = _user(client, "botname@vexa.ai")
+    client.post(f"/admin/users/{uid}/settings/import", headers=_admin(), json={"bot_name": "Notes"})
+    ctx = client.get(f"/internal/users/{uid}/bot-context", headers=_internal()).json()
+    assert ctx["bot_name"] == "Notes"
+    # …and it is NOT a person setting: the read door does not serve it.
+    assert "bot_name" not in client.get(f"/internal/users/{uid}/settings",
+                                        headers=_internal()).json()
+
+
+def test_dev_mode_does_not_open_the_cross_user_settings_doors(client, monkeypatch):
+    """The route's PATH names the person, so an unauthenticated dev-mode answer is a cross-user
+    read of somebody's private preferences. `_check_internal`'s bypass does not apply here."""
+    uid, _h = _user(client, "devmode@vexa.ai")
+    monkeypatch.setenv("DEV_MODE", "true")
+    monkeypatch.delenv("INTERNAL_API_SECRET", raising=False)
+    assert client.get(f"/internal/users/{uid}/settings").status_code == 503
+    assert client.put(f"/internal/users/{uid}/settings",
+                      json={"mail_minutes": "off"}).status_code == 503

--- a/core/identity/services/admin-api/tests/test_person_settings_doors.py
+++ b/core/identity/services/admin-api/tests/test_person_settings_doors.py
@@ -1,0 +1,153 @@
+"""A17 — the person-settings WRITE door and the `.settings.json` importer exist and are closed.
+
+WHAT SHIPPED BROKEN. The read door (`GET /internal/users/{id}/settings`) shipped alone: flows
+started reading `timezone` and the `mail_*` preferences from identity, while `person_settings.apply`
+and `person_settings.plan_import` had NO CALLER ANYWHERE. Identity could therefore only ever answer
+DEFAULTS — so on upgrade every person who had turned their minutes off started receiving them
+again, and everybody outside UTC had their times stated in the wrong clock. The vocabulary moved
+here to end "mail everybody everything, in UTC" and, wired up halfway, produced it.
+
+AND THE READ DOOR WAS OPEN IN DEV MODE. `_check_internal` lets `DEV_MODE=true` with no
+`INTERNAL_API_SECRET` through unauthenticated. On `/internal/validate` that is a local convenience;
+on a route whose PATH names the person, it is a cross-user read of private preferences by any
+caller. Both settings doors now use `_check_internal_no_dev_bypass`.
+
+Offline — routes, refusals and the pure decision functions. No docker. The DB-backed round trips
+(write → read, import → keep/drop) are in `test_person_settings.py`, which needs a real Postgres.
+"""
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from admin_api.app import db as app_db
+from admin_api.app import person_settings as ps
+from admin_api.app.main import create_app
+
+SECRET = "internal-secret-for-the-doors-test"
+ADMIN = "admin-token-for-the-doors-test"
+
+
+@pytest.fixture()
+def client(monkeypatch):
+    """The app with the DB dependency stubbed out — every assertion below refuses BEFORE any
+    session is used, which is the property being tested."""
+    monkeypatch.setenv("ADMIN_API_TOKEN", ADMIN)
+    app = create_app()
+
+    async def _no_db():
+        yield None
+
+    app.dependency_overrides[app_db.get_db] = _no_db
+    with TestClient(app) as c:
+        yield c
+
+
+def _routes(app):
+    return {(m, r.path) for r in app.routes for m in getattr(r, "methods", set()) or set()}
+
+
+# ── the doors exist at all (the A17 defect was an absence, not a bug) ──────────────────────────
+def test_the_write_door_and_the_importer_are_routed(client):
+    routes = _routes(client.app)
+    assert ("GET", "/internal/users/{user_id}/settings") in routes
+    assert ("PUT", "/internal/users/{user_id}/settings") in routes, (
+        "identity serves person settings and nothing can write them — every preference reverts "
+        "to defaults on upgrade")
+    assert ("POST", "/admin/users/{user_id}/settings/import") in routes, (
+        "`plan_import` is the one-shot migration off .settings.json and has no route to fire it")
+
+
+# ── the dev-mode bypass is gone from the per-person doors ──────────────────────────────────────
+@pytest.mark.parametrize("method", ["GET", "PUT"])
+def test_dev_mode_does_not_open_a_cross_user_settings_door(client, monkeypatch, method):
+    """`DEV_MODE=true` + no secret used to answer this route unauthenticated — for ANY user id the
+    caller cares to type. It is a 503 now: dev mode still works, it just has to name a secret."""
+    monkeypatch.setenv("DEV_MODE", "true")
+    monkeypatch.delenv("INTERNAL_API_SECRET", raising=False)
+    r = client.request(method, "/internal/users/1/settings", json={"timezone": "UTC"})
+    assert r.status_code == 503
+    assert "never open" in str(r.json()["detail"])
+
+
+@pytest.mark.parametrize("method", ["GET", "PUT"])
+def test_a_wrong_or_missing_secret_is_refused_with_a_secret_configured(client, monkeypatch, method):
+    monkeypatch.setenv("DEV_MODE", "true")          # still true — and still no help
+    monkeypatch.setenv("INTERNAL_API_SECRET", SECRET)
+    assert client.request(method, "/internal/users/1/settings", json={}).status_code == 403
+    assert client.request(method, "/internal/users/1/settings", json={},
+                          headers={"X-Internal-Secret": "wrong"}).status_code == 403
+
+
+def test_the_importer_is_admin_gated(client, monkeypatch):
+    monkeypatch.setenv("INTERNAL_API_SECRET", SECRET)
+    r = client.post("/admin/users/1/settings/import", json={"timezone": "UTC"})
+    assert r.status_code in (401, 403)
+
+
+# ── the write door's vocabulary refusals, before any DB work ───────────────────────────────────
+def test_bot_name_is_refused_on_the_person_settings_door(client, monkeypatch):
+    """A bot default is a fact about the BOT. meetings owns it and resolves it on every spawn path
+    through /internal/users/{id}/bot-context; accepting it here would be a second name for one
+    fact. The refusal says where it lives."""
+    monkeypatch.setenv("INTERNAL_API_SECRET", SECRET)
+    r = client.put("/internal/users/1/settings", json={"bot_name": "Notes"},
+                   headers={"X-Internal-Secret": SECRET})
+    assert r.status_code == 422
+    detail = r.json()["detail"]
+    assert detail["refused"] == "bot_name is not a person setting"
+    assert "bot-context" in detail["why"]
+
+
+def test_a_non_object_body_is_refused(client, monkeypatch):
+    monkeypatch.setenv("INTERNAL_API_SECRET", SECRET)
+    r = client.put("/internal/users/1/settings", json=["timezone"],
+                   headers={"X-Internal-Secret": SECRET})
+    assert r.status_code == 422
+
+
+# ── the pure decisions the two doors are wired to (unchanged, now reachable) ───────────────────
+def test_apply_validates_every_key_before_writing_any():
+    """All-or-nothing: a half-applied change is a person who believes they turned two things off
+    and turned one."""
+    before = {"person_settings": {"mail_minutes": True}}
+    with pytest.raises(ps.Refused):
+        ps.apply(before, {"mail_join": "off", "timezone": "Not/AZone"})
+    assert before == {"person_settings": {"mail_minutes": True}}   # untouched
+
+    after = ps.apply(before, {"mail_join": "off", "timezone": "Europe/Lisbon"})
+    assert after["person_settings"] == {
+        "mail_minutes": True, "mail_join": False, "timezone": "Europe/Lisbon"}
+
+
+def test_the_five_person_facts_are_what_the_read_door_serves():
+    facts = ps.read_person_facts({})
+    assert set(facts) == {"timezone", "mail_minutes", "mail_join", "mail_rsvp", "mail_prep"}
+    assert ps.BOT_NAME_KEY not in facts
+
+
+def test_plan_import_keeps_an_already_set_key_and_drops_an_unknown_one():
+    """Re-runnable across an estate where somebody has since changed a preference: a second run
+    that clobbered it would silently undo a person's choice. And an unknown key is DROPPED, not
+    refused — a migration that stops on one odd key leaves half the estate on the old store."""
+    existing = {"person_settings": {"mail_minutes": False}}
+    new, imported, kept, dropped = ps.plan_import(existing, {
+        "mail_minutes": True,            # already set through the new door → kept
+        "timezone": "Europe/Lisbon",     # → imported
+        "colour": "blue",                # not in the vocabulary → dropped
+    })
+    assert imported == {"timezone": "Europe/Lisbon"}
+    assert kept == ["mail_minutes"] and dropped == ["colour"]
+    assert new["person_settings"]["mail_minutes"] is False
+
+
+def test_plan_import_carries_bot_name_into_the_bots_own_store_only_when_empty():
+    """The one path that carries `bot_name` — into `calendar_bot_name`, the store meetings already
+    reads — and only when nobody has set one, in either direction."""
+    new, imported, _kept, _dropped = ps.plan_import({}, {"bot_name": "Notes"})
+    assert new[ps.BOT_NAME_STORE] == "Notes"
+    assert imported == {"bot_name": "Notes"}
+
+    new2, imported2, kept2, _ = ps.plan_import({ps.BOT_NAME_STORE: "Mine"}, {"bot_name": "Notes"})
+    assert new2[ps.BOT_NAME_STORE] == "Mine"
+    assert imported2 == {} and kept2 == ["bot_name"]

--- a/core/meetings/services/meeting-api/src/meeting_api/__main__.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/__main__.py
@@ -226,11 +226,6 @@ def build_production_app():
 
     app = create_app(
         transcript_store=transcript_store,
-        # The person's default bot name reaches the DIRECT spawn path too, resolved by the domain
-        # that owns the bot — same edge, same value, same precedence as the auto-join sweep.
-        fetch_bot_context=_bot_context_fetcher(
-            (os.getenv("ADMIN_API_URL") or "").rstrip("/"),
-            os.getenv("INTERNAL_API_SECRET") or ""),
         redis=segment_bus,
         meeting_repo=meeting_repo,
         runtime=runtime_client,
@@ -774,12 +769,19 @@ def __getattr__(name: str):
 
 
 def _bot_context_fetcher(admin_api_url: str, internal_secret: str):
-    """The per-user spawn context from identity, or None when no identity edge is configured.
+    """The per-user spawn context from identity for the AUTO-JOIN SWEEP, or None when no identity
+    edge is configured.
 
-    ONE builder for BOTH spawn paths. The auto-join sweep has taken this edge since it existed; the
-    direct `POST /bots` path did not, which is why the same person's bot showed up under one name
-    when a calendar armed it and another when they asked for it in chat. Two fetchers would be two
-    answers to one question, so there is one, here.
+    The sweep needs its own fetcher because it spawns bots OUTSIDE a request — it stands in for the
+    headers the gateway would have injected, and it caches one answer per user across a whole tick.
+
+    NOT USED BY `POST /bots` any more. The direct path used to be handed this same builder so the
+    person's default name reached it too, which made that one request fetch
+    `/internal/users/{id}/bot-context` TWICE: once here at 10s for the name, once inside
+    `bot_spawn/service.request_bot` at 5s for the transcription backend and the capture-signal
+    decision — up to +15s on a path a person is waiting on, for one string. `request_bot` reads the
+    name out of the context it already has. Both paths still resolve the same value from the same
+    door, which is what the founder ruling required; there is just one call per spawn.
     """
     if not admin_api_url or not internal_secret:
         return None

--- a/core/meetings/services/meeting-api/src/meeting_api/app.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/app.py
@@ -29,7 +29,7 @@ from __future__ import annotations
 import asyncio
 import time
 from collections import deque
-from typing import Awaitable, Callable, Optional
+from typing import Optional
 
 from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
@@ -158,11 +158,6 @@ def create_app(
     # bot_spawn ports
     meeting_repo: Optional["_bot_spawn.MeetingRepo"] = None,
     runtime: Optional["_bot_spawn.RuntimeClient"] = None,
-    # The per-user spawn context from identity — the SAME edge the auto-join sweep takes. It is
-    # here so the person's default bot name is resolved by the domain that owns the bot, on EVERY
-    # path a bot is spawned, rather than by each caller out of a store of its own (which is how one
-    # fact came to have three). None = no identity edge configured; a smaller answer, never an error.
-    fetch_bot_context: Optional[Callable[[int], Awaitable[Optional[dict]]]] = None,
     service_authority: Optional["object"] = None,
     # recordings ports
     recording_repo: Optional["_recordings.RecordingRepo"] = None,
@@ -259,11 +254,13 @@ def create_app(
     )
 
     # --- bot_spawn: POST /bots (invocation.v1 + runtime.v1) ---
+    # No `fetch_bot_context` here: `request_bot` resolves this person's default bot name out of the
+    # spawn context it already fetches for the transcription backend and the capture-signal
+    # decision. Injecting a second fetcher made POST /bots ask identity for the same body twice.
     app.include_router(_bot_spawn.build_router(
         meeting_repo,
         runtime,
         service_authority,
-        fetch_bot_context=fetch_bot_context,
     ))
 
     # --- user-stop: DELETE /bots/{platform}/{native_meeting_id} (lifecycle/stop.py over redis) ---

--- a/core/meetings/services/meeting-api/src/meeting_api/app.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/app.py
@@ -680,7 +680,7 @@ def _mount_lifecycle(
                 _uid = _meeting_block.get("user_id")
                 if _uid is not None and _et == "meeting.started":
                     try:
-                        _flows_events.publish_meeting_started(
+                        await _flows_events.publish_meeting_started(
                             _meeting_block.get("id"),
                             _meeting_block.get("native_meeting_id"),
                             _meeting_block.get("platform"),
@@ -690,7 +690,7 @@ def _mount_lifecycle(
                         pass
                 elif _uid is not None and _et == "meeting.completed":
                     try:
-                        _flows_events.publish_meeting_completed(
+                        await _flows_events.publish_meeting_completed(
                             _meeting_block.get("id"),
                             _meeting_block.get("native_meeting_id"),
                             _meeting_block.get("platform"),

--- a/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/router.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/router.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 
 import ipaddress
 import os
-from typing import Awaitable, Callable, Optional
+from typing import Optional
 from urllib.parse import parse_qs, urlparse
 
 from fastapi import APIRouter, Header, HTTPException, Request
@@ -250,17 +250,17 @@ def build_router(
     repo: MeetingRepo,
     runtime: RuntimeClient,
     authority=None,
-    *,
-    fetch_bot_context: "Optional[Callable[[int], Awaitable[Optional[dict]]]]" = None,
 ) -> APIRouter:
     """The bot-spawn routes over the injected ``MeetingRepo`` + ``RuntimeClient`` + authority ports.
 
-    ``fetch_bot_context`` is the per-user spawn context from identity — the SAME edge the auto-join
-    sweep already takes (``auto_join.py:324``). It is here so that the person's default bot name is
-    resolved by the domain that OWNS the bot, on every path a bot is spawned, rather than by each
-    caller out of a store of its own: that is how one fact came to have three (founder ruling,
-    2026-09-02 — no fourth store). None = no identity edge configured (offline / self-host), which
-    is a smaller answer and never an error."""
+    NO ``fetch_bot_context`` HERE, on purpose. The person's default bot name is still resolved by
+    the domain that owns the bot, on every path a bot is spawned (founder ruling, 2026-09-02 — no
+    fourth store) — but ``request_bot`` ALREADY fetches that person's whole spawn context, on this
+    same request, to resolve the transcription backend and the capture-signal decision. A
+    router-level fetcher made `POST /bots` ask identity for the same body TWICE, with two different
+    timeouts (10s here, 5s there), for one string: up to +15s on a path a person is waiting on,
+    while each fetcher's comment claimed to be the only one. The name now comes out of the context
+    the service already has (``service._bot_name_from_context``)."""
     router = APIRouter()
 
     @router.post("/bots", status_code=201)
@@ -445,21 +445,12 @@ def build_router(
 
         transcribe_enabled = _resolve_transcribe_enabled(body.get("transcribe_enabled"))
 
-        # THE NAME THIS PERSON'S BOT SHOWS UP AS. Precedence is auto-join's, unchanged: an explicit
-        # name on THIS request, then this person's default from identity, then the deployment's.
-        # Identity is not asked when the caller already named the bot — one fewer hop on a path a
-        # person is waiting on, and the answer could not change anything.
-        #
-        # A FAILED LOOKUP NEVER STOPS THE SPAWN. A name is a nicety; joining the call is the
-        # product, and failing it because a preference read timed out trades the thing they asked
-        # for against the label on it.
+        # THE NAME THIS PERSON'S BOT SHOWS UP AS — an explicit name on THIS request, and nothing
+        # else here. `request_bot` fills in this person's default from identity out of the bot
+        # context it already fetches (one hop, three readers: transcription backend, capture-signal
+        # decision, bot name), and the deployment default underneath that. A FAILED LOOKUP NEVER
+        # STOPS THE SPAWN: a name is a nicety, joining the call is the product.
         bot_name = body.get("bot_name")
-        if not bot_name and fetch_bot_context is not None:
-            try:
-                ctx = await fetch_bot_context(user_id)
-                bot_name = (ctx or {}).get("bot_name") or None
-            except Exception:  # noqa: BLE001
-                bot_name = None
 
         try:
             meeting = await request_bot(

--- a/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/service.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/service.py
@@ -235,6 +235,23 @@ def _capture_signal_from_context(ctx: dict) -> bool:
     return ctx.get("capture_signal") is not False
 
 
+def _bot_name_from_context(ctx: dict) -> Optional[str]:
+    """This person's default bot name out of a bot-context body, or None.
+
+    THE THIRD READER OF ONE FETCH. `POST /bots` used to resolve the name through a SECOND,
+    router-level `fetch_bot_context` — a separate call to the same `/internal/users/{id}/bot-context`
+    door, on the same request, with its own 10s timeout, while `request_bot` already fetched the
+    same body at 5s. Worst case that was +15s on the path a person is waiting on for one string,
+    and both fetchers' comments claimed to be the only one. The lookup is unchanged; there is one
+    of it, and the transcription backend, the capture-signal decision and the bot name are three
+    readers of one answer.
+
+    Best-effort like its siblings: an unreachable identity yields None and the caller falls back to
+    the deployment default. A name is a nicety; joining the call is the product."""
+    name = ctx.get("bot_name")
+    return name.strip() or None if isinstance(name, str) else None
+
+
 def construct_meeting_url(
     platform: str,
     native_meeting_id: str,
@@ -455,6 +472,12 @@ async def request_bot(
     # O-TEL-1 fixture collection, resolved from the SAME best-effort lookup (one hop, two readers).
     # Default ON: only an explicit false from identity stops the tape.
     capture_signal_enabled = _capture_signal_from_context(bot_context)
+    # THE NAME THIS PERSON'S BOT SHOWS UP AS — third reader of the same one hop. Precedence is
+    # auto-join's, unchanged: an explicit name on THIS request, then this person's default from
+    # identity, then the deployment's (applied at `build_invocation` below). An explicit name wins
+    # without identity being consulted about it at all — the answer could not change anything.
+    if not bot_name:
+        bot_name = _bot_name_from_context(bot_context)
     transcription_provider: Optional[str] = "none" if not transcribe_enabled else None
     if configured.get("url"):
         transcription_service_url = configured["url"]

--- a/core/meetings/services/meeting-api/src/meeting_api/collector/adapters.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/collector/adapters.py
@@ -203,6 +203,70 @@ def _upsert_processed_view(
     return out
 
 
+def _merge_notes_by_id(existing: list[dict], incoming: list[dict]) -> list[dict]:
+    """Merge drained copilot notes into a processed view's ``doc['notes']`` list, keyed by note
+    ``id`` (== segment_id): a refining re-emit UPDATES its note in place (order preserved);
+    a new id appends. Notes without an id append as-is (nothing to key an upsert on)."""
+    out = [dict(n) for n in existing]
+    index = {str(n.get("id")): i for i, n in enumerate(out) if n.get("id") is not None}
+    for note in incoming:
+        nid = note.get("id")
+        if nid is not None and str(nid) in index:
+            out[index[str(nid)]].update(note)
+        else:
+            if nid is not None:
+                index[str(nid)] = len(out)
+            out.append(dict(note))
+    return out
+
+
+def _find_processed_view(data: dict, view_id: str) -> Optional[dict]:
+    """The view with ``view_id`` inside ``data['processed']['views']`` (None when absent)."""
+    processed = data.get("processed") if isinstance(data.get("processed"), dict) else {}
+    views = processed.get("views") if isinstance(processed.get("views"), list) else []
+    return next((v for v in views if isinstance(v, dict) and v.get("id") == view_id), None)
+
+
+def _upsert_processed_view(
+    data: dict, *, view_id: str, kind: str, notes: list[dict],
+    source_cursor: Optional[str], params: Optional[dict],
+) -> dict:
+    """Pure merge of drained copilot notes into the ADDRESSABLE, VERSIONED processed shape
+    (release DoD — multi-consumer, meeting-scoped today, mountable by N consumers later):
+
+        data.processed = {"views": [{id, kind, params, doc, source_cursor, updated_at}]}
+
+    Upserts the view keyed by ``id`` — other views (future per-workspace/other processings) are
+    preserved untouched; merges ``notes`` into the view's ``doc['notes']`` by note id; stamps
+    ``params`` (the processing metadata APPLIED — provider/model/pipeline, stamped by the
+    producing worker — reproducibility) only when the drain carried them, so an idle drain never
+    erases provenance; ``source_cursor`` records the stream position the view reflects.
+    Returns the new ``data`` dict (the caller persists it)."""
+    from datetime import datetime, timezone
+
+    out = dict(data)
+    processed = dict(out.get("processed")) if isinstance(out.get("processed"), dict) else {}
+    views = [dict(v) for v in processed.get("views", []) if isinstance(v, dict)] \
+        if isinstance(processed.get("views"), list) else []
+    view = next((v for v in views if v.get("id") == view_id), None)
+    if view is None:
+        view = {"id": view_id, "kind": kind, "params": {}, "doc": {"notes": []}}
+        views.append(view)
+    doc = dict(view.get("doc")) if isinstance(view.get("doc"), dict) else {}
+    existing_notes = doc.get("notes") if isinstance(doc.get("notes"), list) else []
+    doc["notes"] = _merge_notes_by_id(list(existing_notes), notes)
+    view["doc"] = doc
+    view["kind"] = kind
+    if params:
+        view["params"] = params
+    if source_cursor:
+        view["source_cursor"] = source_cursor
+    view["updated_at"] = datetime.now(timezone.utc).isoformat()
+    processed["views"] = views
+    out["processed"] = processed
+    return out
+
+
 # A relative in-meeting offset never approaches this; anything at/above is an absolute epoch.
 _EPOCH_THRESHOLD_S = 1_000_000_000  # ~2001-09-09
 
@@ -924,6 +988,47 @@ class SqlAlchemyTranscriptStore:
                     """),
                     row,
                 )
+            await db.commit()
+
+    async def processed_view_cursor(self, meeting_id, view_id) -> Optional[str]:
+        """The ``source_cursor`` of the ``view_id`` view inside ``meeting.data['processed']['views']``
+        — the last ``proc:meeting:{id}`` stream entry already durable; the db-writer resumes after it."""
+        from sqlalchemy import select
+
+        from .models import Meeting
+
+        async with self._session_factory() as db:
+            m = (await db.execute(select(Meeting).where(Meeting.id == int(meeting_id)))).scalars().first()
+            if not m or not isinstance(m.data, dict):
+                return None
+            view = _find_processed_view(m.data, view_id)
+            return view.get("source_cursor") if view else None
+
+    async def merge_processed_view(
+        self, meeting_id, *, view_id, kind, notes, source_cursor, params=None,
+    ) -> None:
+        """Persist drained copilot notes into the meeting row's ``data['processed']['views']``
+        JSONB (the documented meeting.data home — the same pattern recordings/notes/docs use; NO
+        schema change), in the ADDRESSABLE, VERSIONED multi-consumer shape (release DoD):
+        the view keyed ``view_id`` is upserted (other views preserved), its ``doc['notes']`` merged
+        by note id, ``params`` = the processing metadata APPLIED, ``source_cursor`` = the stream
+        position the view reflects. ONE ``SELECT … FOR UPDATE`` row lock."""
+        from sqlalchemy import select
+        from sqlalchemy.orm.attributes import flag_modified
+
+        from .models import Meeting
+
+        async with self._session_factory() as db:
+            stmt = select(Meeting).where(Meeting.id == int(meeting_id)).with_for_update()
+            meeting = (await db.execute(stmt)).scalars().first()
+            if not meeting:
+                return
+            data = dict(meeting.data) if isinstance(meeting.data, dict) else {}
+            meeting.data = _upsert_processed_view(
+                data, view_id=view_id, kind=kind, notes=notes,
+                source_cursor=source_cursor, params=params,
+            )
+            flag_modified(meeting, "data")
             await db.commit()
 
     async def processed_view_cursor(self, meeting_id, view_id) -> Optional[str]:

--- a/core/meetings/services/meeting-api/src/meeting_api/collector/app.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/collector/app.py
@@ -54,6 +54,24 @@ _FSM_OWNED_STATUSES = frozenset({
     "active", "stopping", "completed", "failed",
 })
 
+# ── transcript-share mint bounds (`_share_payload`) ────────────────────────────────────────────
+# THE MODE SET IS CLOSED AND THAT IS THE SECURITY-RELEVANT ONE. `validate_transcript_grant`
+# (collector/adapters.py) applies the email allow-list only when `mode == "restricted"` — every
+# other string, including a near-miss typo, is stored verbatim and read back as an OPEN share that
+# anyone authenticated can redeem. The failure is silent and it points the wrong way, so the value
+# is checked at the door instead of being trusted downstream.
+SHARE_MODES = frozenset({"open", "restricted"})
+SHARE_DEFAULT_TTL_SEC = 86_400                  # 24h — unchanged default
+SHARE_MIN_TTL_SEC = 60                          # a link nobody can redeem in time is not a share
+SHARE_MAX_TTL_SEC = 30 * 24 * 60 * 60           # 30d — a capability, not a second front door
+# The list lives in the meeting row's JSONB and is walked on every access check, so its length is
+# a cost the OWNER pays on every read of that meeting, for ever.
+SHARE_MAX_ALLOWED_EMAILS = 200
+# The search text is bound as a parameter (never interpolated), so this is a resource bound, not an
+# injection one: `websearch_to_tsquery` + `ts_headline` over an unbounded string is CPU an
+# unauthenticated-shaped request should not be able to ask for.
+SEARCH_QUERY_MAX_CHARS = 512
+
 
 async def _publish_user_meeting_status(
     redis,
@@ -156,7 +174,7 @@ def build_router(
     @router.get("/transcripts/search")
     async def search_transcripts(
         request: Request,
-        q: str = Query(..., min_length=1, description=(
+        q: str = Query(..., min_length=1, max_length=SEARCH_QUERY_MAX_CHARS, description=(
             "Search text. Supports \"quoted phrases\", `or`, and `-excluded` terms "
             "(websearch syntax). Malformed input never errors."
         )),
@@ -928,15 +946,60 @@ def build_router(
         return JSONResponse(content={"workspace_id": bound})
 
     def _share_payload(payload) -> "tuple[str, list, int]":
-        """mode | allowed_emails | ttl out of a share-mint body, defaulted the same way for both
-        address shapes. `restricted` + allowed_emails is what makes a forwarded mail grant nothing."""
+        """mode | allowed_emails | ttl out of a share-mint body, defaulted and VALIDATED the same
+        way for both address shapes.
+
+        `restricted` + allowed_emails is what makes a forwarded mail grant nothing — and that is
+        exactly why `mode` has to be checked against the closed set. `validate_transcript_grant`
+        gates on `mode == "restricted"` and nothing else, so ANY other string — `"Restricted"`,
+        `"restrcted"`, `""` — is stored verbatim and read back as an OPEN share. A typo in a caller
+        minted a link anyone authenticated could redeem, silently, while the caller believed they
+        had restricted it. Refusing an unknown mode is the whole fix; the caller finds out at mint
+        time instead of the recipient finding out later.
+
+        The other two are denial-of-service shaped rather than disclosure shaped, and both used to
+        be unbounded: a non-numeric `expires_in_sec` raised inside `int()` and became a 500 (an
+        unhandled exception on a public route), and neither the TTL nor `allowed_emails` had a
+        ceiling, so one request could plant a share lasting a century or a JSONB grant with a
+        million addresses in it — on the meeting row every read of that meeting loads."""
         if not isinstance(payload, dict):
             payload = {}
-        return (
-            str(payload.get("mode", "open")).strip() or "open",
-            payload.get("allowed_emails") or [],
-            int(payload.get("expires_in_sec", 86400) or 86400),
-        )
+
+        mode = str(payload.get("mode", "open")).strip() or "open"
+        if mode not in SHARE_MODES:
+            raise HTTPException(
+                status_code=422,
+                detail=f"'mode' must be one of {sorted(SHARE_MODES)} — got {mode!r}",
+            )
+
+        emails = payload.get("allowed_emails")
+        if emails is None or emails == "":
+            emails = []
+        if not isinstance(emails, list):
+            raise HTTPException(status_code=422, detail="'allowed_emails' must be a list")
+        if len(emails) > SHARE_MAX_ALLOWED_EMAILS:
+            raise HTTPException(
+                status_code=422,
+                detail=(f"'allowed_emails' holds {len(emails)} entries; the maximum is "
+                        f"{SHARE_MAX_ALLOWED_EMAILS} — the list is stored on the meeting row and "
+                        "read back on every access check"),
+            )
+        emails = [str(e).strip() for e in emails if str(e).strip()]
+
+        raw_ttl = payload.get("expires_in_sec", SHARE_DEFAULT_TTL_SEC)
+        if raw_ttl in (None, ""):
+            raw_ttl = SHARE_DEFAULT_TTL_SEC
+        if isinstance(raw_ttl, bool):    # `True` is an int in python and is not a duration
+            raise HTTPException(status_code=422, detail="'expires_in_sec' must be a number")
+        try:
+            ttl = int(raw_ttl)
+        except (TypeError, ValueError):
+            raise HTTPException(status_code=422, detail="'expires_in_sec' must be a number")
+        # CLAMPED, not refused: an out-of-range TTL is a caller asking for something we will not
+        # give, not a malformed request, and the safe direction is the shorter link. The floor
+        # keeps a share usable long enough to be redeemed at all.
+        ttl = max(SHARE_MIN_TTL_SEC, min(ttl, SHARE_MAX_TTL_SEC))
+        return mode, emails, ttl
 
     # --- POST /meetings/{meeting_id}/share → the SAME mint, addressed by the ROW's primary key.
     #

--- a/core/meetings/services/meeting-api/src/meeting_api/collector/db_writer.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/collector/db_writer.py
@@ -1,4 +1,4 @@
-"""The background **db-writer** — flush live Redis segments to the durable store.
+"""The background **db-writer** — flush live Redis segments (and processed notes) to the durable store.
 
 RESTORES the parent loop the 0.12 carve dropped (0.10 ``meeting_api/collector/db_writer.py``
 ``process_redis_to_postgres``): the consumer (``ingest.py``) lands live segments in the Redis hash
@@ -31,16 +31,45 @@ Additions over the parent:
   * ``finalize_meeting(...)`` — the completion hook: flush EVERYTHING left (threshold 0, mutable
     tail included) the moment the lifecycle FSM lands on a terminal status, so a completed meeting's
     transcript is durable immediately instead of eventually.
-There used to be a second drain beside it — ``flush_meeting_processed(...)``, which pulled the
-copilot's cleaned-notes stream ``proc:meeting:{meeting_id}`` into the meeting row's
-``data['processed']`` JSONB, plus the ``processed_pending`` parking that waited for that
-producer's ``view_end`` marker after a meeting finished. PRD decision 34 removed the producer:
-the product runs no model calls of its own beside the agent, so nothing writes that stream and
-there is no second body of a transcript to keep durable. Segments are the whole job.
+  * ``flush_meeting_processed(...)`` — drain the copilot's cleaned-notes stream
+    (``proc:meeting:{meeting_id}``, agent-worker the single writer, P23) into the meeting row's
+    ``data['processed']`` JSONB (the documented meeting.data home; NO schema change), resuming
+    from the persisted ``source_cursor``. Redis was the ONLY home of the processed doc before
+    this — stopping the bot made the processed output unreachable over REST.
+
+RESTORED ON THIS RELEASE, AND WHY — read this before deleting it again. The drain was removed once
+with the justification "PRD decision 34 removed the producer: nothing writes that stream". On this
+candidate that sentence is FALSE, and it is checkable in three places, all of which
+``tests/test_db_writer.py::test_the_processed_notes_producer_is_still_here`` asserts from source:
+
+  * ``core/agent/control_plane/dispatch.py`` still stamps ``VEXA_TRANSCRIPT_STREAM`` on a meeting
+    dispatch, so the meeting worker still runs;
+  * ``core/agent/worker/engine.py`` still passes ``proc_stream=f"proc:meeting:{row_id}"`` into
+    ``serve_meeting`` — unconditionally, on that path;
+  * ``core/agent/worker/meeting.py`` still ``xadd``s each cleaned note onto it, and still emits the
+    ``view_end`` marker.
+
+The removal commit that made the claim true (``f95d4d5e0``) is NOT in this branch's ancestry; the
+docstring travelled here without the code it described. With the producer alive and the drain gone,
+``proc:meeting:{id}`` fills up in redis and ``data.processed.views[]`` is never written — so the
+terminal's durable notes pane and the schedule digest's ``notes`` flag are permanently empty the
+moment the bot stops. That is the exact bug the drain was written for. **If the producer is ever
+actually removed, delete the producer and this drain in ONE change** — the failure mode being
+avoided here is a half-applied removal, in either direction.
+
+The persisted processed shape is ADDRESSABLE and VERSIONED (multi-consumer, per the release DoD):
+``data.processed = {"views": [{id, kind, params, doc, source_cursor, updated_at}]}`` — ``params``
+records the processing metadata APPLIED (provider/model/pipeline, stamped by the producing worker
+on the stream entries — reproducibility), ``doc`` is the view body (``{"notes": [...]}`` for the
+copilot's cleaned-transcript view), ``source_cursor`` the stream position the view reflects. A
+LIST of views so multiple processings of one meeting (per-workspace views are coming) coexist;
+today the collector maintains the ONE meeting-scoped copilot view, upserted by ``id``. The views
+ride the sealed api.v1 responses' existing free-form ``data`` field (GET /transcripts +
+GET /meetings) — no new REST surface, no contract change.
 
 Everything here talks to redis through plain client calls (hgetall/hdel/smembers/scan/xrange) that
 both ``redis.asyncio`` and ``fakeredis.aioredis`` satisfy, and to the durable store through two
-a getattr-guarded sink method (``upsert_segments``) implemented by BOTH
+getattr-guarded sink methods (``upsert_segments``, ``merge_processed_notes``) implemented by BOTH
 ``SqlAlchemyTranscriptStore`` (prod) and ``InMemoryTranscriptStore`` (tests) — so the whole writer
 is unit-tested offline, no docker.
 """
@@ -167,10 +196,34 @@ async def _trim_segments_stream(redis_c, retention_s: float, now_ms: int) -> Non
     except Exception:
         pass
 
+# ── the end-of-processing protocol (ADR 0027 / processed-notes.v1) ────────────────────────────────
+# The copilot worker runs one final LLM beat AFTER session_end (~10s), then XADDs a `view_end`
+# marker: the proc stream is COMPLETE at that entry. finalize_meeting's inline drain used to be the
+# LAST drain ever (the meeting then left this writer's sweep), so the final beat's notes stayed in
+# redis forever (run-46: durable cursor 1783512746260-0 < stream tail 1783512757882-0). Now a
+# finalized meeting whose stream is not yet marker-complete PARKS in `processed_pending` (zset,
+# score = deadline) and every tick re-drains it until the marker is seen — or the deadline passes
+# (the P22 pairing: graceful marker, hard bounded guarantee for a worker that died markerless).
+PROC_PENDING_KEY = "processed_pending"
+PROC_PENDING_GRACE_SEC = float(os.environ.get("PROC_PENDING_GRACE_SEC", "120"))
+
+# The one processed view the collector maintains today: the copilot's 1:1 cleaned transcript.
+# Addressable by id inside data.processed.views[] so future processings (per-workspace views,
+# summaries, translations) ADD views instead of overwriting this one.
+PROC_VIEW_ID = "copilot-notes"
+PROC_VIEW_KIND = "cleaned_transcript"
+
 
 def segments_hash_key(meeting_id) -> str:
     """The live Redis hash of in-flight segments (``ingest`` writes it; the read path merges it)."""
     return f"meeting:{meeting_id}:segments"
+
+
+def proc_stream_key(meeting_id) -> str:
+    """The copilot's cleaned-notes stream for ONE meeting row — keyed by the NUMERIC meeting id
+    (unique per row) so a re-sent bot on the same native link can never mix/clobber a previous
+    meeting's processed doc (the native-id keying defect)."""
+    return f"proc:meeting:{meeting_id}"
 
 
 def _s(v) -> str:
@@ -255,6 +308,77 @@ async def flush_meeting_segments(
     return len(batch)
 
 
+async def flush_meeting_processed(redis_c, sink, meeting_id: int) -> int:
+    """Drain NEW entries of the meeting's processed-notes stream (``proc:meeting:{meeting_id}``,
+    written by the agent worker) into the copilot view of the meeting row's
+    ``data['processed']['views']`` JSONB via the sink, resuming from the view's persisted
+    ``source_cursor`` (exclusive). Notes are merged by their ``id`` (== segment_id), so a refining
+    re-emit updates in place. ``params`` (provider/model/pipeline, stamped by the worker on each
+    entry) ride along into the view for reproducibility. Returns the count of notes merged."""
+    merge = getattr(sink, "merge_processed_view", None)
+    cursor_of = getattr(sink, "processed_view_cursor", None)
+    if merge is None or cursor_of is None:
+        return 0
+    cursor = await cursor_of(meeting_id, PROC_VIEW_ID)
+    start = "-" if not cursor else f"({cursor}"
+    try:
+        rows = await redis_c.xrange(proc_stream_key(meeting_id), min=start, max="+")
+    except Exception:  # noqa: BLE001 — a missing/typed-over key must not break the segments flush
+        return 0
+    if not rows:
+        return 0
+    notes: list[dict] = []
+    params: Optional[dict] = None
+    last_id = cursor
+    for entry_id, fields in rows:
+        last_id = _s(entry_id)
+        decoded = {_s(k): _s(v) for k, v in fields.items()}
+        raw_params = decoded.get("params")
+        if raw_params:
+            try:
+                parsed = json.loads(raw_params)
+                if isinstance(parsed, dict):
+                    params = parsed  # last writer wins — the params APPLIED to the newest notes
+            except (json.JSONDecodeError, ValueError):
+                pass
+        raw_note = decoded.get("note")
+        if not raw_note:
+            continue
+        try:
+            note = json.loads(raw_note)
+        except (json.JSONDecodeError, ValueError):
+            continue
+        if isinstance(note, dict):
+            notes.append(note)
+    if notes or last_id != cursor:
+        await merge(
+            meeting_id,
+            view_id=PROC_VIEW_ID, kind=PROC_VIEW_KIND,
+            notes=notes, source_cursor=last_id, params=params,
+        )
+    return len(notes)
+
+
+async def _processed_complete(redis_c, sink, meeting_id: int) -> bool:
+    """Whether the meeting's processed stream is DRAINED THROUGH its ``view_end`` marker: the
+    stream's last entry is the marker AND the persisted view cursor sits exactly on it. A sink
+    that can't persist views has nothing to wait for (vacuously complete)."""
+    cursor_of = getattr(sink, "processed_view_cursor", None)
+    if cursor_of is None:
+        return True
+    try:
+        rows = await redis_c.xrevrange(proc_stream_key(meeting_id), max="+", min="-", count=1)
+    except Exception:  # noqa: BLE001 — unreadable stream ⇒ not provably complete
+        return False
+    if not rows:
+        return False  # nothing written (yet) — a just-armed copilot may still deliver
+    entry_id, fields = rows[0]
+    decoded = {_s(k): _s(v) for k, v in fields.items()}
+    if decoded.get("type") != "view_end":
+        return False
+    return await cursor_of(meeting_id, PROC_VIEW_ID) == _s(entry_id)
+
+
 async def db_writer_tick(
     redis_c,
     sink,
@@ -264,7 +388,8 @@ async def db_writer_tick(
     reconcile: bool = False,
 ) -> int:
     """ONE db-writer sweep (the loop body ``__main__`` polls): flush every discovered meeting's
-    immutable segments to the durable sink. Returns the total segments stored. Per-meeting failures are contained — one bad meeting never starves the rest.
+    immutable segments to the durable sink, then drain its processed-notes stream. Returns the total
+    segments stored. Per-meeting failures are contained — one bad meeting never starves the rest.
 
     Discovery is the ``active_meetings`` set (authoritative in steady state — ``append_segment`` SADDs
     the meeting in the SAME transaction that writes its hash). ``reconcile=True`` ADDITIONALLY runs the
@@ -297,8 +422,41 @@ async def db_writer_tick(
                 redis_c, sink, meeting_id,
                 immutability_threshold=immutability_threshold, now=now,
             )
+            await flush_meeting_processed(redis_c, sink, meeting_id)
         except Exception:  # noqa: BLE001 — isolate per meeting; the next tick retries
             log.exception("db-writer flush failed for meeting %s", raw_id)
+
+    # Finalized-but-incomplete processed streams (ADR 0027): re-drain each parked meeting until its
+    # view_end marker is drained-through, or its deadline passes. These meetings have LEFT the sweep
+    # above (hash drained, out of active_meetings) — without this pass the final beat's notes would
+    # never reach the durable row.
+    try:
+        pending = await redis_c.zrange(PROC_PENDING_KEY, 0, -1, withscores=True)
+    except Exception:  # noqa: BLE001 — the pending pass is additive; never break the main sweep
+        pending = []
+    now_ts = (now or datetime.now(timezone.utc)).timestamp()
+    for member, deadline in pending or []:
+        raw_id = _s(member)
+        try:
+            meeting_id = int(raw_id)
+        except (TypeError, ValueError):
+            await redis_c.zrem(PROC_PENDING_KEY, member)
+            continue
+        try:
+            await flush_meeting_processed(redis_c, sink, meeting_id)
+            if await _processed_complete(redis_c, sink, meeting_id):
+                await redis_c.zrem(PROC_PENDING_KEY, raw_id)
+            elif now_ts >= float(deadline):
+                # P18: the give-up is a reportable state, not silence — everything that DID arrive
+                # was flushed above; what never arrived is attributed to the worker, loudly.
+                log.warning(
+                    "processed view for meeting %s never saw view_end within %ss — "
+                    "flushed what arrived, giving up the pending re-drain",
+                    raw_id, PROC_PENDING_GRACE_SEC,
+                )
+                await redis_c.zrem(PROC_PENDING_KEY, raw_id)
+        except Exception:  # noqa: BLE001 — isolate per meeting; the next tick retries
+            log.exception("pending processed re-drain failed for meeting %s", raw_id)
 
     # #527 C2: bound the ingest stream in steady state (trims only acked entries past the retention
     # window; never an unread one). Isolated — a trim failure never blocks the durable flush above.
@@ -313,11 +471,19 @@ async def db_writer_tick(
 async def finalize_meeting(redis_c, sink, meeting_id: int) -> int:
     """The COMPLETION flush — called by the lifecycle callback the moment a meeting reaches a
     terminal status (completed/failed): flush EVERYTHING still in the hash (threshold 0 — the
-    mutable tail and trailing drafts included; no more updates are coming), so the finished
-    meeting's transcript is durable IMMEDIATELY.
+    mutable tail and trailing drafts included; no more updates are coming) and drain the processed
+    notes, so the finished meeting's transcript + processed doc are durable IMMEDIATELY.
 
-    It used to do a second thing: drain the copilot's processed notes and, when their ``view_end``
-    marker had not arrived, PARK the meeting in ``processed_pending`` for a bounded re-drain — the
-    final beat ran ~10s after session_end. PRD decision 34 removed that producer, so there is
-    nothing left to wait for and the flush is complete when the segments are."""
-    return await flush_meeting_segments(redis_c, sink, meeting_id, immutability_threshold=0)
+    The processed stream is NOT necessarily complete here — the copilot's final beat runs ~10s
+    AFTER session_end (ADR 0027). Unless the ``view_end`` marker is already drained-through, the
+    meeting PARKS in ``processed_pending``; ``db_writer_tick`` keeps re-draining it until the
+    marker (or the bounded deadline). Never processed ⇒ the deadline simply expires the parking."""
+    stored = await flush_meeting_segments(redis_c, sink, meeting_id, immutability_threshold=0)
+    await flush_meeting_processed(redis_c, sink, meeting_id)
+    if not await _processed_complete(redis_c, sink, meeting_id):
+        try:
+            deadline = datetime.now(timezone.utc).timestamp() + PROC_PENDING_GRACE_SEC
+            await redis_c.zadd(PROC_PENDING_KEY, {str(meeting_id): deadline})
+        except Exception:  # noqa: BLE001 — parking is the safety net, never fail the finalize
+            log.exception("could not park meeting %s for the pending processed re-drain", meeting_id)
+    return stored

--- a/core/meetings/services/meeting-api/src/meeting_api/collector/fakes.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/collector/fakes.py
@@ -830,6 +830,28 @@ class InMemoryTranscriptStore:
             source_cursor=source_cursor, params=params,
         )
 
+    async def processed_view_cursor(self, meeting_id, view_id) -> Optional[str]:
+        from .adapters import _find_processed_view
+
+        m = self._meetings.get(meeting_id)
+        if not m:
+            return None
+        view = _find_processed_view(m["data"], view_id)
+        return view.get("source_cursor") if view else None
+
+    async def merge_processed_view(
+        self, meeting_id, *, view_id, kind, notes, source_cursor, params=None,
+    ) -> None:
+        """Persist drained copilot notes into ``data['processed']['views']`` — the SAME pure
+        upsert the SqlAlchemy store commits (the versioned multi-view shape, merged by note id)."""
+        from .adapters import _upsert_processed_view
+
+        m = self._row_or_placeholder(meeting_id)
+        m["data"] = _upsert_processed_view(
+            m["data"], view_id=view_id, kind=kind, notes=notes,
+            source_cursor=source_cursor, params=params,
+        )
+
 
 class FakeRedisBus:
     """A ``RedisBus`` over fakeredis. Wraps a fakeredis async client for stream read/ack/publish,

--- a/core/meetings/services/meeting-api/src/meeting_api/config.v1.json
+++ b/core/meetings/services/meeting-api/src/meeting_api/config.v1.json
@@ -328,6 +328,13 @@
    "targets": []
   },
   {
+   "key": "PROC_PENDING_GRACE_SEC",
+   "class": "defaulted",
+   "default": "120",
+   "description": "how long (seconds) the db-writer keeps re-draining a FINISHED meeting's copilot processed-notes stream while waiting for the producing worker's view_end marker, before giving up loudly. The copilot's final beat runs ~10s after session_end and by then the meeting has left the active sweep, so without the parked re-drain those last notes stay in redis forever (ADR 0027)",
+   "targets": []
+  },
+  {
    "key": "IMMUTABILITY_THRESHOLD",
    "class": "defaulted",
    "default": "30",

--- a/core/meetings/services/meeting-api/src/meeting_api/events.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/events.py
@@ -45,16 +45,28 @@ not silently absorbed — see the filed issue.
 from __future__ import annotations
 
 import json
+import logging
 import os
-import urllib.request
 from typing import Optional
 
 EVENT_MEETING_STARTED = "meeting.started"
 EVENT_MEETING_COMPLETED = "meeting.completed"
 
+log = logging.getLogger("meeting_api.events")
+
 #: Bounded on purpose. Both publishes run inside the lifecycle callback a bot's own HTTP round
 #: trip is waiting on, so the ceiling on how slow flows can make that callback is this number, not
 #: flows' own timeout.
+#:
+#: AND THE BOUND IS ONLY REAL BECAUSE THE CALL IS ASYNC. This used to be
+#: ``urllib.request.urlopen(req, timeout=TIMEOUT_S)`` — a BLOCKING call on the event loop inside
+#: ``async def _apply_lifecycle_event``, which is the same loop that runs the segment consumer, the
+#: db-writer, the live transcript reads and ``/health``. Two things were wrong with it and only one
+#: of them was the 2 s: urllib's ``timeout`` is a SOCKET timeout, so name resolution is not covered
+#: at all — an unresolvable ``VEXA_FLOWS_API_URL`` stalled the whole process for as long as the
+#: resolver took, not for two seconds. ``httpx.AsyncClient(timeout=…)`` bounds connect (DNS
+#: included), write, read and pool acquisition, and awaits instead of blocking, so a slow or dead
+#: flows costs THIS callback its bound and costs every other coroutine nothing.
 TIMEOUT_S = 2.0
 
 
@@ -66,13 +78,15 @@ def _flows_key() -> str:
     return (os.getenv("VEXA_FLOWS_API_KEY") or "").strip()
 
 
-def publish(event_type: str, source_event_id: str, refs: dict,
-            *, timeout: Optional[float] = None) -> bool:
+async def publish(event_type: str, source_event_id: str, refs: dict,
+                  *, timeout: Optional[float] = None) -> bool:
     """Hand one fact to the flows intake. Returns whether it landed; NEVER raises.
 
     The return value is for a caller that wants to log or count, not one that wants to decide:
     there is no correct behaviour on a failed publish except to carry on, because the alternative
     is failing a bot's own lifecycle callback over a message it never asked us to send.
+
+    AWAITED, not blocking — see ``TIMEOUT_S``. The caller is ``async def _apply_lifecycle_event``.
     """
     base = _flows_base()
     if not base:
@@ -92,11 +106,19 @@ def publish(event_type: str, source_event_id: str, refs: dict,
         # service's own token. The header used to be spelled X-Flows-Admin-Key; flows accepts the
         # old name for one release and this producer sends only the current one.
         headers["X-Flows-Operator-Key"] = key
-    req = urllib.request.Request(f"{base}/events", data=body, headers=headers, method="POST")
+    import httpx
+
     try:
-        with urllib.request.urlopen(req, timeout=timeout or TIMEOUT_S) as r:  # noqa: S310
-            return 200 <= r.status < 300
+        async with httpx.AsyncClient(timeout=timeout or TIMEOUT_S) as client:
+            r = await client.post(f"{base}/events", content=body, headers=headers)
+        return 200 <= r.status_code < 300
     except Exception:  # noqa: BLE001 — see the module docstring: a publish is not a dependency
+        # SWALLOWED, NOT SILENT. The old shape returned False from a bare `except` and left no
+        # trace anywhere, so a flows address that had been wrong since a deploy looked exactly like
+        # a deployment with no flows domain. DEBUG, not warning: this fires per meeting lifecycle
+        # transition, and a deployment that has flows down does not need one line per meeting at
+        # warning level to be told so twice.
+        log.debug("flows publish %s did not land (base=%s)", event_type, base, exc_info=True)
         return False
 
 
@@ -127,14 +149,15 @@ def meeting_completed_refs(meeting_id, native, platform, uid, completion_reason)
             "platform": str(platform or ""), "completion_reason": str(completion_reason or "")}
 
 
-def publish_meeting_started(meeting_id, native, platform, uid,
-                             *, timeout: Optional[float] = None) -> bool:
-    return publish(EVENT_MEETING_STARTED, meeting_started_source_id(meeting_id),
-                    meeting_started_refs(meeting_id, native, platform, uid), timeout=timeout)
+async def publish_meeting_started(meeting_id, native, platform, uid,
+                                  *, timeout: Optional[float] = None) -> bool:
+    return await publish(EVENT_MEETING_STARTED, meeting_started_source_id(meeting_id),
+                         meeting_started_refs(meeting_id, native, platform, uid), timeout=timeout)
 
 
-def publish_meeting_completed(meeting_id, native, platform, uid, completion_reason,
-                               *, timeout: Optional[float] = None) -> bool:
-    return publish(EVENT_MEETING_COMPLETED, meeting_completed_source_id(meeting_id),
-                    meeting_completed_refs(meeting_id, native, platform, uid, completion_reason),
-                    timeout=timeout)
+async def publish_meeting_completed(meeting_id, native, platform, uid, completion_reason,
+                                    *, timeout: Optional[float] = None) -> bool:
+    return await publish(
+        EVENT_MEETING_COMPLETED, meeting_completed_source_id(meeting_id),
+        meeting_completed_refs(meeting_id, native, platform, uid, completion_reason),
+        timeout=timeout)

--- a/core/meetings/services/meeting-api/src/meeting_api/service_authority/models.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/service_authority/models.py
@@ -2,11 +2,14 @@
 from __future__ import annotations
 
 import json
+import logging
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any, Literal, Mapping, Optional
 from urllib.parse import urlparse
 
+
+_log = logging.getLogger("meeting_api.service_authority.models")
 
 AUTHORITY_VERSION = "service-authority.v1"
 LIFECYCLE_CONTRACT_VERSION = "2026-07-28"
@@ -225,6 +228,10 @@ _DECISION_KEYS = frozenset({
     "message",
     "action_url",
 })
+# THIS SET IS NOW THE CONTRACT'S CENSUS, NOT A GATE. `from_wire` ignores what it does not find here
+# (see its docstring); only `from_wire(..., strict=True)` — the contract test — refuses. Adding a
+# name here still teaches meeting-api to READ that field; leaving one out no longer costs the
+# customer their meeting.
 
 # Present-but-empty is the same as absent everywhere below, so the required set is spelled once.
 _OPTIONAL_DECISION_KEYS = frozenset({"stop_scope", "message", "action_url"})
@@ -283,11 +290,35 @@ class ServiceAuthorityDecision:
         now: datetime,
         max_age_seconds: float,
         enforced: bool = True,
+        strict: bool = False,
     ) -> "ServiceAuthorityDecision":
+        """Parse one wire decision. UNKNOWN KEYS ARE IGNORED; every known key is still validated.
+
+        WHY TOLERANT AT THE RUNTIME DOOR. This used to reject the whole response on any key it did
+        not recognise, and that is how a decider adding a field became an OUTAGE: an actionable 403
+        arrived, `from_wire` raised, the adapter mapped the raise to `ServiceAuthorityUnavailable`,
+        and the caller got a 503. The release that added `message` / `action_url` fixed that
+        instance by widening the allow-list by exactly two names — which leaves the CLASS intact and
+        recreates the outage on the next optional field anybody adds. A decider and a meeting-api
+        are separately deployed; requiring them to ship together is precisely the coupling this
+        contract exists to avoid, and the failure is asymmetric — ignoring a field we do not
+        understand costs us that field, while refusing the response costs the customer the service.
+
+        ``strict=True`` keeps the old refusal, and it is for the CONTRACT TEST only: that is where
+        an unexpected key means "our own fixture drifted from the contract" rather than "the other
+        side is newer than us". No production path passes it.
+        """
         if not isinstance(value, Mapping):
             raise ValueError("service-authority response must be an object")
-        if set(value) - _DECISION_KEYS:
+        unknown = set(value) - _DECISION_KEYS
+        if unknown and strict:
             raise ValueError("service-authority response contains unknown fields")
+        if unknown:
+            _log.debug(
+                "service-authority response carried unknown field(s) %s — ignored; "
+                "this meeting-api is older than the deciding service",
+                ",".join(sorted(unknown)),
+            )
         required = _DECISION_KEYS - _OPTIONAL_DECISION_KEYS
         if any(key not in value for key in required):
             raise ValueError("service-authority response is incomplete")

--- a/core/meetings/services/meeting-api/tests/test_db_writer.py
+++ b/core/meetings/services/meeting-api/tests/test_db_writer.py
@@ -11,12 +11,9 @@ the redis-wired in-memory store mirroring the prod topology — no docker):
   * the FLIPPED INCIDENT — redis wiped after a flush ⇒ GET /transcripts still serves from durable;
   * parent semantics — the mutable tail (young ``updated_at``) stays in redis; empty text is
     dropped not stored; a failed durable write leaves the hash INTACT (trim-after-confirm);
-  * completion finalization — the lifecycle callback's terminal advance flushes EVERYTHING left.
-
-A whole section used to sit beside these: the processed-doc drain — ``proc:meeting:{row_id}``
-notes into ``data['processed']``, its ``view_end`` end-of-processing protocol and the bounded
-``processed_pending`` re-drain. PRD decision 34 removed the producer of that stream, so there is
-one body of a transcript and one drain to prove.
+  * completion finalization — the lifecycle callback's terminal advance flushes EVERYTHING left;
+  * processed-doc durability — ``proc:meeting:{row_id}`` notes persist into ``data['processed']``,
+    and a SECOND meeting on the same native link never clobbers the first row's persisted doc.
 """
 from __future__ import annotations
 
@@ -30,9 +27,13 @@ from fastapi.testclient import TestClient
 from meeting_api.collector import consume_segments
 from meeting_api.collector.db_writer import (
     ACTIVE_MEETINGS_KEY,
+    PROC_PENDING_KEY,
+    PROC_VIEW_ID,
     db_writer_tick,
     finalize_meeting,
+    flush_meeting_processed,
     flush_meeting_segments,
+    proc_stream_key,
     segments_hash_key,
 )
 from meeting_api.collector.fakes import FakeRedisBus, InMemoryTranscriptStore
@@ -357,6 +358,145 @@ async def test_nonterminal_advance_does_not_finalize(redis_c, goldens):
     assert await redis_c.hlen(segments_hash_key(1)) == 1
 
 
+# ── (d) processed-doc durability + the re-send clobber fix ──────────────────────────────────────
+
+def _note(nid: str, text: str) -> dict:
+    return {"id": nid, "speaker": "Alice", "text": text}
+
+
+def _view(store, meeting_id: int, view_id: str = PROC_VIEW_ID) -> dict:
+    """The persisted processed VIEW — data.processed.views[] upserted by id (the addressable,
+    versioned multi-consumer shape the release DoD rules)."""
+    views = store._meetings[meeting_id]["data"]["processed"]["views"]
+    return next(v for v in views if v["id"] == view_id)
+
+
+async def test_processed_doc_persists_into_meeting_data_as_versioned_view(store, redis_c):
+    params = {"provider": "anthropic", "model": "claude-x", "pipeline": "meeting-copilot/proc-notes", "version": 1}
+    await redis_c.xadd(proc_stream_key(1), {"note": json.dumps(_note("s1", "Cleaned one.")),
+                                            "params": json.dumps(params)})
+    await redis_c.xadd(proc_stream_key(1), {"note": json.dumps(_note("s2", "Cleaned two.")),
+                                            "params": json.dumps(params)})
+
+    assert await flush_meeting_processed(redis_c, store, 1) == 2
+    view = _view(store, 1)
+    assert view["kind"] == "cleaned_transcript"
+    assert [n["text"] for n in view["doc"]["notes"]] == ["Cleaned one.", "Cleaned two."]
+    assert view["params"] == params        # the processing metadata APPLIED — reproducibility
+    assert view["source_cursor"]           # the stream position this view reflects
+    assert view["updated_at"]
+
+    # Cursor resume: nothing new ⇒ nothing re-merged; a refining re-emit UPDATES in place.
+    assert await flush_meeting_processed(redis_c, store, 1) == 0
+    await redis_c.xadd(proc_stream_key(1), {"note": json.dumps(_note("s2", "Cleaned two, better."))})
+    assert await flush_meeting_processed(redis_c, store, 1) == 1
+    view = _view(store, 1)
+    assert [n["text"] for n in view["doc"]["notes"]] == ["Cleaned one.", "Cleaned two, better."]
+    assert view["params"] == params        # a params-less drain never erases provenance
+
+
+async def test_processed_views_are_multi_consumer_other_views_preserved(store, redis_c):
+    """The views LIST is the multi-consumer seam: a future per-workspace/other processing's view
+    must survive the copilot view's upsert untouched."""
+    other = {"id": "ws-team:summary", "kind": "summary", "params": {"model": "m"},
+             "doc": {"text": "…"}, "source_cursor": "9-0", "updated_at": "2026-06-20T09:00:00Z"}
+    store._meetings[1]["data"]["processed"] = {"views": [dict(other)]}
+    await redis_c.xadd(proc_stream_key(1), {"note": json.dumps(_note("s1", "Copilot note."))})
+
+    await flush_meeting_processed(redis_c, store, 1)
+    views = store._meetings[1]["data"]["processed"]["views"]
+    assert [v["id"] for v in views] == ["ws-team:summary", PROC_VIEW_ID]
+    assert views[0] == other  # untouched
+
+
+async def test_second_meeting_on_same_native_does_not_clobber_first_processed_doc(redis_c):
+    """The clobber defect: proc docs were keyed by the NATIVE id, which a re-sent bot REUSES —
+    meeting 2's copilot output landed on meeting 1's doc. Keyed by the ROW id and persisted per
+    row, each meeting keeps its own processed doc across completion and a re-send."""
+    store = InMemoryTranscriptStore(redis_client=redis_c)
+    store.seed_meeting(user_id=USER, platform="google_meet", native_meeting_id=NATIVE, meeting_id=1,
+                       created_at="2026-06-20T08:59:00Z")
+    await redis_c.xadd(proc_stream_key(1), {"note": json.dumps(_note("a1", "First meeting note."))})
+    await finalize_meeting(redis_c, store, 1)  # meeting 1 completes; its doc is durable
+
+    # The bot is RE-SENT to the same native link → a NEW meeting row (id 2), its own proc stream.
+    store.seed_meeting(user_id=USER, platform="google_meet", native_meeting_id=NATIVE, meeting_id=2,
+                       created_at="2026-06-20T10:00:00Z")
+    await redis_c.xadd(proc_stream_key(2), {"note": json.dumps(_note("b1", "Second meeting note."))})
+    await finalize_meeting(redis_c, store, 2)
+
+    first = _view(store, 1)["doc"]["notes"]
+    second = _view(store, 2)["doc"]["notes"]
+    assert [n["text"] for n in first] == ["First meeting note."]    # SURVIVED the re-send
+    assert [n["text"] for n in second] == ["Second meeting note."]
+
+
+async def test_db_writer_tick_also_drains_processed_notes(store, bus, redis_c):
+    """The periodic tick persists the processed doc for ACTIVE meetings too (not only at
+    completion) — a crash mid-meeting keeps everything cleaned so far."""
+    await bus.xadd("transcription_segments", json.loads(_message(1, [_seg("s1", 1.0, "raw")])["payload"]))
+    await consume_segments(store, bus)  # puts meeting 1 in active_meetings
+    await redis_c.xadd(proc_stream_key(1), {"note": json.dumps(_note("s1", "Cleaned mid-meeting."))})
+
+    await db_writer_tick(redis_c, store, now=LATER)
+    assert [n["text"] for n in _view(store, 1)["doc"]["notes"]] == ["Cleaned mid-meeting."]
+
+
+# ── the end-of-processing protocol (ADR 0027 / processed-notes.v1 view_end) ─────────────────────
+# The copilot's final beat lands ~10s AFTER session_end, i.e. AFTER finalize_meeting's inline drain
+# — and the meeting then leaves the tick's sweep, so those notes were stranded in redis forever
+# (run-46: durable cursor froze below the stream tail). The protocol: finalize PARKS an
+# incomplete meeting in `processed_pending`; the tick re-drains it until the worker's `view_end`
+# marker is drained-through (or a bounded deadline passes — the dead-worker guarantee).
+
+async def _pending_ids(redis_c):
+    return [m.decode() if isinstance(m, bytes) else m
+            for m in await redis_c.zrange(PROC_PENDING_KEY, 0, -1)]
+
+
+async def test_late_final_beat_notes_land_after_finalize_via_view_end(store, redis_c):
+    """The run-46 regression: notes written AFTER the completion flush reach the durable row on the
+    next tick, and the parking clears exactly when the view_end marker is drained-through."""
+    await redis_c.xadd(proc_stream_key(1), {"note": json.dumps(_note("s1", "Mid-meeting note."))})
+    await finalize_meeting(redis_c, store, 1)
+    assert [n["text"] for n in _view(store, 1)["doc"]["notes"]] == ["Mid-meeting note."]
+    assert await _pending_ids(redis_c) == ["1"]        # no marker yet → parked, not forgotten
+
+    # The final post-session_end beat lands AFTER the finalize drain — then the marker.
+    await redis_c.xadd(proc_stream_key(1), {"note": json.dumps(_note("s1", "Final polished note."))})
+    marker_id = await redis_c.xadd(proc_stream_key(1), {"type": "view_end", "cursor": "9-0"})
+
+    await db_writer_tick(redis_c, store, now=LATER)
+    view = _view(store, 1)
+    assert [n["text"] for n in view["doc"]["notes"]] == ["Final polished note."]  # upgraded in place
+    assert view["source_cursor"] == (marker_id.decode() if isinstance(marker_id, bytes) else marker_id)
+    assert await _pending_ids(redis_c) == []           # drained-through the marker → unparked
+
+
+async def test_finalize_already_marker_complete_does_not_park(store, redis_c):
+    """A worker that finished BEFORE the terminal callback (marker already on the stream): the
+    finalize drain goes through the marker in one pass — nothing parks."""
+    await redis_c.xadd(proc_stream_key(1), {"note": json.dumps(_note("s1", "Done early."))})
+    await redis_c.xadd(proc_stream_key(1), {"type": "view_end"})
+
+    await finalize_meeting(redis_c, store, 1)
+    assert [n["text"] for n in _view(store, 1)["doc"]["notes"]] == ["Done early."]
+    assert await _pending_ids(redis_c) == []
+
+
+async def test_pending_redrain_gives_up_at_deadline_keeping_what_arrived(store, redis_c):
+    """A worker that died markerless: the parking expires at its deadline (bounded, P22's hard
+    guarantee) — everything that DID arrive is durable, the zset never grows unbounded."""
+    await redis_c.xadd(proc_stream_key(1), {"note": json.dumps(_note("s1", "Only note."))})
+    await finalize_meeting(redis_c, store, 1)
+    assert await _pending_ids(redis_c) == ["1"]
+
+    past_deadline = datetime.now(timezone.utc) + timedelta(seconds=600)  # > PROC_PENDING_GRACE_SEC
+    await db_writer_tick(redis_c, store, now=past_deadline)
+    assert await _pending_ids(redis_c) == []                             # gave up, loudly (logged)
+    assert [n["text"] for n in _view(store, 1)["doc"]["notes"]] == ["Only note."]  # kept
+
+
 # ── the REST surface, during AND after (DoD 8): api.v1 responses, both phases ───────────────────
 
 def _rest(store):
@@ -387,19 +527,18 @@ async def test_rest_mid_meeting_serves_merged_postgres_plus_redis_tail(store, bu
     assert_api_conforms("TranscriptionResponse", body)
 
 
-async def test_rest_after_completion_with_redis_wiped_serves_the_transcript(redis_c, goldens):
-    """AFTER the meeting — the observed defect: stop the bot, redis evicted ⇒ (pre-fix) the
-    transcript read EMPTY. Post-fix: completion finalizes it into postgres and GET /transcripts
-    serves the full transcript from the durable row alone — conformant to the sealed api.v1 shape.
-
-    It also used to assert a second body on the same response: ``data.processed.views[]``, the
-    copilot's cleaned view. PRD decision 34 removed the producer; a legacy row may still carry the
-    key (the free-form ``data`` field is unchanged), but nothing writes or reads one."""
+async def test_rest_after_completion_with_redis_wiped_serves_transcript_and_processed_view(redis_c, goldens):
+    """AFTER the meeting — the observed defects, both: stop the bot, redis evicted ⇒ (pre-fix) the
+    transcript read EMPTY and the processed output was UNREACHABLE. Post-fix: completion finalizes
+    both into postgres (meeting.data JSONB), and GET /transcripts serves the full transcript AND the
+    processed view from the durable row alone — conformant to the sealed api.v1 shape."""
     from collector_contracts import assert_api_conforms
 
     client, store = await _terminal_app_and_stores(redis_c)
     await store.append_segment(1, {**_seg("s1", 1.0, "closing words"),
                                    "updated_at": datetime.now(timezone.utc).isoformat()})
+    await redis_c.xadd(proc_stream_key(1), {"note": json.dumps(_note("s1", "Closing words, cleaned.")),
+                                            "params": json.dumps({"model": "claude-x"})})
 
     for case in ("joining", "active", "completed-stopped"):
         assert client.post("/bots/internal/callback/lifecycle", json=goldens[case]).status_code == 200
@@ -410,5 +549,63 @@ async def test_rest_after_completion_with_redis_wiped_serves_the_transcript(redi
     assert r.status_code == 200
     body = r.json()
     assert [s["text"] for s in body["segments"]] == ["closing words"]
-    assert not (body.get("data") or {}).get("processed")
+    views = body["data"]["processed"]["views"]  # rides the existing free-form data field — no new surface
+    assert views[0]["id"] == PROC_VIEW_ID and views[0]["kind"] == "cleaned_transcript"
+    assert [n["text"] for n in views[0]["doc"]["notes"]] == ["Closing words, cleaned."]
+    assert views[0]["params"] == {"model": "claude-x"}
     assert_api_conforms("TranscriptionResponse", body)
+
+
+# ── A18: the drain's justification for being GONE was false, and this is the check ─────────────
+
+def test_the_processed_notes_producer_is_still_here():
+    """THE FINDING. The drain was deleted with the justification "PRD decision 34 removed the
+    producer: nothing writes that stream". On this candidate the producer is alive in all three of
+    its parts, so the claim was false and `data.processed.views[]` simply stopped being written —
+    the terminal's durable notes pane and the schedule digest's `notes` flag go permanently empty
+    the moment the bot stops, which is the exact bug the drain exists for.
+
+    Read from SOURCE, deliberately: this is a cross-domain claim about the AGENT domain (meetings ⊥
+    agent — no import, no call), and the only honest way to check "does anybody still write this
+    stream" is to look. If the producer is genuinely removed one day, this test fails and the drain
+    goes with it — in ONE change. A half-applied removal, in either direction, is the failure."""
+    import pathlib
+
+    root = pathlib.Path(__file__).resolve().parents[5]
+    dispatch = (root / "core/agent/control_plane/dispatch.py").read_text()
+    engine = (root / "core/agent/worker/engine.py").read_text()
+    worker = (root / "core/agent/worker/meeting.py").read_text()
+
+    assert "VEXA_TRANSCRIPT_STREAM" in dispatch, (
+        "the meeting worker is no longer dispatched — if that is true, delete the drain too")
+    assert 'proc_stream=f"proc:meeting:{row_id}"' in engine, (
+        "the worker is no longer given a proc stream — if that is true, delete the drain too")
+    assert "stream.xadd(proc_stream, fields)" in worker, (
+        "nothing xadds cleaned notes any more — if that is true, delete the drain too")
+
+
+def test_the_drain_and_its_pending_re_drain_are_wired_into_the_tick_and_the_finalize():
+    """The two call sites the removal took out. Asserted from source rather than only through
+    behaviour, because the behavioural tests above pass a sink that implements the merge — and the
+    defect was that nothing ever CALLED it."""
+    import inspect
+
+    from meeting_api.collector import db_writer as dw
+
+    assert "flush_meeting_processed" in inspect.getsource(dw.db_writer_tick)
+    assert "PROC_PENDING_KEY" in inspect.getsource(dw.db_writer_tick)
+    assert "flush_meeting_processed" in inspect.getsource(dw.finalize_meeting)
+
+
+def test_the_grace_period_is_declared_config(monkeypatch):
+    """`PROC_PENDING_GRACE_SEC` is read from the environment, so gate:config-contract requires it in
+    meeting-api's declaration — an undeclared env read is a value an operator can set that reaches
+    nothing (or, here, one they cannot set at all)."""
+    import json
+    import pathlib
+
+    decl = json.loads((pathlib.Path(__file__).resolve().parents[1]
+                       / "src/meeting_api/config.v1.json").read_text())
+    entry = next((k for k in decl["keys"] if k["key"] == "PROC_PENDING_GRACE_SEC"), None)
+    assert entry is not None, "PROC_PENDING_GRACE_SEC is read by db_writer.py and declared nowhere"
+    assert entry["class"] == "defaulted" and entry["default"] == "120"

--- a/core/meetings/services/meeting-api/tests/test_flows_publish.py
+++ b/core/meetings/services/meeting-api/tests/test_flows_publish.py
@@ -16,7 +16,10 @@ from __future__ import annotations
 import asyncio
 import json
 import pathlib
+import socket
+import time
 
+import httpx
 import pytest
 from fastapi.testclient import TestClient
 
@@ -45,7 +48,7 @@ def published(monkeypatch):
     """Every fact meeting-api handed to `events_mod.publish`, recorded at the seam. No network."""
     sent = []
 
-    def fake(event_type, source_event_id, refs, **kw):
+    async def fake(event_type, source_event_id, refs, **kw):
         sent.append({"event_type": event_type, "source_event_id": source_event_id, "refs": refs})
         return True
 
@@ -54,44 +57,57 @@ def published(monkeypatch):
 
 
 # ── the wire shape (F142's own test, run here against meeting-api's copy) ──────────────────────
-def test_publish_sends_refs_not_subject_refs_and_the_operator_header(monkeypatch):
+def _record_transport(calls, status=202):
+    """An httpx transport that records the request instead of sending it. Replaces the old
+    `urlopen` monkeypatch: the publisher is `async` now precisely so it cannot block the loop."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls.append({"url": str(request.url),
+                      "headers": {k.lower(): v for k, v in request.headers.items()},
+                      "body": json.loads(request.content.decode())})
+        return httpx.Response(status)
+
+    return httpx.MockTransport(handler)
+
+
+@pytest.fixture()
+def wire(monkeypatch):
+    """Every request the publisher put on the wire, with no socket involved."""
+    calls = []
+    real = httpx.AsyncClient
+
+    def factory(*a, **kw):
+        kw["transport"] = _record_transport(calls)
+        return real(*a, **kw)
+
+    # `events.publish` does `import httpx` at call time, so patching the module attribute is what
+    # the publisher will see — there is deliberately no module-level client to reach past.
+    monkeypatch.setattr(httpx, "AsyncClient", factory)
+    return calls
+
+
+async def test_publish_sends_refs_not_subject_refs_and_the_operator_header(monkeypatch, wire):
     """`EventSubmission` is a plain pydantic model — an unknown key is IGNORED, not refused, which
     is exactly how a body spelled `subject_refs` was admitted 202 with `refs == {}` on the F142
     incident. Asserted directly against the wire body this copy of the publisher builds."""
-    calls = []
-
-    class _Resp:
-        status = 202
-        def __enter__(self):
-            return self
-        def __exit__(self, *a):
-            return False
-
-    def fake_urlopen(req, timeout=None):
-        calls.append({"headers": {k.lower(): v for k, v in req.header_items()},
-                      "body": json.loads(req.data.decode())})
-        return _Resp()
-
     monkeypatch.setenv("VEXA_FLOWS_API_URL", "http://flows.example")
     monkeypatch.setenv("VEXA_FLOWS_API_KEY", "op-key")
-    monkeypatch.setattr(events_mod.urllib.request, "urlopen", fake_urlopen)
 
-    ok = events_mod.publish("meeting.started", "live-9", {"uid": "1", "meeting_id": "9"})
+    ok = await events_mod.publish("meeting.started", "live-9", {"uid": "1", "meeting_id": "9"})
 
     assert ok is True
-    assert calls[0]["body"] == {
+    assert wire[0]["url"] == "http://flows.example/events"
+    assert wire[0]["body"] == {
         "event_type": "meeting.started", "source_event_id": "live-9",
         "refs": {"uid": "1", "meeting_id": "9"},
     }
-    assert calls[0]["headers"].get("x-flows-operator-key") == "op-key"
+    assert wire[0]["headers"].get("x-flows-operator-key") == "op-key"
 
 
-def test_publish_makes_no_call_and_returns_false_with_no_flows_url(monkeypatch):
+async def test_publish_makes_no_call_and_returns_false_with_no_flows_url(monkeypatch, wire):
     monkeypatch.delenv("VEXA_FLOWS_API_URL", raising=False)
-    called = []
-    monkeypatch.setattr(events_mod.urllib.request, "urlopen", lambda *a, **kw: called.append(1))
-    assert events_mod.publish("meeting.started", "live-1", {"uid": "1"}) is False
-    assert called == []
+    assert await events_mod.publish("meeting.started", "live-1", {"uid": "1"}) is False
+    assert wire == []
 
 
 def test_source_event_ids_match_invite_intakes_own_scheme():
@@ -174,7 +190,12 @@ def test_no_flows_configured_makes_no_http_call_and_the_callback_still_succeeds(
     monkeypatch.delenv("VEXA_FLOWS_API_URL", raising=False)
     monkeypatch.delenv("VEXA_FLOWS_API_KEY", raising=False)
     called = []
-    monkeypatch.setattr(events_mod.urllib.request, "urlopen", lambda *a, **kw: called.append(1))
+
+    def _no_client(*a, **kw):
+        called.append(1)
+        raise AssertionError("publish opened an HTTP client with no flows domain configured")
+
+    monkeypatch.setattr(httpx, "AsyncClient", _no_client)
     repo = InMemoryMeetingRepo()
     _seed(repo)
     client = TestClient(create_app(meeting_repo=repo))
@@ -198,10 +219,94 @@ def test_a_publish_that_raises_never_fails_the_lifecycle_callback(monkeypatch):
     assert r.status_code == 200
 
 
-def test_the_publisher_itself_swallows_a_dead_flows_host(monkeypatch):
+async def test_the_publisher_itself_swallows_a_dead_flows_host(monkeypatch):
     monkeypatch.setenv("VEXA_FLOWS_API_URL", "http://127.0.0.1:9")  # nothing listens
     monkeypatch.setenv("VEXA_FLOWS_API_KEY", "op-key")
-    assert events_mod.publish("meeting.started", "live-1", {"uid": "1"}) is False
+    assert await events_mod.publish("meeting.started", "live-1", {"uid": "1"}) is False
+
+
+# ── A8: the publish is AWAITED, so a hanging flows never stalls the process ─────────────────────
+async def test_a_hanging_flows_target_does_not_block_the_event_loop(monkeypatch):
+    """THE DEFECT THIS REPLACES. `publish` was `urllib.request.urlopen` called from inside
+    `async def _apply_lifecycle_event` — a BLOCKING call on the one event loop that also runs the
+    segment consumer, the db-writer, the live transcript reads and `/health`. The 2 s bound was
+    per-request; the stall was per-PROCESS. (And urllib's `timeout` is a socket timeout, so an
+    unresolvable host was not bounded by it at all.)
+
+    A real socket that accepts and never answers: the publish must hang on ITS OWN timeout while
+    every other coroutine keeps being scheduled. Pre-fix, the heartbeat below could not tick until
+    the publish returned, so its elapsed time was the publish's timeout, not its own ~0.2 s."""
+    server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    server.bind(("127.0.0.1", 0))
+    server.listen(1)                      # accepts into the backlog, answers nothing, ever
+    host, port = server.getsockname()
+    monkeypatch.setenv("VEXA_FLOWS_API_URL", f"http://{host}:{port}")
+    monkeypatch.delenv("VEXA_FLOWS_API_KEY", raising=False)
+    try:
+        ticks = []
+
+        async def heartbeat():
+            for _ in range(10):
+                await asyncio.sleep(0.02)
+                ticks.append(time.monotonic())
+
+        publishing = asyncio.create_task(
+            events_mod.publish("meeting.started", "live-1", {"uid": "1"}, timeout=1.5))
+        started = time.monotonic()
+        await heartbeat()
+        heartbeat_took = time.monotonic() - started
+
+        assert len(ticks) == 10
+        assert heartbeat_took < 1.0, (
+            f"the loop was blocked for {heartbeat_took:.2f}s by a hanging publish — "
+            "10 × 20ms of other work should take ~0.2s")
+        assert not publishing.done(), "the publish should still be in flight, bounded by ITS timeout"
+        assert await publishing is False          # bounded, swallowed, no exception out
+    finally:
+        server.close()
+
+
+async def test_the_hanging_publish_returns_within_its_own_timeout(monkeypatch):
+    """The bound is honoured, and it covers connect (DNS included) as well as read — the half
+    urllib's socket timeout never covered."""
+    server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    server.bind(("127.0.0.1", 0))
+    server.listen(1)
+    host, port = server.getsockname()
+    monkeypatch.setenv("VEXA_FLOWS_API_URL", f"http://{host}:{port}")
+    try:
+        started = time.monotonic()
+        landed = await events_mod.publish("meeting.started", "live-1", {"uid": "1"}, timeout=0.25)
+        elapsed = time.monotonic() - started
+        assert landed is False
+        assert elapsed < 3.0, f"publish took {elapsed:.2f}s against a 0.25s bound"
+    finally:
+        server.close()
+
+
+def test_the_lifecycle_callback_is_not_delayed_by_a_hanging_flows(monkeypatch):
+    """The callback the BOT is waiting on. With flows pointed at a socket that never answers, the
+    transition still completes — bounded by the publisher's own timeout, never by the resolver."""
+    server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    server.bind(("127.0.0.1", 0))
+    server.listen(1)
+    host, port = server.getsockname()
+    monkeypatch.setenv("VEXA_FLOWS_API_URL", f"http://{host}:{port}")
+    monkeypatch.setattr(events_mod, "TIMEOUT_S", 0.25)
+    try:
+        repo = InMemoryMeetingRepo()
+        _seed(repo)
+        client = TestClient(create_app(meeting_repo=repo))
+        _post(client, {"connection_id": "sess-flows", "status": "joining",
+                       "timestamp": "2026-09-03T10:00:00Z"})
+        started = time.monotonic()
+        r = _post(client, {"connection_id": "sess-flows", "status": "active",
+                           "timestamp": "2026-09-03T10:00:10Z"})
+        elapsed = time.monotonic() - started
+        assert r.status_code == 200
+        assert elapsed < 5.0, f"the lifecycle callback took {elapsed:.2f}s on a dead flows target"
+    finally:
+        server.close()
 
 
 # ── declaration ↔ census agreement (mirrors flows' own carrier-census suite, run locally) ──────

--- a/core/meetings/services/meeting-api/tests/test_person_bot_name.py
+++ b/core/meetings/services/meeting-api/tests/test_person_bot_name.py
@@ -1,26 +1,36 @@
-"""THE PERSON'S DEFAULT BOT NAME — one store, and meetings resolves it.
+"""THE PERSON'S DEFAULT BOT NAME — one store, one lookup, and meetings resolves it.
 
 There were three stores for one fact: `users.data.calendar_bot_name` (served on
-`/internal/users/{id}/bot-context`, which `auto_join.py:324` reads), a per-calendar override that
-beats it, and a `bot_name` key in a `.settings.json` file in the AGENT domain that only
-chat-dispatched bots read. So the same person's bot showed up under one name when a calendar armed
-it and another when they asked for it in chat, and nothing anywhere reconciled the two.
+`/internal/users/{id}/bot-context`, which `auto_join.py` reads), a per-calendar override that beats
+it, and a `bot_name` key in a `.settings.json` file in the AGENT domain that only chat-dispatched
+bots read. So the same person's bot showed up under one name when a calendar armed it and another
+when they asked for it in chat, and nothing anywhere reconciled the two.
 
 Founder ruling, 2026-09-02: NO FOURTH STORE. The bot-context value is the single source. Meetings
-owns the bot, so meetings resolves the default — here, on the direct spawn path, exactly as
-auto-join already does on its own. Callers stop resolving it: the rig stops reading a workspace
-file, and flows stops passing a name at all.
+owns the bot, so meetings resolves the default — on the direct spawn path exactly as auto-join
+already does on its own.
 
-PRECEDENCE, and it is the same order auto-join uses:
+AND ONE LOOKUP (A21). The first shape of that fix injected a SECOND fetcher into `build_router`, so
+`POST /bots` asked identity for the same `/internal/users/{id}/bot-context` body twice on one
+request — once at 10s for the name, once inside `request_bot` at 5s for the transcription backend
+and the capture-signal decision. Up to +15s on the path a person is waiting on, for one string,
+while both fetchers' comments claimed to be the only one. The name now comes out of the context the
+service already fetches: one hop, three readers.
+
+PRECEDENCE, unchanged, and the same order auto-join uses:
     an explicit bot_name on the request  >  this person's default  >  the deployment's
 """
 from __future__ import annotations
+
+import inspect
+import json
 
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from meeting_api.bot_spawn import build_router
+from meeting_api.bot_spawn import service as spawn_service
 from meeting_api.bot_spawn.fakes import FakeRuntimeClient, InMemoryMeetingRepo
 
 USER = 7
@@ -34,64 +44,74 @@ def _admin_token(monkeypatch):
     monkeypatch.setenv("ADMIN_TOKEN", "test-admin-token")
 
 
-def _client(context=None, calls=None):
+def _client(monkeypatch, context=None, calls=None):
+    """The router with the ONE bot-context lookup stubbed — `service._fetch_bot_context`, the same
+    seam `test_bot_spawn.py` uses for the transcription half of the same body."""
     repo, runtime = InMemoryMeetingRepo(), FakeRuntimeClient()
 
-    async def fetch_bot_context(user_id: int):
+    async def fetch(user_id: int):
         if calls is not None:
             calls.append(user_id)
-        return context
+        return context if context is not None else {}
 
+    monkeypatch.setattr(spawn_service, "_fetch_bot_context", fetch)
     app = FastAPI()
-    app.include_router(build_router(repo, runtime, fetch_bot_context=fetch_bot_context))
+    app.include_router(build_router(repo, runtime))
     return TestClient(app), runtime
 
 
 def _spawned_name(runtime):
     """The name the bot actually goes into the room with, out of the recorded workload spec."""
-    import json
     return json.dumps(runtime.specs[-1])
+
+
+def _spawn(client, **body):
+    return client.post("/bots", headers=HEADERS, json={
+        "platform": "google_meet", "native_meeting_id": "abc-defg-hij",
+        "meeting_url": URL, **body})
 
 
 def test_the_persons_default_is_used_when_the_caller_names_none(monkeypatch):
     monkeypatch.setenv("DEFAULT_BOT_NAME", "DeploymentBot")
-    client, runtime = _client(context={"bot_name": "Scribe"})
-    r = client.post("/bots", headers=HEADERS,
-                    json={"platform": "google_meet", "native_meeting_id": "abc-defg-hij",
-                          "meeting_url": URL})
+    client, runtime = _client(monkeypatch, context={"bot_name": "Scribe"})
+    r = _spawn(client)
     assert r.status_code == 201, r.text
     assert "Scribe" in _spawned_name(runtime)
 
 
-def test_an_explicit_name_beats_the_persons_default():
-    client, runtime = _client(context={"bot_name": "Scribe"})
-    client.post("/bots", headers=HEADERS,
-                json={"platform": "google_meet", "native_meeting_id": "abc-defg-hij",
-                      "meeting_url": URL, "bot_name": "JustThisOnce"})
+def test_an_explicit_name_beats_the_persons_default(monkeypatch):
+    client, runtime = _client(monkeypatch, context={"bot_name": "Scribe"})
+    _spawn(client, bot_name="JustThisOnce")
     body = _spawned_name(runtime)
     assert "JustThisOnce" in body and "Scribe" not in body
 
 
 def test_the_deployment_default_still_applies_when_the_person_has_none(monkeypatch):
     monkeypatch.setenv("DEFAULT_BOT_NAME", "DeploymentBot")
-    client, runtime = _client(context={})
-    client.post("/bots", headers=HEADERS,
-                json={"platform": "google_meet", "native_meeting_id": "abc-defg-hij",
-                      "meeting_url": URL})
+    client, runtime = _client(monkeypatch, context={})
+    _spawn(client)
+    assert "DeploymentBot" in _spawned_name(runtime)
+
+
+def test_a_blank_name_from_identity_is_not_a_name(monkeypatch):
+    monkeypatch.setenv("DEFAULT_BOT_NAME", "DeploymentBot")
+    client, runtime = _client(monkeypatch, context={"bot_name": "   "})
+    _spawn(client)
     assert "DeploymentBot" in _spawned_name(runtime)
 
 
 def test_an_unreachable_identity_never_stops_a_bot_joining(monkeypatch):
     """A name is a nicety; joining the call is the product. Failing the spawn because a preference
-    lookup timed out would trade the thing they asked for against the label on it."""
+    lookup timed out would trade the thing they asked for against the label on it.
+
+    The REAL `_fetch_bot_context` against a dead address, not a stub: with one fetcher, the
+    swallow-everything guarantee lives inside it and nowhere else, so that is what has to hold."""
     monkeypatch.setenv("DEFAULT_BOT_NAME", "DeploymentBot")
+    monkeypatch.setenv("ADMIN_API_URL", "http://127.0.0.1:9")   # nothing listens
+    monkeypatch.setenv("INTERNAL_API_SECRET", "unused-but-required-to-attempt-the-call")
     repo, runtime = InMemoryMeetingRepo(), FakeRuntimeClient()
-
-    async def boom(user_id: int):
-        raise RuntimeError("identity is down")
-
     app = FastAPI()
-    app.include_router(build_router(repo, runtime, fetch_bot_context=boom))
+    app.include_router(build_router(repo, runtime))
     r = TestClient(app).post("/bots", headers=HEADERS,
                              json={"platform": "google_meet", "native_meeting_id": "abc-defg-hij",
                                    "meeting_url": URL})
@@ -99,18 +119,49 @@ def test_an_unreachable_identity_never_stops_a_bot_joining(monkeypatch):
     assert "DeploymentBot" in _spawned_name(runtime)
 
 
-def test_identity_is_not_asked_when_the_caller_already_named_the_bot():
-    """One fewer hop on the path a person is waiting on, and the answer could not change anything."""
+# ── A21: exactly one bot-context fetch per spawn ───────────────────────────────────────────────
+def test_identity_is_asked_exactly_once_per_spawn(monkeypatch):
+    """The whole point. The same body answers three questions on this request — the transcription
+    backend, the capture-signal decision, and the name — so it is fetched once."""
     calls = []
-    client, _runtime = _client(context={"bot_name": "Scribe"}, calls=calls)
-    client.post("/bots", headers=HEADERS,
-                json={"platform": "google_meet", "native_meeting_id": "abc-defg-hij",
-                      "meeting_url": URL, "bot_name": "JustThisOnce"})
-    assert calls == []
+    client, _runtime = _client(monkeypatch, context={"bot_name": "Scribe"}, calls=calls)
+    _spawn(client)
+    assert calls == [USER]
+
+
+def test_naming_the_bot_explicitly_does_not_add_or_remove_a_fetch(monkeypatch):
+    """It used to REMOVE one (the router skipped its extra fetcher) — which is only a saving
+    because there were two. There is one, `request_bot` needs it for the transcription backend
+    whatever the bot is called, and the explicit name still wins without identity being consulted
+    about it."""
+    calls = []
+    client, runtime = _client(monkeypatch, context={"bot_name": "Scribe"}, calls=calls)
+    _spawn(client, bot_name="JustThisOnce")
+    assert calls == [USER]
+    assert "JustThisOnce" in _spawned_name(runtime)
+
+
+def test_the_router_no_longer_carries_a_bot_context_fetcher():
+    """Asserted on the signature, because the defect was structural: a second injected fetcher is
+    invisible in behaviour (both return the same body) and shows up only as latency."""
+    assert "fetch_bot_context" not in inspect.signature(build_router).parameters
+    # …and nothing in the body calls one either (the docstring still explains why it is gone).
+    body = inspect.getsource(build_router).split('"""', 2)[-1]
+    assert "fetch_bot_context" not in body
+
+
+def test_the_one_fetcher_keeps_its_own_timeout(monkeypatch):
+    """`service._fetch_bot_context` is bounded at 5s. The removed router fetcher was bounded at 10s
+    and ran in series with it — the worst case was the sum, not the max."""
+    src = inspect.getsource(spawn_service._fetch_bot_context)
+    assert "timeout=5.0" in src
 
 
 def test_a_deployment_with_no_identity_edge_still_spawns(monkeypatch):
-    """`fetch_bot_context=None` is the offline/self-host shape — no admin edge configured."""
+    """The offline/self-host shape: no ADMIN_API_URL, so `_fetch_bot_context` answers `{}` without
+    reaching for anything."""
+    monkeypatch.delenv("ADMIN_API_URL", raising=False)
+    monkeypatch.delenv("INTERNAL_API_SECRET", raising=False)
     monkeypatch.setenv("DEFAULT_BOT_NAME", "DeploymentBot")
     repo, runtime = InMemoryMeetingRepo(), FakeRuntimeClient()
     app = FastAPI()

--- a/core/meetings/services/meeting-api/tests/test_service_denial_passthrough.py
+++ b/core/meetings/services/meeting-api/tests/test_service_denial_passthrough.py
@@ -273,10 +273,74 @@ async def test_wire_hostile_fields_are_sanitised_without_losing_the_decision() -
     assert decision.action_url is None
 
 
+# --- A10: the trap is the CLASS, not the two names ---------------------------------------------
+
 @pytest.mark.asyncio
-async def test_genuinely_unknown_fields_are_still_rejected() -> None:
-    """Widening the allow-list by exactly two names is the change; it is not an open door."""
+async def test_an_unknown_optional_field_does_not_cost_the_customer_the_decision() -> None:
+    """THE CLASS the two-name widening left open.
+
+    `message` / `action_url` were added to the allow-list because, without them, a decider that
+    started sending them turned an actionable 403 into a 503 outage. That fixed one instance. The
+    NEXT optional field any decider adds reproduced it exactly — and a decider and a meeting-api
+    are separately deployed, which is the whole reason this contract exists.
+
+    So the runtime door now IGNORES what it does not recognise and still validates everything it
+    does. The decision survives; only the field we cannot read is lost."""
+    decision = await _wire_denial({
+        "message": "Fixture words the caller can act on.",
+        "some_field_a_newer_decider_sends": {"nested": ["anything", 1, None]},
+    })
+    assert decision.allow is False
+    assert decision.reason == "fixture_gate_closed"
+    assert decision.message == "Fixture words the caller can act on."
+    assert not hasattr(decision, "some_field_a_newer_decider_sends")
+
+
+@pytest.mark.asyncio
+async def test_tolerating_unknown_fields_does_not_stop_validating_the_known_ones() -> None:
+    """Tolerant is not lax. An unknown key rides along; a MALFORMED KNOWN key still refuses, and
+    the adapter still turns that into `ServiceAuthorityUnavailable` rather than a bad decision."""
     from meeting_api.service_authority import ServiceAuthorityUnavailable
 
     with pytest.raises(ServiceAuthorityUnavailable):
-        await _wire_denial({"totally_unexpected_field": "x"})
+        # `allow` is the field the whole decision turns on; a string is not a decision.
+        await _wire_denial({"allow": "no", "whatever_else": "x"})
+
+    with pytest.raises(ServiceAuthorityUnavailable):
+        # An admission decision may not carry a stop scope — a cross-field rule, still enforced.
+        await _wire_denial({"stop_scope": "billable_service", "whatever_else": "x"})
+
+
+def test_strict_mode_still_refuses_and_is_for_the_contract_test_only() -> None:
+    """The strictness has not been deleted — it has MOVED to where an unexpected key means our own
+    fixture drifted from the contract, rather than "the other side shipped first". No production
+    path passes `strict=True`; `adapters.HttpServiceAuthority` parses tolerantly."""
+    import inspect
+
+    from meeting_api.service_authority import adapters as authority_adapters
+
+    now = datetime.now(UTC)
+    request = ServiceAuthorityRequest.admit(
+        user_id=41,
+        request_id="meeting-session:fixture:admit",
+        service_identity="meeting-session:fixture",
+        transcription_provider="none",
+        active_concurrency=0,
+    )
+    wire = {
+        "authority_version": "service-authority.v1",
+        "decision_id": "decision-wire-1",
+        "request_id": request.request_id,
+        "service_identity": request.service_identity,
+        "allow": False,
+        "reason": "fixture_gate_closed",
+        "decided_at": now.isoformat(),
+        "a_field_the_contract_does_not_declare": "x",
+    }
+    with pytest.raises(ValueError, match="unknown fields"):
+        ServiceAuthorityDecision.from_wire(
+            wire, request=request, now=now, max_age_seconds=60, strict=True)
+    # …and the same body is a decision without the flag.
+    assert ServiceAuthorityDecision.from_wire(
+        wire, request=request, now=now, max_age_seconds=60).allow is False
+    assert "strict" not in inspect.getsource(authority_adapters.HttpServiceAuthority.decide)

--- a/core/meetings/services/meeting-api/tests/test_transcript_share.py
+++ b/core/meetings/services/meeting-api/tests/test_transcript_share.py
@@ -209,3 +209,134 @@ def test_the_two_routes_do_not_shadow_each_other():
 
     # a non-numeric id is refused by validation, never resolved as some other kind of name
     assert client.post("/meetings/not-a-row/share", json={}, headers=hdr).status_code == 422
+
+
+# ── A22: the mint body is validated, on BOTH address shapes ────────────────────────────────────
+# `_share_payload` took `mode` as free text, `int()`-ed `expires_in_sec` unguarded, and bounded
+# neither the TTL nor `allowed_emails`. The first of those is a DISCLOSURE: `validate_transcript_
+# grant` applies the allow-list only when `mode == "restricted"`, so any other string — a typo
+# included — is stored verbatim and read back as an OPEN share, silently, while the caller believes
+# they restricted it.
+
+import pytest
+
+from meeting_api.collector.app import (
+    SEARCH_QUERY_MAX_CHARS,
+    SHARE_MAX_ALLOWED_EMAILS,
+    SHARE_MAX_TTL_SEC,
+    SHARE_MIN_TTL_SEC,
+)
+
+def _mint(client, body, *, by_id=None):
+    path = f"/meetings/{by_id}/share" if by_id else f"/meetings/{PLAT}/{NID}/share"
+    return client.post(path, json=body, headers={"x-user-id": str(OWNER)})
+
+
+def _client_and_row():
+    store = InMemoryTranscriptStore()
+    mid = store.seed_meeting(user_id=OWNER, platform=PLAT, native_meeting_id=NID)
+    return TestClient(create_app(store, redis=None)), store, mid
+
+
+@pytest.mark.parametrize("bad_mode", ["Restricted", "restrcted", "public", "private", "none"])
+def test_an_unknown_mode_is_refused_rather_than_minting_an_open_share(bad_mode):
+    """THE DEFECT. A near-miss on `restricted` is not a restricted share — it is an OPEN one, and
+    nothing anywhere says so. The caller finds out at mint time now, instead of the recipient
+    finding out later."""
+    client, store, mid = _client_and_row()
+    r = _mint(client, {"mode": bad_mode}, by_id=mid)
+    assert r.status_code == 422, r.text
+    assert "mode" in str(r.json()["detail"])
+    assert not store._meetings[mid]["data"].get("share_grants")
+
+
+def test_the_same_refusal_on_the_pair_route():
+    """One helper, two routes: the pair route is the older one and carried the same hole."""
+    client, store, mid = _client_and_row()
+    assert _mint(client, {"mode": "Restricted"}).status_code == 422
+    assert not store._meetings[mid]["data"].get("share_grants")
+
+
+def test_the_two_real_modes_still_mint():
+    client, _store, mid = _client_and_row()
+    assert _mint(client, {"mode": "open"}, by_id=mid).status_code == 200
+    assert _mint(client, {"mode": "restricted", "allowed_emails": ["a@b.test"]},
+                 by_id=mid).status_code == 200
+    assert _mint(client, {}, by_id=mid).status_code == 200          # default stays `open`
+    # A BLANK mode is still "unset", not an unknown value: most clients send "" for a field the
+    # user left alone, and 422-ing that would break working callers over an absent value. The
+    # dangerous case is a value that LOOKS like a decision and is not one, which is what is refused
+    # above.
+    assert _mint(client, {"mode": ""}, by_id=mid).status_code == 200
+    assert _mint(client, {"mode": "   "}, by_id=mid).status_code == 200
+
+
+@pytest.mark.parametrize("bad_ttl", ["soon", "1 day", [], {}, True])
+def test_a_non_numeric_ttl_is_a_422_not_a_500(bad_ttl):
+    """`int("soon")` raised inside the handler — an unhandled exception on a public route."""
+    client, _store, mid = _client_and_row()
+    r = _mint(client, {"mode": "open", "expires_in_sec": bad_ttl}, by_id=mid)
+    assert r.status_code == 422, r.text
+
+
+def test_the_ttl_is_clamped_at_both_ends():
+    """CLAMPED, not refused: an out-of-range duration is a caller asking for something we will not
+    give, and the safe direction is the shorter link."""
+    from datetime import datetime, timezone
+
+    client, store, mid = _client_and_row()
+
+    _mint(client, {"mode": "open", "expires_in_sec": 10 ** 9}, by_id=mid)
+    _mint(client, {"mode": "open", "expires_in_sec": 1}, by_id=mid)
+    grants = store._meetings[mid]["data"]["share_grants"]
+
+    def _seconds(grant):
+        exp = datetime.fromisoformat(grant["expires_at"])
+        if exp.tzinfo is None:
+            exp = exp.replace(tzinfo=timezone.utc)
+        return (exp - datetime.now(timezone.utc)).total_seconds()
+
+    assert _seconds(grants[0]) <= SHARE_MAX_TTL_SEC + 5
+    assert _seconds(grants[1]) >= SHARE_MIN_TTL_SEC - 5
+
+
+def test_allowed_emails_is_a_bounded_list():
+    """The list is stored on the meeting row and walked on every access check, so its length is a
+    cost the OWNER pays on every read of that meeting, for ever."""
+    client, _store, mid = _client_and_row()
+    too_many = [f"p{i}@acme.test" for i in range(SHARE_MAX_ALLOWED_EMAILS + 1)]
+    r = _mint(client, {"mode": "restricted", "allowed_emails": too_many}, by_id=mid)
+    assert r.status_code == 422 and "allowed_emails" in str(r.json()["detail"])
+
+    assert _mint(client, {"mode": "restricted", "allowed_emails": "a@b.test"},
+                 by_id=mid).status_code == 422        # a string is not a list
+    assert _mint(client, {"mode": "restricted",
+                          "allowed_emails": too_many[:SHARE_MAX_ALLOWED_EMAILS]},
+                 by_id=mid).status_code == 200
+
+
+def test_a_restricted_share_still_admits_only_the_allow_list_after_validation():
+    """The validation must not have changed what the grant MEANS — blanks dropped, addresses kept."""
+    client, store, mid = _client_and_row()
+    minted = _mint(client, {"mode": "restricted",
+                            "allowed_emails": ["  Guest@acme.test  ", "", "  "]},
+                   by_id=mid).json()
+    grant = store._meetings[mid]["data"]["share_grants"][-1]
+    assert grant["mode"] == "restricted"
+    assert grant["allowed_emails"] == ["Guest@acme.test"]
+
+    refused = client.post("/transcripts/share/accept", json={"token": minted["token"]},
+                          headers={"x-user-id": str(VISITOR), "x-user-email": "someone@else.test"})
+    assert refused.status_code != 200 or refused.json().get("ok") is not True
+
+
+def test_the_search_query_is_length_bounded():
+    """Bound as a parameter, never interpolated — so this is a RESOURCE bound, not an injection
+    one: `websearch_to_tsquery` + `ts_headline` over an unbounded string is CPU a caller should not
+    be able to ask for by the megabyte."""
+    client, _store, _mid = _client_and_row()
+    hdr = {"x-user-id": str(OWNER)}
+    assert client.get("/transcripts/search", params={"q": "x" * SEARCH_QUERY_MAX_CHARS},
+                      headers=hdr).status_code == 200
+    assert client.get("/transcripts/search", params={"q": "x" * (SEARCH_QUERY_MAX_CHARS + 1)},
+                      headers=hdr).status_code == 422


### PR DESCRIPTION
Car 4 of the v0.12.27 candidate — the meeting-api and identity findings from the OSS code review
(A8, A10, A17, A18, A20, A21, A22, and lens A's `_dev_mode()` note). Seven commits, one per item.

## What changed

- **A8 — the flows publish edges are awaited, not blocking.** `meeting_api/events.py` (called from
  `async def _apply_lifecycle_event`) and `admin_api/app/events.py` (called from
  `async def create_user`) both ran `urllib.request.urlopen` **on the event loop**. The 2 s bound
  was per request while the stall was per **process** — the same loop serves the segment consumer,
  the db-writer, live transcript reads, `/internal/validate` and `/health`. And urllib's `timeout`
  is a socket timeout, so **DNS was not bounded by it at all**: an unresolvable
  `VEXA_FLOWS_API_URL` stalled the process for as long as the resolver took. Both are now
  `async def` over `httpx.AsyncClient(timeout=…)`, which bounds connect (DNS included), write, read
  and pool acquisition. The swallow keeps its contract but is no longer silent — a debug line names
  the base, so a flows address wrong since a deploy stops looking exactly like a deployment with no
  flows domain.

- **A10 — the service-authority wire tolerates unknown fields.**
  `ServiceAuthorityDecision.from_wire` rejected the whole response on any unrecognised key, and the
  adapter maps that raise to `ServiceAuthorityUnavailable` — so a decider adding a field turned an
  actionable 403 into a 503. Widening the allow-list by `message`/`action_url` fixed one instance
  and left the class. Unknown keys are now ignored (logged, named) while every known key and every
  cross-field rule is still validated; the refusal moves behind `strict=True`, used only by the
  contract test, and the production adapter is asserted never to pass it.

- **A17 — person settings gain a write door and a migration door, and the per-person internal doors
  lose the dev-mode bypass.** The read door shipped alone: `person_settings.apply` and `plan_import`
  had **no caller anywhere**, so identity could only ever answer defaults — on upgrade everyone who
  had turned their minutes off started receiving them again, and everyone outside UTC had their
  times stated in the wrong clock. Now `PUT /internal/users/{id}/settings` (partial, validated
  all-or-nothing, `bot_name` refused with a pointer to `/internal/users/{id}/bot-context`) and
  `POST /admin/users/{id}/settings/import` (operator-driven one-shot migration; body is the old
  `.settings.json` object verbatim; re-runnable, keeps a since-changed preference, carries
  `bot_name` into the bot's own store only when empty, drops unknown keys). Both doors are
  documented in the module docstring. Separately: `_check_internal` lets `DEV_MODE=true` with no
  `INTERNAL_API_SECRET` through unauthenticated — a local convenience on `/internal/validate`, a
  **cross-user read** on a route whose path names the person. Both settings doors now require the
  secret in every mode.

- **A18 — the processed-notes drain is restored; its justification for being gone is false here.**
  `flush_meeting_processed`, the `processed_pending` re-drain and the two sink methods were deleted
  with the claim *"PRD decision 34 removed the producer: nothing writes that stream"*. On this
  candidate the producer is alive in all three of its parts —
  `core/agent/control_plane/dispatch.py` still stamps `VEXA_TRANSCRIPT_STREAM`,
  `core/agent/worker/engine.py` still passes `proc_stream=f"proc:meeting:{row_id}"`, and
  `core/agent/worker/meeting.py` still `xadd`s every cleaned note and emits `view_end`. The removal
  commit that would have made the claim true (`f95d4d5e0`) **is not in this branch's ancestry**: the
  docstring travelled here without the code it described, and meeting-api's own `__main__` still
  documented the drain it no longer had. With the producer alive and the drain gone,
  `data.processed.views[]` is never written, so the terminal's durable notes pane and the schedule
  digest's `notes` flag go permanently empty the moment the bot stops. Restored verbatim, plus
  `PROC_PENDING_GRACE_SEC` re-declared in `config.v1.json` (an env read `gate:config-contract`
  requires) and a docstring note carrying the evidence.

- **A20 — the case-folded email lookups get an ORDER BY, a folded write, and an index.**
  `ORDER BY User.id` on both lookups (oldest wins): on an instance already holding case-variant
  duplicates, `.first()` without one returns whichever row the plan reached first, so the two routes
  could disagree and either could disagree with itself after a vacuum. New rows are stored folded
  (existing rows are never rewritten), which closes the two-concurrent-creates race no read-side
  fold can — the second insert hits the `users.email` UNIQUE index that already exists and
  `create_user` re-resolves to the winner (200, not 500, not a second account). Plus
  `ix_users_email_lower` and `schema/MIGRATION-0007-users-email-lower.md`.

- **A21 — `POST /bots` asks identity for the bot context once, not twice.** `request_bot` already
  fetches `/internal/users/{id}/bot-context` for the transcription backend and the capture-signal
  decision; the bot-name fix injected a **second** fetcher into `build_router`, so one request asked
  for the same body twice — 10 s there, 5 s here, in series, worst case +15 s on the path a person
  is waiting on, for one string, while each fetcher's comment claimed to be the only one. The name
  now comes out of the context the service already has. Precedence unchanged; `__main__`'s
  `_bot_context_fetcher` stays for the auto-join sweep, which spawns outside a request.

- **A22 — the transcript-share mint body is validated and the search query is bounded.** `mode` was
  free text, and `validate_transcript_grant` gates on `mode == "restricted"` and nothing else — so
  `"Restricted"`, `"restrcted"`, `"private"` were stored verbatim and read back as an **open** share
  anyone authenticated could redeem, silently, while the caller believed they had restricted it. The
  closed set is checked at the door (422), on both address shapes, before any grant is written. A
  non-numeric `expires_in_sec` was a 500 on a public route (now 422); TTL is clamped to 60 s–30 d;
  `allowed_emails` must be a list and is capped at 200 (it is walked on every access check of that
  meeting, for ever). `GET /transcripts/search` gains `max_length` on `q`.

## Two decisions worth a reviewer's eye

**1. A20 reverses an existing test.** `test_the_stored_address_is_not_rewritten` asserted that
storage preserves the typed case, on the grounds that it is the address a person's mail is addressed
to. This PR stores **new** addresses folded, so that test is rewritten. Case in an address is not
deliverability, and keeping it cost the two things a read-side fold cannot buy: the concurrent-create
race stays open, and `lower(email)` can never become UNIQUE while stored values disagree in case.
The surviving half of the old decision — never rewrite what is already stored — is kept and tested.

**2. A20's index ships NON-unique, deliberately.** The invariant we want is
`CREATE UNIQUE INDEX ON users (lower(email))`. It cannot ship in the model: the instances that need
it are exactly the ones already holding case-variant duplicates, and `_sync_indexes` **fails closed**
on a unique index it cannot build (#1186) — so shipping it unique turns *"this instance has a few
ghost accounts"* into *"admin-api will not start"*. Trading a data defect for an outage is not a fix.
`MIGRATION-0007` carries the operator path: find the duplicates, reconcile them by hand, build
`UNIQUE CONCURRENTLY`, and only then may the model carry it.

## Not fixed here — needs another car

`docs/changelog.d/1456-proc-pending-grace.md` on this candidate says **"`PROC_PENDING_GRACE_SEC` is
gone… the variable is no longer read. Delete it from your `.env`."** A18 restores the drain, so that
entry is now wrong and would ship an instruction to delete a live variable. `docs/` is outside this
car's file scope — it needs a one-line correction from whoever owns the release notes.

## Test results (verbatim)

`core/meetings/services/meeting-api` — `uv run pytest -q -p no:cacheprovider`
(baseline on the candidate before this branch: `1379 passed, 5 skipped`):

```
-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
1414 passed, 5 skipped, 1 warning in 70.48s (0:01:10)
```

`core/identity/services/admin-api` — `uv run pytest -q`:

```
-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
67 passed, 87 skipped, 4 warnings in 6.98s
```

**The 87 skips are the docker-backed testcontainers suites** (`conftest.requires_docker`), which
this workspace runs container workloads on a separate host for — they were **not executed here**.
That includes the DB-backed halves of A17 (`test_person_settings.py`: the write→read round trip, the
all-or-nothing refusal, the migration and its re-run, the imported `bot_name` reaching bot-context,
the dev-mode refusal) and of A20 (`test_email_case_folding.py`: planted duplicates resolving to the
same oldest row from both routes, a planted row surviving a second create in another case, an
existing mixed-case row left untouched). **Those need a CI or bbb run before merge.** The offline
halves — `test_person_settings_doors.py` (12) and `test_email_lookup_plan.py` (7) — do run above and
cover the routes, refusals, the pure decisions, the SQL both lookups emit, and the index.

`node scripts/gates.mjs dataflow` is green on this branch (it was red on the older base; the
candidate's own `flows.v1` CALM registration landed in the meantime, and this branch is rebased onto
it). The pre-push static gate suite passed.

Refs #1553

COMMITMENTS IN THIS DRAFT — none.

<!-- vexa-agent -->
