### PR TITLE
[DEV] 0.12.27 car 7: exact-host meeting-link parsing, bounded regex, token fingerprint, mkstemp; placeholder passcodes in fixtures (#1553)

### DIFF
--- a/core/flows/tests/test_storm.py
+++ b/core/flows/tests/test_storm.py
@@ -155,7 +155,11 @@ def test_engine_restart_with_durable_db_never_repeats_effects():
     from fixtures import INVITE_REFS, drain
     from flows import FakeClock
 
-    path = tempfile.mktemp(suffix=".db")
+    # mkstemp, not mktemp: mktemp returns a name and leaves the race between the check and the
+    # open to whoever gets there first. The fd is closed immediately — sqlite opens the path
+    # itself — but the file now EXISTS and is ours, which is the whole point.
+    fd, path = tempfile.mkstemp(suffix=".db")
+    os.close(fd)
     try:
         world = FakeWorld()
         reg = build_registry(world); register_flows(reg)

--- a/core/meetings/services/mcp/README.md
+++ b/core/meetings/services/mcp/README.md
@@ -125,8 +125,9 @@ pointer** — theirs is `linode_id`, ours is `meeting_id` + `platform`. The agen
 (`what_i_tried` / `what_happened` / `deployment` / `version`) are composed into that pair
 server-side, so the MCP tool and any later HTTP ticket surface land **one shape** in the sink.
 Alongside it the sink receives capped `logs` with a `logs_truncated` flag, a server-side
-`reported_at`, a content-derived `fingerprint` for dedupe, and `caller_fingerprint` — a salted
-SHA-256 prefix of the caller's API key. The response mirrors Linode's ticket object: `id`,
+`reported_at`, a content-derived `fingerprint` for dedupe, and `caller_fingerprint` — a
+salt-keyed BLAKE2b fingerprint of the caller's API key (16 hex chars; the key itself is never
+stored, logged, or sent). The response mirrors Linode's ticket object: `id`,
 `status`, `severity`, `opened`, `updated`, `opened_by`, `entity`.
 
 **The caller is authenticated before the operator's credential is spent.** Every ticket is filed
@@ -145,7 +146,7 @@ accept teaches us nothing.
 
 | Property | How it is held |
 |---|---|
-| **The API key is never forwarded to the sink** | only `caller_fingerprint`, a salted SHA-256 prefix; asserted with a negative control in `tests/test_app.py` |
+| **The API key is never forwarded to the sink** | only `caller_fingerprint`, a salt-keyed BLAKE2b fingerprint; asserted with a negative control in `tests/test_app.py` |
 | **Ticket text is data, never instruction** | forwarded verbatim, never parsed, never executed, never fed to an agent of ours |
 | **SSRF closed by construction** | there is no url-shaped field, and **nothing a caller sends is ever dereferenced**. The only URL this route opens is the operator's `VEXA_TICKET_SINK_URL`. Links belong in the text, where a human reads them |
 | **No path to account state** | the service has no DB, no ORM, no redis — a test walks the package's imports to keep it that way, so a ticket write cannot touch meetings or users |

--- a/core/meetings/services/mcp/src/vexa_mcp/app.py
+++ b/core/meetings/services/mcp/src/vexa_mcp/app.py
@@ -211,13 +211,23 @@ def _caller_fingerprint(api_key: str) -> str:
     """A pseudonymous, stable handle for the caller — NEVER the API key itself.
 
     Deliberate choice: the ticket sink is an operator surface, not an auth boundary, so it
-    receives a salted SHA-256 prefix of the key instead of the credential. That is enough to
+    receives a salted keyed FINGERPRINT of the key instead of the credential. That is enough to
     join two tickets from the same account (and, with the same salt, to match an account
     server-side) while a leak of the sink or its logs leaks no usable Vexa credential.
-    The raw key is forwarded to the GATEWAY only, exactly as every other tool does.
+    The raw key is forwarded to the GATEWAY only, exactly as every other tool does. The raw key
+    is never stored, logged, or returned.
+
+    ``blake2b`` keyed with the deployment salt, not a bare SHA-256: this is a keyed fingerprint,
+    not password storage (there is nothing here to verify a secret AGAINST), and the keyed
+    construction is the right primitive for it — a plain digest of a low-entropy input is
+    guessable by whoever holds the salt-free hash.
     """
     salt = os.getenv("VEXA_TICKET_FINGERPRINT_SALT") or _DEFAULT_CALLER_SALT
-    return hashlib.sha256(f"{salt}|{api_key}".encode("utf-8")).hexdigest()[:16]
+    return hashlib.blake2b(
+        api_key.encode("utf-8"),
+        key=salt.encode("utf-8")[:64],   # blake2b keys are capped at 64 bytes
+        digest_size=8,                   # 8 bytes → the same 16 hex chars this has always emitted
+    ).hexdigest()
 
 # Standard bearer-token auth parsing. We treat the token value as the Vexa API key.
 bearer_scheme = HTTPBearer(auto_error=False)

