### PR TITLE
docs-current gate: raise the API read buffer so a large train evaluates

### DIFF
--- a/scripts/docs-current-gate.mjs
+++ b/scripts/docs-current-gate.mjs
@@ -22,7 +22,7 @@ const isSurface = (p) => SURFACE_FILES.includes(p) || SURFACE_PREFIXES.some((pre
 const isDocs = (p) => p.startsWith("docs/") || p.endsWith(".mdx");
 const NONE_LABEL = "docs: none";
 
-function ghRaw(path) { let e; for (let i = 0; i < 3; i++) { try { return execSync(`gh api "${path}"`, { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] }); } catch (x) { e = x; } } throw e; }
+function ghRaw(path) { let e; for (let i = 0; i < 3; i++) { try { return execSync(`gh api "${path}"`, { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"], maxBuffer: 256 * 1024 * 1024 }); } catch (x) { e = x; } } throw e; }
 const ghj = (path) => JSON.parse(ghRaw(path));
 
 function prNumbers() {


### PR DESCRIPTION
`scripts/docs-current-gate.mjs` reads `pulls/<n>/files` through `execSync` with the 1 MB default buffer. Each entry carries its patch, so a large PR overflows it (`spawnSync /bin/sh ENOBUFS`) and the gate reports "need a docs decision" for a PR that changes `docs/**`. Seen on the v0.12.27 train #1559 (272 files): passed while draft only because the gate skips drafts; failed identically on every run once undrafted, including a rerun.

The workflow checks the gate code out from `main`, so the fix has to land here first; the train carries the same line as car 13 (#1569) so the two trees agree.

One option added: `maxBuffer: 256 MB`. No logic change. Repo-only lane; no product surface.

COMMITMENTS IN THIS DRAFT — none.
<!-- vexa-agent -->

## Contribution rights
<!-- Select exactly ONE. This is a legal certification: an agent may explain the choices but
     must not select one for you. See CONTRIBUTOR_RIGHTS.md. -->

- [x] **Independent:** I created this contribution, or otherwise have the right to submit it
  under Apache-2.0, and it is not owned or controlled by an employer, client, or other entity.
  <!-- rights:independent -->
- [ ] **Employer/client authorization required:** an employer, client, or other entity owns or
  may control this contribution. I am requesting Vexa's private corporate-authorization process.
  <!-- rights:corporate -->
- [ ] **Unsure:** I need a private rights review before merge.
  <!-- rights:uncertain -->
