### PR TITLE
[DEV] 0.12.27 car 9: await the async flows publisher in the admin-api swallow test (gate:python red) (#1553)

### DIFF
--- a/core/identity/services/admin-api/tests/test_onboarding_event.py
+++ b/core/identity/services/admin-api/tests/test_onboarding_event.py
@@ -18,6 +18,7 @@ onboarding completing without the event — because that is a person who is sign
 """
 from __future__ import annotations
 
+import asyncio
 import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy import create_engine
@@ -199,4 +200,4 @@ def test_the_publisher_itself_swallows_everything(monkeypatch):
     """Asserted on the publisher, not only through the route: the next caller of `publish` gets the
     same guarantee without having to know to wrap it."""
     monkeypatch.setenv("VEXA_FLOWS_API_URL", "http://127.0.0.1:9")   # nothing listens
-    assert events_mod.publish("onboarding.completed", "x", {"subject": "1"}) is False
+    assert asyncio.run(events_mod.publish("onboarding.completed", "x", {"subject": "1"})) is False


### PR DESCRIPTION
Car 4 (#1561) made `admin_api.app.events.publish` async; `test_the_publisher_itself_swallows_everything` still called it synchronously and asserted on the coroutine object — the one red test in `gate:python` on the train PR. Wrapped in `asyncio.run`, matching `test_boot_db_retry.py`. Refs #1553.

COMMITMENTS IN THIS DRAFT — none.

<!-- vexa-agent -->