### PR TITLE
car 13: docs-current gate — raise the API read buffer (ENOBUFS on the 272-file train)

### DIFF
--- a/scripts/docs-current-gate.mjs
+++ b/scripts/docs-current-gate.mjs
@@ -22,7 +22,7 @@ const isSurface = (p) => SURFACE_FILES.includes(p) || SURFACE_PREFIXES.some((pre
 const isDocs = (p) => p.startsWith("docs/") || p.endsWith(".mdx");
 const NONE_LABEL = "docs: none";
 
-function ghRaw(path) { let e; for (let i = 0; i < 3; i++) { try { return execSync(`gh api "${path}"`, { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] }); } catch (x) { e = x; } } throw e; }
+function ghRaw(path) { let e; for (let i = 0; i < 3; i++) { try { return execSync(`gh api "${path}"`, { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"], maxBuffer: 256 * 1024 * 1024 }); } catch (x) { e = x; } } throw e; }
 const ghj = (path) => JSON.parse(ghRaw(path));
 
 function prNumbers() {


### PR DESCRIPTION
Rides `release/0.12.27-candidate` for the v0.12.27 train (#1553, train PR #1559).

`scripts/docs-current-gate.mjs` reads `pulls/<n>/files` through `execSync` with the 1 MB default buffer. Each entry carries its patch, so the 272-file train overflows it (`spawnSync /bin/sh ENOBUFS`) and the gate reports "need a docs decision" for a PR that changes `docs/**`. It passed on the same head while #1559 was a draft only because the gate skips drafts. One option added: `maxBuffer: 256 MB`. No logic change; repo-only lane.

COMMITMENTS IN THIS DRAFT — none.
<!-- vexa-agent -->