### PR TITLE
docs: no hosted pricing copy in the OSS docs tree

### DIFF
--- a/docs/docs/api/meetings.mdx
+++ b/docs/docs/api/meetings.mdx
@@ -21,7 +21,7 @@ Every request carries your key:
 ```
 
 **Don't have a key yet?** Hosted: sign in at [vexa.ai/signin](https://vexa.ai/signin) with a Google
-account and copy your key from [your account page](https://vexa.ai/account) — free credit, no card
+account and copy your key from [your account page](https://vexa.ai/account)
 required. Self-hosted: `make all` prints a key when the stack comes up.
 
 ## Platforms

--- a/docs/docs/authentication.mdx
+++ b/docs/docs/authentication.mdx
@@ -21,7 +21,7 @@ derives it from the key.
 ## Getting a key
 
 **Don't have a key yet?** Hosted: sign in at [vexa.ai/signin](https://vexa.ai/signin) with a Google
-account and copy your key from [your account page](https://vexa.ai/account) — free credit, no card
+account and copy your key from [your account page](https://vexa.ai/account)
 required. Self-hosted: `make all` prints a key when the stack comes up.
 
 `make all` mints a key as part of bring-up and **prints it** (along with the service URLs) when the

--- a/docs/docs/comparison.mdx
+++ b/docs/docs/comparison.mdx
@@ -102,7 +102,7 @@ ignore it. See [Configuration](/configuration#transcription-stt).
   [agent layer](/core/agents) that compounds those transcripts into a knowledge base your team owns.
 
 **Don't have a key yet?** Hosted: sign in at [vexa.ai/signin](https://vexa.ai/signin) with a Google
-account and copy your key from [your account page](https://vexa.ai/account) — free credit, no card
+account and copy your key from [your account page](https://vexa.ai/account)
 required. Self-hosted: `make all` prints a key when the stack comes up.
 
 The deeper positioning discussion — why capture sits upstream of every "chat with your docs" tool —

--- a/docs/docs/concepts.mdx
+++ b/docs/docs/concepts.mdx
@@ -9,7 +9,7 @@ Everything in Vexa composes from a handful of primitives. A unit of work — a *
 from [meetings](#meeting) and docs.
 
 **Don't have a key yet?** Hosted: sign in at [vexa.ai/signin](https://vexa.ai/signin) with a Google
-account and copy your key from [your account page](https://vexa.ai/account) — free credit, no card
+account and copy your key from [your account page](https://vexa.ai/account)
 required. Self-hosted: `make all` prints a key when the stack comes up.
 
 ## Workspace

--- a/docs/docs/core/meetings.mdx
+++ b/docs/docs/core/meetings.mdx
@@ -19,7 +19,7 @@ on — but that is a composition, not a dependency: meetings stands alone. How t
 `transcript.v1` → agent bridge) lives in one place: [Modules & seams](/architecture/modules).
 
 **Don't have a key yet?** Hosted: sign in at [vexa.ai/signin](https://vexa.ai/signin) with a Google
-account and copy your key from [your account page](https://vexa.ai/account) — free credit, no card
+account and copy your key from [your account page](https://vexa.ai/account)
 required. Self-hosted: `make all` prints a key when the stack comes up.
 
 ## The lifecycle — one meeting, one row

--- a/docs/docs/deployment-kubernetes.mdx
+++ b/docs/docs/deployment-kubernetes.mdx
@@ -36,7 +36,7 @@ helm install vexa deploy/helm/charts/vexa -f deploy/helm/charts/vexa/values.yaml
 (`helm lint` + template tests) live under `deploy/helm/tests/`.
 
 **Don't have a key yet?** Hosted: sign in at [vexa.ai/signin](https://vexa.ai/signin) with a Google
-account and copy your key from [your account page](https://vexa.ai/account) — free credit, no card
+account and copy your key from [your account page](https://vexa.ai/account)
 required. Self-hosted: `make all` prints a key when the stack comes up.
 
 ### Is this install actually working? — `make probe SURFACE=helm`

--- a/docs/docs/deployment-lite.mdx
+++ b/docs/docs/deployment-lite.mdx
@@ -33,7 +33,7 @@ keys — and hands them to the terminal, so `http://localhost:3001` opens signed
 `VEXA_API_KEY` in `.env` to bring your own key and skip the minting.
 
 **Don't have a key yet?** Hosted: sign in at [vexa.ai/signin](https://vexa.ai/signin) with a Google
