### PR TITLE
release-images: build the gateway from the repository root, as its Dockerfile requires

### DIFF
--- a/release/candidate-image-map.mjs
+++ b/release/candidate-image-map.mjs
@@ -56,7 +56,12 @@ export const RUNTIME_INPUTS_BY_IMAGE = {
     "core/runtime/contracts/schedule.v1/schedule.schema.json",
   ],
   "vexaai/v012-gateway": [
+    ".dockerignore",
     "core/gateway/services/gateway",
+    "core/meetings/routes.v1.json",
+    "core/meetings/services/mcp/routes.v1.json",
+    "core/identity/routes.v1.json",
+    "core/agent/routes.v1.json",
   ],
   "vexaai/v012-mcp": [
     "core/meetings/services/mcp",
@@ -122,7 +127,7 @@ export const BUILD_MATRIX_BY_IMAGE = {
   "vexaai/v012-gateway": {
     name: "gateway",
     repository: "v012-gateway",
-    context: "core/gateway/services/gateway",
+    context: ".",
     dockerfile: "core/gateway/services/gateway/Dockerfile",
   },
   "vexaai/v012-mcp": {

--- a/release/candidate-image-map.test.mjs
+++ b/release/candidate-image-map.test.mjs
@@ -208,6 +208,7 @@ test("a root .dockerignore-only change invalidates every affected candidate", (t
     "vexaai/v012-agent-worker: .dockerignore",
     "vexaai/v012-agent-api: .dockerignore",
     "vexaai/v012-meeting-api: .dockerignore",
+    "vexaai/v012-gateway: .dockerignore",
     "vexaai/vexa-bot: .dockerignore",
   ]);
 });


### PR DESCRIPTION
Part of Vexa-ai/vexa#1553 (release train v0.12.27). Blocks the rc packet: [run 33981148748](https://github.com/Vexa-ai/vexa/actions/runs/33981148748) on `v0.12.27-rc.1`, job `build gateway`, fails on the first COPY (`"/core/agent/routes.v1.json": not found`).

The gateway Dockerfile builds from the repository root since the edge stopped owning its route table: it COPYs the service's `pyproject.toml`, `uv.lock` and `src` by repo-relative path plus the five `routes.v1.json` manifests of the domains it fronts. `deploy/compose` already builds it with `context: ../..`. `release/candidate-image-map.mjs` still handed the release build the service directory as context.

- `context` for `vexaai/v012-gateway` → `.`
- its declared runtime inputs gain `.dockerignore` and the four out-of-tree manifests, so a change to any of them invalidates the candidate map
- the drift test now lists the gateway among the root-context images

48 tests pass (`release/*.test.mjs`, `scripts/registry-candidate-validate.test.mjs`). After merge: tag `v0.12.27-rc.2` on the resulting commit; `rc.1` stays as the partial attempt.

COMMITMENTS IN THIS DRAFT — none.
<!-- vexa-agent -->

## Contribution rights
<!-- Select exactly ONE. This is a legal certification: an agent may explain the choices but
     must not select one for you. See CONTRIBUTOR_RIGHTS.md. -->

- [x] **Independent:** I created this contribution, or otherwise have the right to submit it
  under Apache-2.0, and it is not owned or controlled by an employer, client, or other entity.
  <!-- rights:independent -->
- [ ] **Employer/client authorization required:** an employer, client, or other entity owns or
  may control this contribution. I am requesting Vexa's private corporate-authorization process.
  <!-- rights:corporate -->
- [ ] **Unsure:** I need a private rights review before merge.
  <!-- rights:uncertain -->