### PR TITLE
release packet: vexaai/v012-flows is the eleventh image (packet schema 2)

### DIFF
--- a/.github/workflows/release-validate.yml
+++ b/.github/workflows/release-validate.yml
@@ -93,6 +93,7 @@ on:
           - vexaai/v012-gateway
           - vexaai/v012-mcp
           - vexaai/v012-terminal
+          - vexaai/v012-flows
           - vexaai/vexa-bot
           - vexaai/vexa-lite
       validation_leg:
@@ -118,6 +119,7 @@ env:
     vexaai/v012-gateway
     vexaai/v012-mcp
     vexaai/v012-terminal
+    vexaai/v012-flows
     vexaai/vexa-bot
     vexaai/vexa-lite
 
@@ -404,6 +406,7 @@ jobs:
               vexaai/v012-gateway)      probe "$ref" python -c "import gateway" ;;
               vexaai/v012-mcp)          probe "$ref" python -c "import vexa_mcp" ;;
               vexaai/v012-terminal)     probe "$ref" node -e "require('fs').accessSync('/app/server.mjs')" ;;
+              vexaai/v012-flows)        probe "$ref" python -c "import flows_worker, flows_integrations.flows_api" ;;
               vexaai/vexa-bot)          probe "$ref" bash -c 'test -x /app/entrypoint.sh && test -f /app/browser-utils.global.js' ;;
               vexaai/vexa-lite)         probe "$ref" bash -c 'test -f /etc/supervisor/conf.d/vexa.conf && test -x /entrypoint.sh' ;;
               *)
@@ -761,6 +764,7 @@ jobs:
               vexaai/v012-gateway)      probe "$ref" python -c "import gateway" ;;
               vexaai/v012-mcp)          probe "$ref" python -c "import vexa_mcp" ;;
               vexaai/v012-terminal)     probe "$ref" node -e "require('fs').accessSync('/app/server.mjs')" ;;
+              vexaai/v012-flows)        probe "$ref" python -c "import flows_worker, flows_integrations.flows_api" ;;
               vexaai/vexa-lite)         probe "$ref" bash -c 'test -f /etc/supervisor/conf.d/vexa.conf && test -x /entrypoint.sh' ;;
               *)
                 echo "::error title=validate-arm64::no identity assertion for $img — every matrix image must state what proves its contents match its name"

--- a/release/README.md
+++ b/release/README.md
@@ -3,7 +3,7 @@
 This directory contains release-time instruments that do not enter any Vexa
 runtime image.
 
-`candidate-image-map.mjs` validates a frozen ten-image candidate map and proves
+`candidate-image-map.mjs` validates a frozen candidate map (eleven images under schema 2, ten under schema 1) and proves
 that the source paths copied by each release Dockerfile are tree-identical to
 that image's witnessed build source. Root-context images include
 `.dockerignore`, because it shapes the bytes Docker receives. A difference is a

--- a/release/candidate-image-map.mjs
+++ b/release/candidate-image-map.mjs
@@ -17,6 +17,21 @@ export const REQUIRED_IMAGES = [
   "vexaai/vexa-lite",
 ];
 