--- a/core/meetings/services/mcp/src/vexa_mcp/link_parser.py
+++ b/core/meetings/services/mcp/src/vexa_mcp/link_parser.py
@@ -33,11 +33,23 @@ _TEAMS_ENTERPRISE_HOSTS = {
 }
 
 
+def _host_is(host: str, domain: str) -> bool:
+    """True when ``host`` IS ``domain`` or a subdomain of it — never a substring test.
+
+    ``"zoom.us" in host`` also accepts ``zoom.us.evil.example`` (the attacker owns the
+    registrable domain) and ``notzoom.us``; ``host.endswith("teams.live.com")`` accepts
+    ``eviltteams.live.com``. CodeQL calls this incomplete URL substring sanitization. The fix is
+    to compare the parsed ``hostname`` exactly, and to allow only an explicit dot-separated
+    subdomain — which is what the legitimate cases are (``us05web.zoom.us``,
+    ``frbmeetings.zoomgov.com``, ``contoso.teams.microsoft.com``)."""
+    return host == domain or host.endswith("." + domain)
+
+
 def _is_teams_enterprise_host(host: str) -> bool:
     return (
         host in _TEAMS_ENTERPRISE_HOSTS
-        or host.endswith(".teams.microsoft.us")
-        or host.endswith(".teams.microsoft.com")
+        or _host_is(host, "teams.microsoft.us")
+        or _host_is(host, "teams.microsoft.com")
     )
 
 
@@ -75,7 +87,7 @@ def parse_meeting_url(meeting_url: str) -> ParseMeetingLinkResponse:
         )
 
     # Teams personal (teams.live.com/meet/<digits>?p=<passcode>)
-    if host.endswith("teams.live.com"):
+    if _host_is(host, "teams.live.com"):
         m = re.match(r"^/meet/(\d{10,15})/?$", path)
         if not m:
             raise HTTPException(status_code=422, detail="Unsupported teams.live.com URL format. Expected /meet/<10-15 digit id>.")
@@ -151,14 +163,16 @@ def parse_meeting_url(meeting_url: str) -> ParseMeetingLinkResponse:
         )
 
     # Zoom Events — not joinable via shareable URL (check before general zoom.us match)
-    if host in {"events.zoom.us", "ev.zoom.com"} or host.endswith(".events.zoom.us"):
+    if host in {"events.zoom.us", "ev.zoom.com"} or _host_is(host, "events.zoom.us"):
         raise HTTPException(
             status_code=422,
             detail="Zoom Events links are not supported. Attendees receive unique per-registrant join links via email; these cannot be shared with a bot.",
         )
 
-    # Zoom: zoom.us (all subdomains) and zoomgov.com
-    if "zoom.us" in host or "zoomgov.com" in host:
+    # Zoom: zoom.us and zoomgov.com, apex or ANY subdomain — vanity tenancies (us02web.zoom.us,
+    # company.zoom.us) and the government cloud (frbmeetings.zoomgov.com) are exactly the
+    # ``*.<domain>`` case, which is why the match is exact-or-dot-suffix and not a substring.
+    if _host_is(host, "zoom.us") or _host_is(host, "zoomgov.com"):
         parts = [p for p in path.split("/") if p]
         native_id = ""
         if len(parts) >= 2 and parts[0] in {"j", "w"}:

--- a/core/meetings/services/mcp/tests/test_parse_meeting_link.py
+++ b/core/meetings/services/mcp/tests/test_parse_meeting_link.py
@@ -150,10 +150,10 @@ class TestTeamsEnterpriseLong:
 
 class TestZoom:
     def test_standard_meeting(self):
-        r = parse("https://zoom.us/j/12345678901?pwd=Abc123")
+        r = parse("https://zoom.us/j/12345678901?pwd=placeholder-passcode")
         assert r.platform == "zoom"
         assert r.native_meeting_id == "12345678901"
-        assert r.passcode == "Abc123"
+        assert r.passcode == "placeholder-passcode"
 
     def test_regional_subdomain(self):
         assert parse("https://us02web.zoom.us/j/12345678901").native_meeting_id == "12345678901"
@@ -186,7 +186,8 @@ class TestZoom:
 
     def test_password_spelling_is_read_as_well_as_pwd(self):
         """A dropped passcode is invisible: the bot sits in a prompt nobody can see."""
-        assert parse("https://zoom.us/j/12345678901?password=Abc123").passcode == "Abc123"
+        r = parse("https://zoom.us/j/12345678901?password=placeholder-passcode")
+        assert r.passcode == "placeholder-passcode"
 
 
 class TestZoomHostedDomains:
@@ -200,21 +201,21 @@ class TestZoomHostedDomains:
 
     #: The exact link that 422'd in production, 2026-09-05.
     LFX = ("https://zoom-lfx.platform.linuxfoundation.org/meeting/96088138284"
-           "?password=6a3b1c2d-4e5f-4a6b-8c9d-0e1f2a3b4c5d")
+           "?password=placeholder-passcode-not-a-secret")
 
     def test_the_linux_foundation_link_that_422d(self):
         r = parse(self.LFX)
         assert r.platform == "zoom"
         assert r.native_meeting_id == "96088138284"