-account and copy your key from [your account page](https://vexa.ai/account) — free credit, no card
+account and copy your key from [your account page](https://vexa.ai/account)
 required. Self-hosted: `make all` prints a key when the stack comes up.
 
 Transcription needs a backend: point `TRANSCRIPTION_SERVICE_URL` / `TRANSCRIPTION_SERVICE_TOKEN`

--- a/docs/docs/deployment.mdx
+++ b/docs/docs/deployment.mdx
@@ -39,7 +39,7 @@ a GPU so the audio path never calls out. The API is then at `http://localhost:18
 terminal web workbench at `http://localhost:13000`.
 
 **Don't have a key yet?** Hosted: sign in at [vexa.ai/signin](https://vexa.ai/signin) with a Google
-account and copy your key from [your account page](https://vexa.ai/account) — free credit, no card
+account and copy your key from [your account page](https://vexa.ai/account)
 required. Self-hosted: `make all` prints a key when the stack comes up.
 
 ## The stack

--- a/docs/docs/how-to/custom-stt.mdx
+++ b/docs/docs/how-to/custom-stt.mdx
@@ -11,7 +11,7 @@ Use this path when you want a different ASR model without changing the bot, meet
 transcript pipeline.
 
 **Don't have a key yet?** Hosted: sign in at [vexa.ai/signin](https://vexa.ai/signin) with a Google
-account and copy your key from [your account page](https://vexa.ai/account) — free credit, no card
+account and copy your key from [your account page](https://vexa.ai/account)
 required. Self-hosted: `make all` prints a key when the stack comes up.
 
 ## Contract

--- a/docs/docs/how-to/overview.mdx
+++ b/docs/docs/how-to/overview.mdx
@@ -7,7 +7,7 @@ Each guide is a complete path to one outcome. They assume you've finished the
 [Quickstart](/quickstart) and have an `$API_BASE` and `$API_KEY` ([Authentication](/authentication)).
 
 **Don't have a key yet?** Hosted: sign in at [vexa.ai/signin](https://vexa.ai/signin) with a Google
-account and copy your key from [your account page](https://vexa.ai/account) — free credit, no card
+account and copy your key from [your account page](https://vexa.ai/account)
 required. Self-hosted: `make all` prints a key when the stack comes up.
 
 The guides fall into three chapters by the plane they work on. **Meetings** and **agents** are

--- a/docs/docs/how-to/recordings.mdx
+++ b/docs/docs/how-to/recordings.mdx
@@ -16,7 +16,7 @@ stored separately from the transcript (speaker separation lives in the transcrip
 per-speaker audio).
 
 **Don't have a key yet?** Hosted: sign in at [vexa.ai/signin](https://vexa.ai/signin) with a Google
-account and copy your key from [your account page](https://vexa.ai/account) — free credit, no card
+account and copy your key from [your account page](https://vexa.ai/account)
 required. Self-hosted: `make all` prints a key when the stack comes up.
 
 ## List recordings

--- a/docs/docs/how-to/send-a-bot.mdx
+++ b/docs/docs/how-to/send-a-bot.mdx
@@ -25,9 +25,6 @@ curl -X POST "https://api.cloud.vexa.ai/bots" \
 `native_meeting_id` is the id inside the join URL — `abc-defg-hij` in
 `https://meet.google.com/abc-defg-hij`.
 
-New accounts get **$5 of free bot credit and no credit card is required** — about 16 hours of bot
-time at $0.30/hr ([pricing](https://vexa.ai/pricing)).
-
 ### Self-hosted
 
 Vexa is Apache-2.0 and runs entirely inside your own perimeter. `make all` pulls the published

--- a/docs/docs/how-to/stream-transcript.mdx
+++ b/docs/docs/how-to/stream-transcript.mdx
@@ -19,7 +19,7 @@ ws://localhost:18056/ws?api_key=<API_KEY>
 A missing key gets a `missing_api_key` error frame; an invalid key is rejected with close code **4401**.
 
 **Don't have a key yet?** Hosted: sign in at [vexa.ai/signin](https://vexa.ai/signin) with a Google
-account and copy your key from [your account page](https://vexa.ai/account) — free credit, no card
+account and copy your key from [your account page](https://vexa.ai/account)
 required. Self-hosted: `make all` prints a key when the stack comes up.
 
 ## Subscribe

--- a/docs/docs/index.mdx
+++ b/docs/docs/index.mdx
@@ -87,7 +87,7 @@ inference — in [Deployment](/deployment).
 **Prefer to look before you build?** Hosted [vexa.ai](https://vexa.ai) runs Vexa 0.12 for meeting bots and transcription today — agents aren't part of the hosted service yet. These docs describe the full 0.12 stack, agents included, that you self-host above.
 
 **Don't have a key yet?** Hosted: sign in at [vexa.ai/signin](https://vexa.ai/signin) with a Google
-account and copy your key from [your account page](https://vexa.ai/account) — free credit, no card
+account and copy your key from [your account page](https://vexa.ai/account)
 required. Self-hosted: `make all` prints a key when the stack comes up.
 
 ## Why Vexa

--- a/docs/docs/interactive-bots.mdx
+++ b/docs/docs/interactive-bots.mdx
@@ -31,7 +31,7 @@ to an unmounted surface returns `404` on every deployment.
   or the transcript API.
 
 **Don't have a key yet?** Hosted: sign in at [vexa.ai/signin](https://vexa.ai/signin) with a Google
-account and copy your key from [your account page](https://vexa.ai/account) — free credit, no card
+account and copy your key from [your account page](https://vexa.ai/account)
 required. Self-hosted: `make all` prints a key when the stack comes up.
 
 ## Where this is going

--- a/docs/docs/n8n.mdx
+++ b/docs/docs/n8n.mdx
@@ -38,7 +38,7 @@ Every Vexa call authenticates with the `X-API-Key` header. Store the key as an n
 not inline in a node.
 
 **Don't have a key yet?** Hosted: sign in at [vexa.ai/signin](https://vexa.ai/signin) with a Google
-account and copy your key from [your account page](https://vexa.ai/account) — free credit, no card
+account and copy your key from [your account page](https://vexa.ai/account)
 required. Self-hosted: `make all` prints a key when the stack comes up.
 
 ## The five steps

--- a/docs/docs/quickstart.mdx
+++ b/docs/docs/quickstart.mdx
@@ -15,8 +15,7 @@ curl -X POST "https://api.cloud.vexa.ai/bots" \
 ```
 
 `native_meeting_id` is the id inside the join URL — `abc-defg-hij` in
-`https://meet.google.com/abc-defg-hij`. New accounts get **$5 of free bot credit and no credit card
-is required** — about 16 hours of bot time at $0.30/hr ([pricing](https://vexa.ai/pricing)). More
+`https://meet.google.com/abc-defg-hij`. More
 calls: [Send a bot](/how-to/send-a-bot).
 
 The rest of this page self-hosts the whole stack, which is how you get the agent plane as well.

--- a/docs/docs/sdks.mdx
+++ b/docs/docs/sdks.mdx
@@ -41,7 +41,7 @@ only invariant is the auth header:
 ```
 
 **Don't have a key yet?** Hosted: sign in at [vexa.ai/signin](https://vexa.ai/signin) with a Google
-account and copy your key from [your account page](https://vexa.ai/account) — free credit, no card
+account and copy your key from [your account page](https://vexa.ai/account)
 required. Self-hosted: `make all` prints a key when the stack comes up.
 
 Identity is **server-derived** from the key — you never send a user id or subject. See

--- a/docs/docs/troubleshooting.mdx
+++ b/docs/docs/troubleshooting.mdx
@@ -175,7 +175,7 @@ retry budget on the first emit (≤ ~15s) already rides out brief transient prog
 | `403 Invalid or missing admin token.` on `/admin/*` | missing or wrong `ADMIN_TOKEN` | use the `X-Admin-API-Key` matching your `ADMIN_TOKEN` |
 
 **Don't have a key yet?** Hosted: sign in at [vexa.ai/signin](https://vexa.ai/signin) with a Google
-account and copy your key from [your account page](https://vexa.ai/account) — free credit, no card
+account and copy your key from [your account page](https://vexa.ai/account)
 required. Self-hosted: `make all` prints a key when the stack comes up.
 
 ## Agent chat says no model credentials are configured

--- a/docs/docs/vexa-mcp.mdx
+++ b/docs/docs/vexa-mcp.mdx
@@ -49,7 +49,7 @@ Point the client at the **gateway**, not at the MCP service's own port — the g
 authenticated front door.
 
 **Don't have a key yet?** Hosted: sign in at [vexa.ai/signin](https://vexa.ai/signin) with a Google
-account and copy your key from [your account page](https://vexa.ai/account) — free credit, no card
+account and copy your key from [your account page](https://vexa.ai/account)
 required. Self-hosted: `make all` prints a key when the stack comes up.
 
 ```json Hosted

--- a/docs/docs/webhooks.mdx
+++ b/docs/docs/webhooks.mdx
@@ -109,7 +109,7 @@ history as "nothing was delivered."**
 </Warning>
 
 **Don't have a key yet?** Hosted: sign in at [vexa.ai/signin](https://vexa.ai/signin) with a Google
-account and copy your key from [your account page](https://vexa.ai/account) — free credit, no card
+account and copy your key from [your account page](https://vexa.ai/account)
 required. Self-hosted: `make all` prints a key when the stack comes up.
 
 ## What is proven, and what is not


### PR DESCRIPTION
The OSS docs tree is a working place — no hosted pricing copy in it (founder, 2026-09-05).

Removed: the hosted welcome-credit sentence ($5 / about 16 hours / $0.30/hr, with the pricing link) from `docs/docs/quickstart.mdx` and `docs/docs/how-to/send-a-bot.mdx`, and the "— free credit, no card" tail from the shared get-a-key line on the other pages that carry it. The link to the hosted account page stays; the offer itself lives on vexa.ai and the hosted docs surface (Vexa-ai/docs).

Supersedes the earlier shape of this PR ($5 → $2). Closes #1540 as no longer applicable to this tree. `README.md` line 63 carries the same sentence and is outside the docs tree — untouched here.

## Contribution rights
<!-- Select exactly ONE. This is a legal certification: an agent may explain the choices but
     must not select one for you. See CONTRIBUTOR_RIGHTS.md. -->

- [ ] **Independent:** I created this contribution, or otherwise have the right to submit it
  under Apache-2.0, and it is not owned or controlled by an employer, client, or other entity.
  <!-- rights:independent -->
- [ ] **Employer/client authorization required:** an employer, client, or other entity owns or
  may control this contribution. I am requesting Vexa's private corporate-authorization process.
  <!-- rights:corporate -->
- [ ] **Unsure:** I need a private rights review before merge.
  <!-- rights:uncertain -->

Every commit must also carry the contributor's own DCO `Signed-off-by` line. Selecting the
independent path means no individual CLA is required. Corporate and unsure paths do not stop
technical review, but they do block merge until resolved.

<!-- vexa-agent -->