+// schema_version 2 (v0.12.27+): the flows domain ships as its own image — one image, three
+// entrypoints (worker · mailbox · api) — because deploy/compose and the chart run it as three
+// services. Frozen schema-1 packets keep validating against the ten; a v0.12.27+ map must name
+// eleven. Production runs its own derivative (vexaai/vexa-flows-platform), so the OSS image is
+// oss_only.
+export const FLOWS_IMAGE = "vexaai/v012-flows";
+export const REQUIRED_IMAGES_V2 = [...REQUIRED_IMAGES, FLOWS_IMAGE];
+export const CURRENT_SCHEMA_VERSION = 2;
+export const CURRENT_REQUIRED_IMAGES = REQUIRED_IMAGES_V2;
+
+export function requiredImagesFor(doc) {
+  if (!doc) return CURRENT_REQUIRED_IMAGES;
+  return doc.schema_version === 2 ? REQUIRED_IMAGES_V2 : REQUIRED_IMAGES;
+}
+
 export const PROD_DEPLOYED_IMAGES = new Set([
   "vexaai/v012-admin-api",
   "vexaai/v012-runtime",
@@ -78,6 +93,11 @@ export const RUNTIME_INPUTS_BY_IMAGE = {
     "tsconfig.base.json",
     "turbo.json",
     "licenses",
+  ],
+  "vexaai/v012-flows": [
+    ".dockerignore",
+    "core/flows",
+    "behavior",
   ],
   "vexaai/vexa-lite": [
     "deploy/lite",
@@ -149,6 +169,12 @@ export const BUILD_MATRIX_BY_IMAGE = {
     dockerfile: "deploy/lite/Dockerfile.lite",
     free_disk: true,
   },
+  "vexaai/v012-flows": {
+    name: "flows",
+    repository: "v012-flows",
+    context: ".",
+    dockerfile: "core/flows/Dockerfile",
+  },
 };
 
 export const RUNTIME_INPUT_PATHS = [
@@ -165,7 +191,7 @@ const fail = (message) => {
 
 export function validateCandidateMap(doc, expectedVersion) {
   if (!doc || typeof doc !== "object" || Array.isArray(doc)) fail("map must be an object");
-  if (doc.schema_version !== 1) fail("schema_version must be 1");
+  if (doc.schema_version !== 1 && doc.schema_version !== 2) fail("schema_version must be 1 or 2");
   if (!VERSION.test(doc.release)) fail(`invalid stable release: ${doc.release}`);
   if (expectedVersion && doc.release !== expectedVersion) {
     fail(`map release ${doc.release} does not match requested ${expectedVersion}`);
@@ -185,13 +211,14 @@ export function validateCandidateMap(doc, expectedVersion) {
     fail("images must be an object keyed by repository");
   }
 
+  const requiredImages = requiredImagesFor(doc);
   const actual = Object.keys(doc.images).sort();
-  const required = [...REQUIRED_IMAGES].sort();
+  const required = [...requiredImages].sort();
   if (actual.join("\n") !== required.join("\n")) {
     fail(`image set mismatch\nactual=${actual.join(",")}\nrequired=${required.join(",")}`);
   }
 
-  for (const image of REQUIRED_IMAGES) {
+  for (const image of requiredImages) {
     const row = doc.images[image];
     if (!row || typeof row !== "object") fail(`${image}: row missing`);
     const expectedClass = PROD_DEPLOYED_IMAGES.has(image) ? "prod_deployed" : "oss_only";
@@ -297,7 +324,7 @@ export function runtimeInputDriftForPaths(
 }
 
 export function candidateInputDrift(doc, head = "HEAD", cwd = process.cwd()) {
-  return REQUIRED_IMAGES.flatMap((image) => {
+  return requiredImagesFor(doc).flatMap((image) => {
     const row = doc.images[image];
     const buildSource = row.build_source || doc.build_source;
     return runtimeInputDriftForPaths(
@@ -310,7 +337,7 @@ export function candidateInputDrift(doc, head = "HEAD", cwd = process.cwd()) {
 }
 
 export function candidateChangedImages(doc, head = "HEAD", cwd = process.cwd()) {
-  return REQUIRED_IMAGES.filter((image) => {
+  return requiredImagesFor(doc).filter((image) => {
     const row = doc.images[image];
     const buildSource = row.build_source || doc.build_source;
     return runtimeInputDriftForPaths(
@@ -323,8 +350,9 @@ export function candidateChangedImages(doc, head = "HEAD", cwd = process.cwd()) 
 }
 
 export function candidateBuildPlanFromChangedImages(doc, changedImages) {
+  const requiredImages = requiredImagesFor(doc);
   const changed = [...new Set(changedImages)];
-  const unknown = changed.filter((image) => !REQUIRED_IMAGES.includes(image));
+  const unknown = changed.filter((image) => !requiredImages.includes(image));
   if (unknown.length > 0) fail(`build plan contains unknown image(s): ${unknown.join(", ")}`);
 
   const botLite = ["vexaai/vexa-bot", "vexaai/vexa-lite"];
@@ -332,8 +360,8 @@ export function candidateBuildPlanFromChangedImages(doc, changedImages) {
     changed.length === botLite.length &&
     botLite.every((image) => changed.includes(image));
   const exactFull =
-    changed.length === REQUIRED_IMAGES.length &&
-    REQUIRED_IMAGES.every((image) => changed.includes(image));
+    changed.length === requiredImages.length &&
+    requiredImages.every((image) => changed.includes(image));
 
   if (!exactBotLite && !exactFull) {
     fail(
@@ -342,7 +370,7 @@ export function candidateBuildPlanFromChangedImages(doc, changedImages) {
     );
   }
 
-  const selected = exactFull ? REQUIRED_IMAGES : botLite;
+  const selected = exactFull ? requiredImages : botLite;
   return {
     mode: exactFull ? "full" : "bot-lite-delta",
     changed_images: selected,
@@ -361,7 +389,7 @@ export function candidateBuildPlan(doc, head = "HEAD", cwd = process.cwd()) {
   if (!doc) {
     return candidateBuildPlanFromChangedImages(
       null,
-      REQUIRED_IMAGES,
+      CURRENT_REQUIRED_IMAGES,
     );
   }
   return candidateBuildPlanFromChangedImages(
@@ -392,12 +420,12 @@ function main(argv) {
 
   if (command === "check") {
     if (!doc) usage();
-    console.log(`✓ ${doc.release}: exact ten-image candidate map is well formed`);
+    console.log(`✓ ${doc.release}: exact ${requiredImagesFor(doc).length}-image candidate map (schema ${doc.schema_version}) is well formed`);
     return;
   }
   if (command === "emit-tsv") {
     if (!doc) usage();
-    for (const image of REQUIRED_IMAGES) {
+    for (const image of requiredImagesFor(doc)) {
       const row = doc.images[image];
       console.log(`${image}\t${row.digest}\t${row.candidate_tag || doc.candidate_tag}`);
     }
@@ -405,7 +433,7 @@ function main(argv) {
   }
   if (command === "emit-platform-tsv") {
     if (!doc) usage();
-    for (const image of REQUIRED_IMAGES) {
+    for (const image of requiredImagesFor(doc)) {
       const row = doc.images[image];
       for (const platform of row.platforms) {
         const identity = row.platform_manifests[platform];

--- a/release/candidate-image-map.test.mjs
+++ b/release/candidate-image-map.test.mjs
@@ -9,6 +9,9 @@ import test from "node:test";
 import {
   PROD_DEPLOYED_IMAGES,
   REQUIRED_IMAGES,
+  FLOWS_IMAGE,
+  CURRENT_REQUIRED_IMAGES,
+  requiredImagesFor,
   BUILD_MATRIX_BY_IMAGE,
   RUNTIME_INPUTS_BY_IMAGE,
   assertNoRuntimeInputDrift,
@@ -120,6 +123,33 @@ test("v0.12.23 canonical packet freezes the rc.21 train candidate", () => {
     ),
     19,
   );
+});
+
+test("schema 2 names the flows image as the eleventh; schema 1 stays ten", () => {
+  const ten = validMap();
+  assert.equal(requiredImagesFor(ten).length, 10);
+  assert.throws(() => validateCandidateMap({ ...ten, schema_version: 2 }), /image set mismatch/);
+  const eleven = validMap();
+  eleven.schema_version = 2;
+  eleven.images[FLOWS_IMAGE] = {
+    ...eleven.images["vexaai/v012-mcp"],
+    digest: "sha256:" + "f".repeat(64),
+  };
+  const map = validateCandidateMap(eleven, eleven.release);
+  assert.equal(requiredImagesFor(map).length, 11);
+  assert.equal(Object.keys(map.images).length, 11);
+  assert.equal(map.images[FLOWS_IMAGE].class, "oss_only");
+  assert.throws(() => validateCandidateMap({ ...eleven, schema_version: 1 }), /image set mismatch/);
+  const plan = candidateBuildPlan(null);
+  assert.equal(plan.mode, "full");
+  assert.equal(plan.changed_images.length, 11);
+  assert.deepEqual(plan.build_matrix.find((row) => row.name === "flows"), {
+    name: "flows",
+    repository: "v012-flows",
+    context: ".",
+    dockerfile: "core/flows/Dockerfile",
+    use_registry_cache: true,
+  });
 });
 
 test("refuses a missing image", () => {
@@ -236,7 +266,7 @@ test("the replacement build plan is bounded to Bot and Lite", () => {
 test("release-images consumes the planner's dynamic matrix instead of a literal fan-out", () => {
   assert.deepEqual(
     Object.keys(BUILD_MATRIX_BY_IMAGE),
-    REQUIRED_IMAGES.filter((image) => image !== "vexaai/vexa-bot"),
+    CURRENT_REQUIRED_IMAGES.filter((image) => image !== "vexaai/vexa-bot"),
   );
   const workflow = readFileSync(
     new URL("../.github/workflows/release-images.yml", import.meta.url),
@@ -288,11 +318,11 @@ test("a partial build cannot silently widen beyond the validated Bot+Lite path",
   );
 });
 
-test("a release with no prior candidate map retains the full ten-image plan", () => {
+test("a release with no prior candidate map retains the full current (eleven-image) plan", () => {
   const plan = candidateBuildPlan(null);
   assert.equal(plan.mode, "full");
-  assert.equal(plan.changed_images.length, REQUIRED_IMAGES.length);
-  assert.equal(plan.build_matrix.length, REQUIRED_IMAGES.length - 1);
+  assert.equal(plan.changed_images.length, CURRENT_REQUIRED_IMAGES.length);
+  assert.equal(plan.build_matrix.length, CURRENT_REQUIRED_IMAGES.length - 1);
   assert.ok(plan.build_matrix.every(({ use_registry_cache }) => use_registry_cache));
   assert.equal(plan.build_bot, true);
   assert.equal(plan.base_candidate_tag, null);

--- a/releases/README.md
+++ b/releases/README.md
@@ -44,7 +44,7 @@ review. Until it is done, the candidate has no reviewed identity — which is ex
 promote and stable-tag gates refuse to move on.
 
 1. **Bind the packet.** Write `releases/v<BASE>/candidate-images.json` from the *exact published*
-   registry identities of the ten images (10 top descriptors, 19 platform identities — the bot is
+   registry identities of the eleven images (11 top descriptors, 21 platform identities — the bot is
    amd64-only), then pin its hash in **both** places that assert it:
    - the reviewed-identity table in the `resolve` job of
      [`.github/workflows/release-validate.yml`](../.github/workflows/release-validate.yml)


### PR DESCRIPTION
Part of Vexa-ai/vexa#1553 (release train v0.12.27). Blocks the rc packet: every compose-backed validate leg on `v0.12.27-rc.2` ([run 33982656213](https://github.com/Vexa-ai/vexa/actions/runs/33982656213)) fails with `No such image: vexaai/v012-flows:v0.12.27-rc.2`.

The train brought the flows domain into `deploy/compose` and the chart as three services from one image, `vexaai/v012-flows` (`core/flows/Dockerfile`, root context). The release packet still named ten images, so the image is never built or published.

- `release/candidate-image-map.mjs`: packet `schema_version` 2 = the ten + flows. Frozen schema-1 packets (v0.12.18…v0.12.26) keep validating against the ten. `requiredImagesFor(doc)` drives the validator, the drift check, the build plan and the TSV emitters; a plan with no prior map builds the current eleven. flows is `oss_only` (production runs its own derivative image); its declared inputs are `.dockerignore`, `core/flows`, `behavior`.
- `.github/workflows/release-validate.yml`: flows in `ALL_IMAGES`, the dispatch image options, and both identity-probe blocks (`import flows_worker, flows_integrations.flows_api`).
- `releases/README.md`, `release/README.md`: eleven images, 11 top descriptors, 21 platform identities from v0.12.27.

49 tests pass (`release/*.test.mjs`, `scripts/registry-candidate-validate.test.mjs`). `emit-build-plan -` yields an 11-image full plan with `flows` in the matrix; the frozen v0.12.26 map still checks as a 10-image schema-1 packet.

Not in this PR, recorded: `core/flows/Dockerfile` installs its four deps unpinned (`sqlalchemy>=2`, `psycopg[binary]>=3`, `fastapi>=0.110`, `uvicorn>=0.29`), so the image is not reproducible from source alone; and the validate legs hit Docker Hub's pull rate limit on rc.2 after two candidate builds in one hour (`toomanyrequests`) even though every job logs in.

After merge: tag `v0.12.27-rc.3` on the resulting commit; the v0.12.27 arm in the resolve table is added at bind, with 11/21.

COMMITMENTS IN THIS DRAFT — none.
<!-- vexa-agent -->

## Contribution rights
<!-- Select exactly ONE. This is a legal certification: an agent may explain the choices but
     must not select one for you. See CONTRIBUTOR_RIGHTS.md. -->

- [x] **Independent:** I created this contribution, or otherwise have the right to submit it
  under Apache-2.0, and it is not owned or controlled by an employer, client, or other entity.
  <!-- rights:independent -->
- [ ] **Employer/client authorization required:** an employer, client, or other entity owns or
  may control this contribution. I am requesting Vexa's private corporate-authorization process.
  <!-- rights:corporate -->
- [ ] **Unsure:** I need a private rights review before merge.
  <!-- rights:uncertain -->