-        assert r.passcode == "6a3b1c2d-4e5f-4a6b-8c9d-0e1f2a3b4c5d"
+        assert r.passcode == "placeholder-passcode-not-a-secret"
 
     def test_the_hosted_read_says_so(self):
         """A host we inferred rather than recognised is reported, the way the jitsi inference is."""
         assert any("path shape" in w for w in parse(self.LFX).warnings)
 
     def test_the_j_path_on_a_hosted_domain(self):
-        r = parse("https://meetings.example.org/j/98765432101?pwd=s3cret")
-        assert (r.platform, r.native_meeting_id, r.passcode) == ("zoom", "98765432101", "s3cret")
+        r = parse("https://meetings.example.org/j/98765432101?pwd=placeholder-pwd")
+        assert (r.platform, r.native_meeting_id, r.passcode) == ("zoom", "98765432101", "placeholder-pwd")
 
     def test_without_a_passcode_it_is_not_claimed(self):
         """THE negative case. A bare numeric path on an unknown host is not a meeting — the
@@ -301,3 +302,56 @@ class TestMisc:
 
     def test_unknown_provider_rejected(self):
         assert_422("https://example.com/meeting/123", "unknown provider")
+
+
+class TestHostnameSpoofing:
+    """A hostname matched by SUBSTRING can be spoofed from both ends, and both ends are cheap:
+    the attacker owns the registrable domain in ``zoom.us.evil.example`` and owns the label in
+    ``notzoom.us``. Either one used to satisfy ``"zoom.us" in host`` /
+    ``host.endswith("teams.live.com")``. The parser now compares the parsed ``hostname``
+    exactly, or as a dot-separated subdomain of a listed host
+    (CodeQL py/incomplete-url-substring-sanitization).
+    """
+
+    def test_zoom_suffix_spoof_is_not_a_recognised_zoom_host(self):
+        # /wc/join is a zoom.us-only path shape: on a host that is not zoom.us it is nothing.
+        assert_422("https://zoom.us.evil.example/wc/join/12345678901", "unknown provider")
+
+    def test_zoom_prefix_spoof_is_not_claimed(self):
+        assert_422("https://notzoom.us/wc/join/12345678901", "unknown provider")
+        assert_422("https://notzoomgov.com/wc/join/12345678901", "unknown provider")
+
+    def test_zoomgov_suffix_spoof_is_not_claimed(self):
+        assert_422("https://zoomgov.com.evil.example/wc/join/12345678901", "unknown provider")
+
+    def test_a_spoofed_host_gets_no_zoom_only_leniency(self):
+        """9-digit ids are accepted on zoom.us because the HOST proves the platform. A spoofed
+        host has proved nothing, so it does not inherit that leniency."""
+        assert_422("https://zoom.us.evil.example/j/123456789?pwd=x", "unknown provider")
+
+    def test_teams_live_suffix_spoof_is_not_claimed(self):
+        assert_422("https://teams.live.com.evil.example/meet/9361792952021?p=x",
+                   "unknown provider")
+
+    def test_teams_live_prefix_spoof_is_not_claimed(self):
+        assert_422("https://eviltteams.live.com/meet/9361792952021?p=x", "unknown provider")
+
+    def test_teams_enterprise_prefix_spoof_is_not_claimed(self):
+        assert_422("https://notteams.microsoft.com/meet/9361792952021?p=x", "unknown provider")
+        assert_422("https://notteams.microsoft.us/meet/9361792952021?p=x", "unknown provider")
+
+    def test_google_meet_suffix_spoof_is_not_google_meet(self):
+        assert parse("https://meet.google.com.evil.example/abc-defg-hij").platform != "google_meet"
+
+    # …and every legitimate host in the same shapes still parses.
+
+    def test_vanity_and_gov_zoom_subdomains_still_parse(self):
+        assert parse("https://us02web.zoom.us/j/12345678901").native_meeting_id == "12345678901"
+        assert parse("https://zoom.us/j/12345678901").native_meeting_id == "12345678901"
+        assert parse("https://frbmeetings.zoomgov.com/j/12345678901").native_meeting_id == "12345678901"
+        assert parse("https://zoomgov.com/j/12345678901").native_meeting_id == "12345678901"
+
+    def test_teams_hosts_still_parse(self):
+        assert parse("https://teams.live.com/meet/9361792952021?p=x").platform == "teams"
+        assert parse("https://gov.teams.microsoft.us/meet/12345678901234").platform == "teams"
+        assert parse("https://contoso.teams.microsoft.com/meet/12345678901234").platform == "teams"

--- a/core/meetings/services/meeting-api/src/meeting_api/collector/meeting_link.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/collector/meeting_link.py
@@ -25,7 +25,12 @@ from urllib.parse import unquote, urlparse
 
 _GMEET_ID = re.compile(r"^[a-z]{3}-[a-z]{4}-[a-z]{3}$")
 _ZOOM_ID = re.compile(r"\d{9,11}")
-_TEAMS_THREAD = re.compile(r"19:meeting_[^@%\s/]+@thread\.v2", re.IGNORECASE)
+# The repeat is BOUNDED on purpose. Unbounded (`[^@%\s/]+@thread\.v2`) this pattern is scanned
+# with `.search()` over caller-supplied text, so every start offset that fails at `@thread.v2`
+# is retried at the next one — quadratic in the input length on a string an attacker chooses
+# (CodeQL py/polynomial-redos). A Teams thread id is a fixed-shape base64ish blob well under
+# 256 characters, so the cap costs nothing and makes the scan linear-bounded.
+_TEAMS_THREAD = re.compile(r"19:meeting_[^@%\s/]{1,256}@thread\.v2", re.IGNORECASE)
 _TEAMS_SHORT = re.compile(r"/meet/([^/?#]+)", re.IGNORECASE)
 # A Jitsi room is the URL path's single segment; permissive by design (jitsi accepts nearly any
 # room string) but excludes separators/whitespace so a mangled URL never yields a bogus room.
@@ -33,6 +38,17 @@ _JITSI_ROOM = re.compile(r"^[^/?#\s]+$")
 # Zoom's own two join paths, on a host that does not say "zoom" — see the hosted-domain branch in
 # ``parse_meeting_url``. Anchored and digit-exact so nothing else can match it.
 _ZOOM_HOSTED_PATH = re.compile(r"^/(?:meeting|j)/(\d{10,11})/?$", re.IGNORECASE)
+
+
+def _host_is(host: str, domain: str) -> bool:
+    """True when ``host`` IS ``domain`` or a subdomain of it — never a substring test.
+
+    ``"teams.live.com" in host`` also accepts ``teams.live.com.evil.example`` (the attacker owns
+    the registrable domain) and ``evil-teams.live.com``; the same hole exists for every hostname
+    checked with ``in`` or a bare ``endswith``. CodeQL calls it incomplete URL substring
+    sanitization, and the fix is to compare the parsed ``hostname`` exactly, allowing only an
+    explicit dot-separated subdomain."""
+    return host == domain or host.endswith("." + domain)
 
 
 def _has_passcode_param(query: str) -> bool:
@@ -75,13 +91,19 @@ def parse_meeting_url(raw: str, *, generic_hosts: bool = True) -> Optional[tuple
     parsed = urlparse(value)
     host = (parsed.hostname or "").lower()
     if host:
-        if "meet.google.com" in host:
+        if _host_is(host, "meet.google.com"):
             code = next((p for p in reversed(parsed.path.split("/")) if p), "").lower()
             return ("google_meet", code) if _GMEET_ID.match(code) else None
+        # Deliberately a NAME heuristic, not a domain allowlist: it is what claims a vanity or
+        # hosted Zoom front door whose hostname still says "zoom" (zoom-lfx.platform.
+        # linuxfoundation.org), including in the ICS free-text scan where the path-shape branch
+        # below is switched off. It is not a trust decision — the only thing taken from the URL
+        # is a 9-11 digit meeting id — so it is not the substring-sanitization defect that the
+        # exact-host checks around it fix.
         if "zoom" in host:
             m = _ZOOM_ID.search(parsed.path) or _ZOOM_ID.search(parsed.query)
             return ("zoom", m.group(0)) if m else None
-        if "teams.microsoft.com" in host or "teams.live.com" in host:
+        if _host_is(host, "teams.microsoft.com") or _host_is(host, "teams.live.com"):
             # Classic deep link carries the thread id (…/l/meetup-join/19:meeting_…@thread.v2).
             thread = _TEAMS_THREAD.search(unquote(value))
             if thread:

--- a/core/meetings/services/meeting-api/tests/test_meeting_link.py
+++ b/core/meetings/services/meeting-api/tests/test_meeting_link.py
@@ -120,13 +120,13 @@ class TestParseZoomHostedDomain:
     """
 
     LFX = ("https://zoom-lfx.platform.linuxfoundation.org/meeting/96088138284"
-           "?password=6a3b1c2d-4e5f-4a6b-8c9d-0e1f2a3b4c5d")
+           "?password=placeholder-passcode-not-a-secret")
 
     def test_the_linux_foundation_link(self):
         assert parse_meeting_url(self.LFX) == ("zoom", "96088138284")
 
     def test_a_host_that_does_not_say_zoom_at_all(self):
-        assert parse_meeting_url("https://meetings.example.org/j/98765432101?pwd=s3cret") == (
+        assert parse_meeting_url("https://meetings.example.org/j/98765432101?pwd=placeholder-pwd") == (
             "zoom", "98765432101",
         )
 
@@ -140,7 +140,7 @@ class TestParseZoomHostedDomain:
     def test_the_ics_free_text_scan_does_not_infer_it(self):
         """``generic_hosts=False`` exists so a calendar description full of arbitrary links does
         not import one as a meeting; a hostname-free inference is exactly what it excludes."""
-        hostname_free = "https://meetings.example.org/j/98765432101?pwd=s3cret"
+        hostname_free = "https://meetings.example.org/j/98765432101?pwd=placeholder-pwd"
         assert parse_meeting_url(hostname_free, generic_hosts=False) is None
         assert find_meeting_link(f"join here {hostname_free} thanks") is None
         # The LFX host is a different case and is unaffected: it literally contains "zoom", so the
@@ -152,3 +152,70 @@ class TestParseZoomHostedDomain:
     def test_a_declared_jitsi_host_is_not_overruled(self, monkeypatch):
         monkeypatch.setenv("VEXA_JITSI_HOSTS", "video.corp.example")
         assert parse_meeting_url("https://video.corp.example/j/12345678901?pwd=x") is None
+
+
+class TestHostnameSpoofing:
+    """A hostname matched by SUBSTRING can be spoofed from both ends, and both ends are cheap:
+    the attacker owns the registrable domain in ``teams.live.com.evil.example`` and owns the
+    label in ``evilteams.live.com``. Either one used to satisfy ``"teams.live.com" in host``.
+    The parser now compares the parsed ``hostname`` exactly, or as a dot-separated subdomain of
+    a listed host (CodeQL py/incomplete-url-substring-sanitization).
+
+    The assertion that matters is that the spoof is not answered with the REAL platform — a
+    caller acting on ``("teams", <id>)`` sends a bot to Microsoft on an attacker's say-so.
+    """
+
+    def test_google_meet_suffix_spoof_is_not_google_meet(self):
+        # Falls through to the pasted-link jitsi naming heuristic (the host does carry a "meet"
+        # label), which is honest about what it is — what it must never do is claim google_meet.
+        got = parse_meeting_url("https://meet.google.com.evil.example/abc-defg-hij")
+        assert got != ("google_meet", "abc-defg-hij")
+        assert got is None or got[0] == "jitsi"
+
+    def test_google_meet_in_the_path_is_not_google_meet(self):
+        assert parse_meeting_url("https://evil.example/meet.google.com/abc-defg-hij") is None
+
+    def test_teams_suffix_spoof_is_not_claimed(self):
+        assert parse_meeting_url(
+            "https://teams.live.com.evil.example/l/meetup-join/19:meeting_AbCd@thread.v2"
+        ) is None
+        assert parse_meeting_url(
+            "https://teams.microsoft.com.evil.example/meet/9361792952021?p=x"
+        ) is None
+
+    def test_teams_prefix_spoof_is_not_claimed(self):
+        assert parse_meeting_url("https://eviltteams.live.com/meet/9361792952021?p=x") is None
+        assert parse_meeting_url("https://notteams.microsoft.com/meet/9361792952021?p=x") is None
+
+    def test_real_teams_subdomains_still_parse(self):
+        assert parse_meeting_url("https://teams.live.com/meet/9361792952021?p=abc") == (
+            "teams", "9361792952021",
+        )
+        assert parse_meeting_url("https://eu.teams.microsoft.com/meet/9361792952021?p=abc") == (
+            "teams", "9361792952021",
+        )
+
+    def test_google_meet_itself_still_parses(self):
+        assert parse_meeting_url("https://meet.google.com/abc-defg-hij") == (
+            "google_meet", "abc-defg-hij",
+        )
+
+
+class TestTeamsThreadIdIsBounded:
+    """The thread-id scan runs ``.search()`` over caller-supplied text, so the repeat is bounded
+    (CodeQL py/polynomial-redos). The bound is far above any real id; what it removes is the
+    quadratic retry an attacker-chosen string would otherwise buy."""
+
+    def test_a_realistic_thread_id_parses(self):
+        thread = "19:meeting_" + "M" * 90 + "@thread.v2"
+        assert parse_meeting_url(f"https://teams.microsoft.com/l/meetup-join/{thread}") == (
+            "teams", thread,
+        )
+
+    def test_an_adversarial_string_terminates(self):
+        import time
+
+        payload = "19:meeting_" + "a" * 40000
+        start = time.monotonic()
+        assert parse_meeting_url(f"https://teams.microsoft.com/l/meetup-join/{payload}") is None
+        assert time.monotonic() - start < 2.0

--- a/docs/changelog.d/1553-link-parse-exact-hosts.md
+++ b/docs/changelog.d/1553-link-parse-exact-hosts.md
@@ -1,0 +1,7 @@
+- **Meeting links are matched on the exact hostname (#1553).** `parse_meeting_link` and the
+  pasted-link/calendar parser used to decide the platform with a substring test, so
+  `teams.live.com.evil.example` and `notzoom.us` were read as Teams and Zoom. They now match the
+  hostname exactly, or as an explicit subdomain — vanity and government tenancies
+  (`us02web.zoom.us`, `company.zoom.us`, `frbmeetings.zoomgov.com`, `contoso.teams.microsoft.com`)
+  are unaffected, and a look-alike hostname is refused instead of sending a bot somewhere on its
+  say-so. See [MCP tools](/mcp).

--- a/scripts/gates.mjs
+++ b/scripts/gates.mjs
@@ -9,7 +9,13 @@
  */
 import { readdirSync, existsSync, readFileSync, writeFileSync, statSync } from "node:fs";
 import { join } from "node:path";
-import { execSync } from "node:child_process";
+import { execSync, execFileSync } from "node:child_process";
+// execFileSync, not execSync, wherever a command carries a PATH we computed (ROOT is
+// process.cwd(), so every such path is an environment value): an argv array is handed to
+// execve directly, so there is no shell to reinterpret a space, a quote or a `;` in the
+// checkout path (CodeQL js/shell-command-injection-from-environment). The remaining execSync
+// calls are either constant command strings or genuine shell pipelines (grep … | grep -v …
+// || true), which need a shell by construction.
 import { createHash } from "node:crypto";
 
 const ROOT = process.cwd();
@@ -77,7 +83,7 @@ function findFile(dir, re) {
 // a Python service that stands up a FastAPI app (→ must answer gate:health). A worker carve
 // (agent-api: spawned by the runtime, liveness = workload lifecycle) builds no app → exempt.
 const hasFastApiApp = (d) => existsSync(join(d, "src")) && findFile(join(d, "src"), /\.py$/) &&
-  (() => { try { execSync(`grep -rql "FastAPI(" ${JSON.stringify(join(d, "src"))}`, { stdio: "pipe" }); return true; } catch { return false; } })();
+  (() => { try { execFileSync("grep", ["-rql", "FastAPI(", join(d, "src")], { stdio: "pipe" }); return true; } catch { return false; } })();
 const pyPackages = () => walkDirs().filter((d) => existsSync(join(d, "pyproject.toml")) && existsSync(join(d, "tests")));
 
 // a published contract is a `<domain>/contracts/X.vN` dir carrying JSON Schema file(s)
@@ -149,7 +155,7 @@ function gateIsolation() {
     .map((d) => [d, join(d, "scripts", "check-isolation.js")])
     .filter(([, s]) => existsSync(s));
   for (const [d, s] of found) {
-    try { execSync(`node ${JSON.stringify(s)}`, { stdio: "pipe" }); }
+    try { execFileSync("node", [s], { stdio: "pipe" }); }
     catch (e) { return fail([`isolation failed in ${rel(d)}: ${errText(e).slice(0, 300)}`]); }
   }
   console.log(`  ✓ gate:isolation — ${found.length} brick(s) checked`);
@@ -161,7 +167,7 @@ function gateGraph() {
   if (!packageDirs().length) { console.log("  ✓ gate:graph — no packages yet (green-on-empty)"); return true; }
   const targets = ["core", "integrations", "clients", "sdks", "schemas", "tools"]
     .filter((d) => existsSync(join(ROOT, d)));
-  try { execSync(`npx depcruise --config .dependency-cruiser.cjs --no-progress ${targets.join(" ")}`, { stdio: "pipe" }); }
+  try { execFileSync("npx", ["depcruise", "--config", ".dependency-cruiser.cjs", "--no-progress", ...targets], { stdio: "pipe" }); }
   catch (e) { return fail([`dependency-cruiser:\n${errText(e)}`]); }
   console.log("  ✓ gate:graph — acyclic + allowed-edges");
   return true;
@@ -174,7 +180,7 @@ function gateGraph() {
 // edges). A forbidden cross-package import → RED, with the file path. Green-on-empty.
 function gateIsolationPy() {
   const s = join(ROOT, "scripts", "check-isolation-py.mjs");
-  try { execSync(`node ${JSON.stringify(s)} --mode=isolation`, { stdio: "pipe" }); }
+  try { execFileSync("node", [s, "--mode=isolation"], { stdio: "pipe" }); }
   catch (e) { return fail([`python isolation:\n${errText(e).slice(0, 1200)}`]); }
   console.log("  ✓ gate:isolation-py — every Python sibling import is own-module, declared, or an allowed edge");
   return true;
@@ -187,7 +193,7 @@ function gateIsolationPy() {
 // with isolation-py (DRY). Green-on-empty.
 function gateGraphPy() {
   const s = join(ROOT, "scripts", "check-isolation-py.mjs");
-  try { execSync(`node ${JSON.stringify(s)} --mode=graph`, { stdio: "pipe" }); }
+  try { execFileSync("node", [s, "--mode=graph"], { stdio: "pipe" }); }
   catch (e) { return fail([`python graph:\n${errText(e).slice(0, 1200)}`]); }
   console.log("  ✓ gate:graph-py — Python cross-package edges acyclic + allow-listed");
   return true;
@@ -200,7 +206,7 @@ function gateGraphPy() {
 // Green-on-empty.
 function gateTestIsolation() {
   const s = join(ROOT, "scripts", "check-isolation-py.mjs");
-  try { execSync(`node ${JSON.stringify(s)} --mode=test-isolation`, { stdio: "pipe" }); }
+  try { execFileSync("node", [s, "--mode=test-isolation"], { stdio: "pipe" }); }
   catch (e) { return fail([`python test-isolation:\n${errText(e).slice(0, 1200)}`]); }
   console.log("  ✓ gate:test-isolation — no Python test imports a sibling module's internals (test lane gated, P2)");
   return true;
@@ -213,7 +219,7 @@ function gateTestIsolation() {
 function gateArchReport() {
   const s = join(ROOT, "scripts", "arch-report.mjs");
   if (!existsSync(s)) { console.log("  ✓ gate:arch-report — no report generator yet (green-on-empty)"); return true; }
-  try { execSync(`node ${JSON.stringify(s)} --check`, { stdio: "pipe" }); }
+  try { execFileSync("node", [s, "--check"], { stdio: "pipe" }); }
   catch (e) { return fail([`arch-report:\n${errText(e).slice(0, 900)}`]); }
   console.log("  ✓ gate:arch-report — every modularity principle maps to a green gate (P9)");
   return true;
@@ -247,7 +253,7 @@ function gateSchema() {
   );
   if (!contracts.length) { console.log("  ✓ gate:schema — no contracts yet (green-on-empty)"); return true; }
   for (const d of contracts) {
-    try { execSync(`node ${JSON.stringify(join(d, "validate.mjs"))} --check`, { stdio: "pipe" }); }
+    try { execFileSync("node", [join(d, "validate.mjs"), "--check"], { stdio: "pipe" }); }
     catch (e) { return fail([`schema ${rel(d)}:\n${errText(e)}`]); }
   }
   console.log(`  ✓ gate:schema — ${contracts.length} contract(s) conform (goldens ≡ schema)`);
@@ -339,7 +345,7 @@ function gateCompose() {
   try { execSync("docker info", { stdio: "pipe" }); }
   catch { console.log("  ✓ gate:compose — docker not available → skip (green-or-skip)"); return true; }
   if (!existsSync(runner)) return fail([`gate:compose — compose stack present but no readiness proof (deploy/compose/bin/stack-test missing)`]);
-  try { execSync(`bash ${JSON.stringify(runner)}`, { stdio: "pipe", env: { ...process.env, COMPOSE_DYNAMIC_PORTS: process.env.COMPOSE_DYNAMIC_PORTS || "1" } }); }
+  try { execFileSync("bash", [runner], { stdio: "pipe", env: { ...process.env, COMPOSE_DYNAMIC_PORTS: process.env.COMPOSE_DYNAMIC_PORTS || "1" } }); }
   catch (e) { return fail([`compose stack-readiness proof:\n${errText(e).slice(-3000)}`]); }
   console.log("  ✓ gate:compose — REAL compose stack proven bot-ready (health·auth·transcript·recording·control-plane)");
   return true;
@@ -393,7 +399,7 @@ function gateEvalBaseline() {
   const baseline = join(ROOT, "core", "meetings", "eval", "BASELINE.md");
   if (!existsSync(verify)) { console.log("  ✓ gate:eval-baseline — no worker-eval harness yet (green-on-empty)"); return true; }
   if (!existsSync(baseline)) return fail(["gate:eval-baseline — core/meetings/eval/BASELINE.md (recorded L4 ground truth) missing"]);
-  try { execSync(`bash ${JSON.stringify(verify)}`, { cwd: ROOT, stdio: "pipe" }); }
+  try { execFileSync("bash", [verify], { cwd: ROOT, stdio: "pipe" }); }
   catch (e) { return fail([`eval-baseline oracle self-test:\n${errText(e).slice(-1500)}`]); }
   console.log("  ✓ gate:eval-baseline — worker-L4 eval oracle self-test passes + BASELINE.md recorded (reusable instrument; live score is B:V1)");
   return true;
@@ -786,7 +792,7 @@ function gateExecutionEnv() {
   if (!existsSync(example)) return fail(["gate:execution-env — committed template deploy/execution-targets.example.json missing"]);
   const real = join(ROOT, "deploy", "execution-targets.json");
   const files = [example, ...(existsSync(real) ? [real] : [])];
-  try { execSync(`node ${JSON.stringify(v)} ${files.map((f) => `--file ${JSON.stringify(f)}`).join(" ")}`, { stdio: "pipe" }); }
+  try { execFileSync("node", [v, ...files.flatMap((f) => ["--file", f])], { stdio: "pipe" }); }
   catch (e) { return fail([`execution-env registry:\n${errText(e).slice(-1500)}`]); }
   console.log(`  ✓ gate:execution-env — ${files.length} registry file(s) conform to execution-targets.v1${existsSync(real) ? "" : " (template only — real registry gitignored/absent)"}`);
   return true;
@@ -1152,7 +1158,7 @@ function gateConfigContract() {
     const declPath = join(ROOT, svc.decl);
     if (!existsSync(declPath)) { errs.push(`${svc.service}: declaration missing (${svc.decl})`); continue; }
     // 1. schema conformance (the contract's own validator — same oracle as gate:schema)
-    try { execSync(`node ${JSON.stringify(join(CONFIG_CONTRACT_DIR, "validate.mjs"))} --check --file ${JSON.stringify(declPath)}`, { stdio: "pipe" }); }
+    try { execFileSync("node", [join(CONFIG_CONTRACT_DIR, "validate.mjs"), "--check", "--file", declPath], { stdio: "pipe" }); }
     catch (e) { errs.push(`${svc.service}: declaration does not conform:\n${errText(e).slice(-800)}`); continue; }
     // 2. the vendored preflight is the canonical one, byte for byte
     if (!existsSync(join(ROOT, svc.preflight)) || readFileSync(join(ROOT, svc.preflight), "utf8") !== canonical)


### PR DESCRIPTION
Car 7 of the v0.12.27 candidate: the CodeQL and GitGuardian findings on the train PR #1559. Code fixed, nothing suppressed.

## CodeQL — high

- **Incomplete URL substring sanitization** (`link_parser.py:78,:161`, `collector/meeting_link.py:78,:84`). The platform was decided by a substring test on the hostname, so `teams.live.com.evil.example` (attacker owns the registrable domain) and `notzoom.us` / `eviltteams.live.com` (attacker owns the label) both passed. Both parsers now compare the parsed `hostname` exactly, or as an explicit dot-separated subdomain, via a shared `_host_is` helper. #1547's Zoom behaviour is preserved by construction: vanity `*.zoom.us`, `frbmeetings.zoomgov.com`, `contoso.teams.microsoft.com` and `gov./dod.teams.microsoft.us` are exactly the subdomain case, and the hosted-domain branch (path shape + passcode, hostname deliberately ignored) is untouched.
- **One substring test is deliberately kept**, now with a comment saying why: meeting-api's `"zoom" in host`. It is a name heuristic, not a domain allowlist — it is what claims a hosted Zoom front door whose hostname still says zoom (`zoom-lfx.platform.linuxfoundation.org`), including in the ICS free-text scan where the path-shape branch is switched off; an existing test pins that. It takes nothing from the URL but a 9-11 digit meeting id.
- **Polynomial regex on uncontrolled data** (`meeting_link.py:86`). `19:meeting_[^@%\s/]+@thread\.v2` is `.search()`ed over caller-supplied text, so every start offset that fails at `@thread.v2` is retried at the next — quadratic on a chosen string. The repeat is bounded to `{1,256}`, far above any real thread id. A test asserts a 40 000-char adversarial payload returns `None` in well under a second, and that a 90-char realistic id still parses.
- **SHA256 on sensitive data** (`mcp/app.py:220`). Read it: `caller_fingerprint` is a pseudonymous handle for the ticket sink, not password storage — the raw key never goes to the sink at all. Now `blake2b(api_key, key=salt, digest_size=8)`: same 16 hex chars, same stability per key, same salt env var, keyed rather than a bare digest of a low-entropy input. README's two "salted SHA-256 prefix" lines updated. No suppression used.
- **`tempfile.mktemp`** (`core/flows/tests/test_storm.py:158`) → `mkstemp`, fd closed immediately because sqlite opens the path itself.
- **11 `scripts/gates.mjs` "shell command built from environment values"** (warnings, non-blocking). Twelve call sites move from `execSync(\`node ${JSON.stringify(path)}\`)` to `execFileSync(cmd, [argv])` — no shell, so a checkout path with a space or a `;` cannot be reinterpreted. The remaining `execSync` calls are left deliberately and the import comment says so: constant command strings (`uv run pytest -q`, `docker info`) or genuine shell pipelines (`grep … | grep -v … || true`).

## GitGuardian — Generic Password (false positives from `19984807f`)

Test fixtures only. The UUID-shaped passcode, `pwd=s3cret` and `password=Abc123` are now `placeholder-*` values that exercise the parser identically. The repo has no `gitguardian:ignore` convention (`git grep gitguardian` is empty), so the placeholder is the whole fix — no new comment convention invented.

## Also swept

`git grep -nE '"[a-z.]+\.(com|us)" in '` over the MCP service and `collector/meeting_link.py` — every hit is fixed or explained above; `events.zoom.us` and the `*.teams.microsoft.{com,us}` checks were already dot-anchored and now go through the same helper.

## Tests

13 new spoof/preservation cases across the two parser suites (suffix spoof, prefix spoof, domain name carried in the path, and every legitimate host in the same shapes), plus the bounded-scan pair.

```
$ cd core/meetings/services/mcp && uv run pytest -q
345 passed, 2 warnings in 31.38s

$ cd core/meetings/services/meeting-api && uv run pytest -q tests/test_meeting_link.py
31 passed in 0.38s

$ cd core/meetings/services/meeting-api && uv run pytest -q tests/ -k "link or zoom or teams or meet"
272 passed, 1120 deselected, 1 warning in 7.27s

$ cd core/flows && python -m pytest tests/test_storm.py -q
2 passed in 0.31s

$ node --test scripts/*.test.mjs
ℹ tests 108
ℹ pass 108
ℹ fail 0
```

Static gates run on the branch after `pnpm install` in the worktree: `gate:schema` (26 contracts), `gate:config-contract` (7 services, 267 keys), `gate:isolation`, `gate:graph` — all green, and the pre-push gate passed on its own.

Car 4's files (`meeting_api/{events.py,app.py,service_authority/,bot_spawn/,collector/app.py,collector/adapters.py}`, `core/identity/**`) were not touched.

Refs #1553

COMMITMENTS IN THIS DRAFT — none.

<!-- vexa-agent -->
