### PR TITLE
release: bind + freeze the v0.12.27-rc.3 packet (eleven images, run 33993759054 all legs green)

### DIFF
--- a/.github/workflows/release-validate.yml
+++ b/.github/workflows/release-validate.yml
@@ -413,7 +413,7 @@ jobs:
               vexaai/v012-gateway)      probe "$ref" python -c "import gateway" ;;
               vexaai/v012-mcp)          probe "$ref" python -c "import vexa_mcp" ;;
               vexaai/v012-terminal)     probe "$ref" node -e "require('fs').accessSync('/app/server.mjs')" ;;
-              vexaai/v012-flows)        probe "$ref" python -c "import flows_worker, flows_integrations.flows_api" ;;
+              vexaai/v012-flows)        probe "$ref" python -c "import flows_worker, importlib.util as u; assert u.find_spec('flows_integrations.flows_api')" ;;
               vexaai/vexa-bot)          probe "$ref" bash -c 'test -x /app/entrypoint.sh && test -f /app/browser-utils.global.js' ;;
               vexaai/vexa-lite)         probe "$ref" bash -c 'test -f /etc/supervisor/conf.d/vexa.conf && test -x /entrypoint.sh' ;;
               *)
@@ -771,7 +771,7 @@ jobs:
               vexaai/v012-gateway)      probe "$ref" python -c "import gateway" ;;
               vexaai/v012-mcp)          probe "$ref" python -c "import vexa_mcp" ;;
               vexaai/v012-terminal)     probe "$ref" node -e "require('fs').accessSync('/app/server.mjs')" ;;
-              vexaai/v012-flows)        probe "$ref" python -c "import flows_worker, flows_integrations.flows_api" ;;
+              vexaai/v012-flows)        probe "$ref" python -c "import flows_worker, importlib.util as u; assert u.find_spec('flows_integrations.flows_api')" ;;
               vexaai/vexa-lite)         probe "$ref" bash -c 'test -f /etc/supervisor/conf.d/vexa.conf && test -x /entrypoint.sh' ;;
               *)
                 echo "::error title=validate-arm64::no identity assertion for $img — every matrix image must state what proves its contents match its name"

--- a/.github/workflows/release-validate.yml
+++ b/.github/workflows/release-validate.yml
@@ -252,7 +252,7 @@ jobs:
             v0.12.27-rc.3|v0.12.27)
               CANDIDATE_MAP=releases/v0.12.27/candidate-images.json
               EXPECTED_MAP_STABLE_TAG=v0.12.27
-              EXPECTED_MAP_SHA256=b1dcb262b7d55048fddf2859758540035e9c70da57aa9af597a64fe8896ea0d6
+              EXPECTED_MAP_SHA256=dd4e9ad62cf327a0320262329a8eb55a58116415a0f3615e8c5d8ae84f4eb055
               EXPECTED_TOP_DESCRIPTORS=11
               EXPECTED_PLATFORM_IDENTITIES=21
               ;;

--- a/.github/workflows/release-validate.yml
+++ b/.github/workflows/release-validate.yml
@@ -249,6 +249,13 @@ jobs:
               EXPECTED_TOP_DESCRIPTORS=10
               EXPECTED_PLATFORM_IDENTITIES=19
               ;;
+            v0.12.27-rc.3|v0.12.27)
+              CANDIDATE_MAP=releases/v0.12.27/candidate-images.json
+              EXPECTED_MAP_STABLE_TAG=v0.12.27
+              EXPECTED_MAP_SHA256=b1dcb262b7d55048fddf2859758540035e9c70da57aa9af597a64fe8896ea0d6
+              EXPECTED_TOP_DESCRIPTORS=11
+              EXPECTED_PLATFORM_IDENTITIES=21
+              ;;
             v0.12.26-rc.1|v0.12.26)
               CANDIDATE_MAP=releases/v0.12.26/candidate-images.json
               EXPECTED_MAP_STABLE_TAG=v0.12.26

--- a/release/candidate-image-map.test.mjs
+++ b/release/candidate-image-map.test.mjs
@@ -363,7 +363,7 @@ test("v0.12.27 canonical packet binds the rc.3 train candidate (schema 2, eleven
   );
   assert.equal(
     createHash("sha256").update(raw).digest("hex"),
-    "b1dcb262b7d55048fddf2859758540035e9c70da57aa9af597a64fe8896ea0d6",
+    "dd4e9ad62cf327a0320262329a8eb55a58116415a0f3615e8c5d8ae84f4eb055",
   );
   const map = validateCandidateMap(JSON.parse(raw), "v0.12.27");
   assert.equal(map.schema_version, 2);

--- a/release/candidate-image-map.test.mjs
+++ b/release/candidate-image-map.test.mjs
@@ -357,6 +357,29 @@ test("v0.12.25 canonical packet binds the rc.1 train candidate", () => {
   );
 });
 
+test("v0.12.27 canonical packet binds the rc.3 train candidate (schema 2, eleven images)", () => {
+  const raw = readFileSync(
+    new URL("../releases/v0.12.27/candidate-images.json", import.meta.url),
+  );
+  assert.equal(
+    createHash("sha256").update(raw).digest("hex"),
+    "b1dcb262b7d55048fddf2859758540035e9c70da57aa9af597a64fe8896ea0d6",
+  );
+  const map = validateCandidateMap(JSON.parse(raw), "v0.12.27");
+  assert.equal(map.schema_version, 2);
+  assert.equal(map.candidate_tag, "v0.12.27-rc.3");
+  assert.equal(map.build_source, "78be718f940a68253a8cd0188e7cfe8edd51d41c");
+  assert.equal(map.images["vexaai/vexa-bot"].digest, "sha256:e4be25d82b29b3bda1a50a33bd7fcc7db1b715dbfa887dc991819e7b1f581537");
+  assert.equal(Object.keys(map.images).length, 11);
+  assert.equal(
+    Object.values(map.images).reduce(
+      (count, image) => count + Object.keys(image.platform_manifests).length,
+      0,
+    ),
+    21,
+  );
+});
+
 test("v0.12.26 canonical packet binds the rc.1 train candidate", () => {
   const raw = readFileSync(
     new URL("../releases/v0.12.26/candidate-images.json", import.meta.url),

--- a/releases/v0.12.27/RELEASE-NOTES.draft.md
+++ b/releases/v0.12.27/RELEASE-NOTES.draft.md
@@ -137,7 +137,7 @@ deployment relies on.
 
 ---
 
-**Images:** <images>, published from the reviewed candidate packet
+**Images (eleven — `vexaai/v012-flows` joins the release set with this version):** `vexaai/v012-admin-api@sha256:bd43f2928c5c60096715383c9ed0dc33e88202630b5ff02c9685751c06b64aa6`, `vexaai/v012-runtime@sha256:ccbd50e384acf4fec6c7666794166af1f58968ad4b48c26831611c865825c4ea`, `vexaai/v012-agent-worker@sha256:75914538982acd7c703a8433e41cca976567b47163908f20c4222ee311306754`, `vexaai/v012-agent-api@sha256:cc8000bfb87eadf2b16aa3e8a00f729ab9a230d3cc07eece4cdebebc7e28d98a`, `vexaai/v012-meeting-api@sha256:bc3025f54b6c0452bda310e8a4d21f779951ef6437bb4de9330dc04d02e7d421`, `vexaai/v012-gateway@sha256:4f22de622093aeb77740df8d57b2a11b766c39dea7766663c3cf2ee36af14ec4`, `vexaai/v012-mcp@sha256:9ddd958646dd51be4b9fffe1c425ad742e754e7bef502d749fed58e3f5e66c32`, `vexaai/v012-terminal@sha256:02858350ca39862d57f81a16d645f8cfbb8404a2e1a6fbed6b1ad560ab5347c2`, `vexaai/vexa-bot@sha256:e4be25d82b29b3bda1a50a33bd7fcc7db1b715dbfa887dc991819e7b1f581537`, `vexaai/vexa-lite@sha256:65dc0fd1781ea7c15a064b66074dabaa3f304776188fe254d603654d4a559d85`, `vexaai/v012-flows@sha256:6ec683e4ff1570f7bb7a0c0134f8722264ce159f266e8b5ba377f8258b083df7`, published from the reviewed candidate packet
 `releases/v0.12.27/candidate-images.json` and validated by <validation run>.
 
 **In production:** this release is what vexa.ai runs, pinned as channel entry <channel entry> and

--- a/releases/v0.12.27/RELEASE-NOTES.draft.md
+++ b/releases/v0.12.27/RELEASE-NOTES.draft.md
@@ -138,7 +138,7 @@ deployment relies on.
 ---
 
 **Images (eleven — `vexaai/v012-flows` joins the release set with this version):** `vexaai/v012-admin-api@sha256:bd43f2928c5c60096715383c9ed0dc33e88202630b5ff02c9685751c06b64aa6`, `vexaai/v012-runtime@sha256:ccbd50e384acf4fec6c7666794166af1f58968ad4b48c26831611c865825c4ea`, `vexaai/v012-agent-worker@sha256:75914538982acd7c703a8433e41cca976567b47163908f20c4222ee311306754`, `vexaai/v012-agent-api@sha256:cc8000bfb87eadf2b16aa3e8a00f729ab9a230d3cc07eece4cdebebc7e28d98a`, `vexaai/v012-meeting-api@sha256:bc3025f54b6c0452bda310e8a4d21f779951ef6437bb4de9330dc04d02e7d421`, `vexaai/v012-gateway@sha256:4f22de622093aeb77740df8d57b2a11b766c39dea7766663c3cf2ee36af14ec4`, `vexaai/v012-mcp@sha256:9ddd958646dd51be4b9fffe1c425ad742e754e7bef502d749fed58e3f5e66c32`, `vexaai/v012-terminal@sha256:02858350ca39862d57f81a16d645f8cfbb8404a2e1a6fbed6b1ad560ab5347c2`, `vexaai/vexa-bot@sha256:e4be25d82b29b3bda1a50a33bd7fcc7db1b715dbfa887dc991819e7b1f581537`, `vexaai/vexa-lite@sha256:65dc0fd1781ea7c15a064b66074dabaa3f304776188fe254d603654d4a559d85`, `vexaai/v012-flows@sha256:6ec683e4ff1570f7bb7a0c0134f8722264ce159f266e8b5ba377f8258b083df7`, published from the reviewed candidate packet
-`releases/v0.12.27/candidate-images.json` and validated by <validation run>.
+`releases/v0.12.27/candidate-images.json` and validated by [run 33993759054](https://github.com/Vexa-ai/vexa/actions/runs/33993759054).
 
 **In production:** this release is what vexa.ai runs, pinned as channel entry <channel entry> and
 re-verified against the cluster after the pin.

--- a/releases/v0.12.27/candidate-images.json
+++ b/releases/v0.12.27/candidate-images.json
@@ -4,9 +4,9 @@
  "stable_tag": "v0.12.27",
  "candidate_tag": "v0.12.27-rc.3",
  "build_source": "78be718f940a68253a8cd0188e7cfe8edd51d41c",
- "validation_source": "78be718f940a68253a8cd0188e7cfe8edd51d41c",
+ "validation_source": "7ba34a301c7672c179d469fe56b75887775103b8",
  "build_run": "https://github.com/Vexa-ai/vexa/actions/runs/33985945402",
- "validation_run": "https://github.com/Vexa-ai/vexa/actions/runs/33985945402",
+ "validation_run": "https://github.com/Vexa-ai/vexa/actions/runs/33993759054",
  "images": {
   "vexaai/v012-admin-api": {
    "class": "prod_deployed",

--- a/releases/v0.12.27/candidate-images.json
+++ b/releases/v0.12.27/candidate-images.json
@@ -1,0 +1,226 @@
+{
+ "schema_version": 2,
+ "release": "v0.12.27",
+ "stable_tag": "v0.12.27",
+ "candidate_tag": "v0.12.27-rc.3",
+ "build_source": "78be718f940a68253a8cd0188e7cfe8edd51d41c",
+ "validation_source": "78be718f940a68253a8cd0188e7cfe8edd51d41c",
+ "build_run": "https://github.com/Vexa-ai/vexa/actions/runs/33985945402",
+ "validation_run": "https://github.com/Vexa-ai/vexa/actions/runs/33985945402",
+ "images": {
+  "vexaai/v012-admin-api": {
+   "class": "prod_deployed",
+   "digest": "sha256:bd43f2928c5c60096715383c9ed0dc33e88202630b5ff02c9685751c06b64aa6",
+   "platforms": [
+    "linux/amd64",
+    "linux/arm64"
+   ],
+   "platform_manifests": {
+    "linux/amd64": {
+     "manifest_digest": "sha256:f901c90d642372bd4d6d93a668381b098fc95eb96fa2593b82497aff011047f5",
+     "config_digest": "sha256:1f859168a6f40c00f006ecb2f28872e13cca0148bf1a912fb44a999639a4e3ab"
+    },
+    "linux/arm64": {
+     "manifest_digest": "sha256:e5f0d53b41c8dd0efcc246e4673fb44db9a99a685a1ce0e51dde73fed1a2e055",
+     "config_digest": "sha256:e5d0430499f552c8b82e20d14842952693e455910897fe75a59d0d5a8c9a98b2"
+    }
+   },
+   "attestations": true,
+   "evidence": "candidate build run 33985945402 at 78be718f; exact registry identities collected after the image job completed"
+  },
+  "vexaai/v012-runtime": {
+   "class": "prod_deployed",
+   "digest": "sha256:ccbd50e384acf4fec6c7666794166af1f58968ad4b48c26831611c865825c4ea",
+   "platforms": [
+    "linux/amd64",
+    "linux/arm64"
+   ],
+   "platform_manifests": {
+    "linux/amd64": {
+     "manifest_digest": "sha256:a6f62fa2209f4210d646e859185514f5c588893b366e957bd0be4b81776bf0bf",
+     "config_digest": "sha256:ed1fa17a8180b3bbf15e6783d5f2ef576894d9e022a21441f9bdda58ee708147"
+    },
+    "linux/arm64": {
+     "manifest_digest": "sha256:e24b2a310c0d63332880193d2ced86b5d26ecb58b3d72f1351b9d21a5856dd25",
+     "config_digest": "sha256:3c1cc0ac3821bc5251308ecb26d80855d04e2346c4da21ca876189bcad017556"
+    }
+   },
+   "attestations": true,
+   "evidence": "candidate build run 33985945402 at 78be718f; exact registry identities collected after the image job completed"
+  },
+  "vexaai/v012-agent-worker": {
+   "class": "oss_only",
+   "digest": "sha256:75914538982acd7c703a8433e41cca976567b47163908f20c4222ee311306754",
+   "platforms": [
+    "linux/amd64",
+    "linux/arm64"
+   ],
+   "platform_manifests": {
+    "linux/amd64": {
+     "manifest_digest": "sha256:3594150db20a606635d37a7c0746fb6cf3fad4fa9523e11821b056924d4f59b3",
+     "config_digest": "sha256:9fd33925563d679fbd0282d465283c9a9c9ace1fe831250dd787f90b849ae51a"
+    },
+    "linux/arm64": {
+     "manifest_digest": "sha256:e5e5529a85d28727cef58f910346670cc96acc215a3e61f10a0984c2028e24a9",
+     "config_digest": "sha256:06f47ac632e754452819746d69d4e4982231227c63522d1b9cb0e9b8dec5a280"
+    }
+   },
+   "attestations": true,
+   "evidence": "candidate build run 33985945402 at 78be718f; exact registry identities collected after the image job completed"
+  },
+  "vexaai/v012-agent-api": {
+   "class": "oss_only",
+   "digest": "sha256:cc8000bfb87eadf2b16aa3e8a00f729ab9a230d3cc07eece4cdebebc7e28d98a",
+   "platforms": [
+    "linux/amd64",
+    "linux/arm64"
+   ],
+   "platform_manifests": {
+    "linux/amd64": {
+     "manifest_digest": "sha256:85208c1d49c3b7695427c322832856ee0bf3a0075da69dd756b5de28d3cd68b6",
+     "config_digest": "sha256:7120079a415def96ccf53d58d2b19c46fb2a9e52d3b1d40d88a189d3b42e06eb"
+    },
+    "linux/arm64": {
+     "manifest_digest": "sha256:b192dc868f993c836138caadbbd8b65c12d6e9fa39a3c9a21dfb92773e3185d1",
+     "config_digest": "sha256:a7c0b0d66079a5912cae56878c1e97ddfeab341228c5f2b14be1edb2d655d2fc"
+    }
+   },
+   "attestations": true,
+   "evidence": "candidate build run 33985945402 at 78be718f; exact registry identities collected after the image job completed"
+  },
+  "vexaai/v012-meeting-api": {
+   "class": "prod_deployed",
+   "digest": "sha256:bc3025f54b6c0452bda310e8a4d21f779951ef6437bb4de9330dc04d02e7d421",
+   "platforms": [
+    "linux/amd64",
+    "linux/arm64"
+   ],
+   "platform_manifests": {
+    "linux/amd64": {
+     "manifest_digest": "sha256:8f52ddaecb44b05a8deba9b914416d6e18d566f91e0a7a995007b45511bcbb14",
+     "config_digest": "sha256:322fa2c133af24f1a7875ee8524f772e5ca4baa09be633160ade21d57833678c"
+    },
+    "linux/arm64": {
+     "manifest_digest": "sha256:ba0cf1104663f4313286a818aa776c219c154e91cd2331719380556cb2dd666e",
+     "config_digest": "sha256:2d3e230928dad6406ea6a3c9af59eb2024f32cc1ff7a5ce67acad99b121d865c"
+    }
+   },
+   "attestations": true,
+   "evidence": "candidate build run 33985945402 at 78be718f; exact registry identities collected after the image job completed"
+  },
+  "vexaai/v012-gateway": {
+   "class": "prod_deployed",
+   "digest": "sha256:4f22de622093aeb77740df8d57b2a11b766c39dea7766663c3cf2ee36af14ec4",
+   "platforms": [
+    "linux/amd64",
+    "linux/arm64"
+   ],
+   "platform_manifests": {
+    "linux/amd64": {
+     "manifest_digest": "sha256:6f620914a6e9afe5f996c9231da982cd3276a0729fd916a73f2393246acdffce",
+     "config_digest": "sha256:277f43ea6c601e64f16119109e9e8a0537e46042a32c53bbb82c4a143be6e436"
+    },
+    "linux/arm64": {
+     "manifest_digest": "sha256:484adbb3384bf623d7db2292274f200cecb00c5875d10ca762d315454cc5fcb0",
+     "config_digest": "sha256:a1d555b058fae334147af6e122e3968be4876ed66ef8aed3d9d6aefb0d1eb149"
+    }
+   },
+   "attestations": true,
+   "evidence": "candidate build run 33985945402 at 78be718f; exact registry identities collected after the image job completed"
+  },
+  "vexaai/v012-mcp": {
+   "class": "oss_only",
+   "digest": "sha256:9ddd958646dd51be4b9fffe1c425ad742e754e7bef502d749fed58e3f5e66c32",
+   "platforms": [
+    "linux/amd64",
+    "linux/arm64"
+   ],
+   "platform_manifests": {
+    "linux/amd64": {
+     "manifest_digest": "sha256:4dd5fc42727c4febdda7389912e01dd62b692f96b9c13a519789db0674e7d1a5",
+     "config_digest": "sha256:516de2c96d18841b895b786d83e7b593e240e75f8448cd879fdcd08379ffa107"
+    },
+    "linux/arm64": {
+     "manifest_digest": "sha256:ef77a272770d2e7689f8c9071e73e2588ed39e7ecbdbe86b4d0fc1ace73d0b21",
+     "config_digest": "sha256:800808977f5dc9e46cf6764cde631ea3a57e6c48f7c47a339f00c85f8842c191"
+    }
+   },
+   "attestations": true,
+   "evidence": "candidate build run 33985945402 at 78be718f; exact registry identities collected after the image job completed"
+  },
+  "vexaai/v012-terminal": {
+   "class": "oss_only",
+   "digest": "sha256:02858350ca39862d57f81a16d645f8cfbb8404a2e1a6fbed6b1ad560ab5347c2",
+   "platforms": [
+    "linux/amd64",
+    "linux/arm64"
+   ],
+   "platform_manifests": {
+    "linux/amd64": {
+     "manifest_digest": "sha256:4eae1f2bf8f5d23184f35852f65dacaacc7919afe4cd44d52607da8ac869ebfb",
+     "config_digest": "sha256:310931b4ba61f5b47624001eb0a580dda8ced1e2c893c2b89ef39d8bb6ee8d97"
+    },
+    "linux/arm64": {
+     "manifest_digest": "sha256:0ac00a134c737588005a05a71c4498e9ebc88b0ca5ad07ed35796e3c17250865",
+     "config_digest": "sha256:e5a45f7d4c8eb81d7244575bd61870984095b15b50fdbc8c120e7fe82bdf3e66"
+    }
+   },
+   "attestations": true,
+   "evidence": "candidate build run 33985945402 at 78be718f; exact registry identities collected after the image job completed"
+  },
+  "vexaai/vexa-bot": {
+   "class": "prod_deployed",
+   "digest": "sha256:e4be25d82b29b3bda1a50a33bd7fcc7db1b715dbfa887dc991819e7b1f581537",
+   "platforms": [
+    "linux/amd64"
+   ],
+   "platform_manifests": {
+    "linux/amd64": {
+     "manifest_digest": "sha256:e4be25d82b29b3bda1a50a33bd7fcc7db1b715dbfa887dc991819e7b1f581537",
+     "config_digest": "sha256:6149331f7922b30c72cd0999a4fcdd2bfccd2b9756b4b2e3005a6a3a9d2dcce8"
+    }
+   },
+   "evidence": "candidate build run 33985945402 at 78be718f; exact registry identities collected after the image job completed"
+  },
+  "vexaai/vexa-lite": {
+   "class": "oss_only",
+   "digest": "sha256:65dc0fd1781ea7c15a064b66074dabaa3f304776188fe254d603654d4a559d85",
+   "platforms": [
+    "linux/amd64",
+    "linux/arm64"
+   ],
+   "platform_manifests": {
+    "linux/amd64": {
+     "manifest_digest": "sha256:6ec5e3503bfacd1b34051ee697e5d8bc2c1a1d909ce84c24bc4f95f800142da2",
+     "config_digest": "sha256:29a89deb192494da2b1156f4b4f064c2f707de987c1535aa1d5f265c25fe60f4"
+    },
+    "linux/arm64": {
+     "manifest_digest": "sha256:03a49aeea9a9d53caa837d4334d6f20f869a4edc8fde51e6ab7399ce30d01fe6",
+     "config_digest": "sha256:cd45334134c232b0523edd9bc1c1f931593078e287c0b81c9897f3c3cb9d9bd7"
+    }
+   },
+   "attestations": true,
+   "evidence": "candidate build run 33985945402 at 78be718f; exact registry identities collected after the image job completed"
+  },
+  "vexaai/v012-flows": {
+   "class": "oss_only",
+   "digest": "sha256:6ec683e4ff1570f7bb7a0c0134f8722264ce159f266e8b5ba377f8258b083df7",
+   "platforms": [
+    "linux/amd64",
+    "linux/arm64"
+   ],
+   "platform_manifests": {
+    "linux/amd64": {
+     "manifest_digest": "sha256:b4d3915889ac455e97a3bc0fa55085ac3facaec4858736a2a1a739bbfed9db95",
+     "config_digest": "sha256:d93c372c95474cb963c7e75a2a42aed9d415e3504401d33f7e10f1d206baf5fd"
+    },
+    "linux/arm64": {
+     "manifest_digest": "sha256:41069ada75f7d03c8165e1422ddf6ed0d295fe77ce1ee0bb3ff8c1cd25085c4c",
+     "config_digest": "sha256:772118dab74f0faa16372b328c25a0b25a6e8f2c2f9393a76e9e2cb8e68a8ffe"
+    }
+   },
+   "attestations": true,
+   "evidence": "candidate build run 33985945402 at 78be718f; exact registry identities collected after the image job completed"
+  }
+ }
+}


### PR DESCRIPTION
Part of Vexa-ai/vexa#1553 (release train v0.12.27). Five commits, the 1a step of `releases/README.md` for this candidate:

1. **bind** — `releases/v0.12.27/candidate-images.json`: the exact published registry identities of the eleven images built by [run 33985945402](https://github.com/Vexa-ai/vexa/actions/runs/33985945402) from `78be718f9` (tag `v0.12.27-rc.3`); 11 top descriptors, 21 platform identities, packet schema 2; sha pinned in the resolve table (`v0.12.27-rc.3|v0.12.27`, 11/21) and the canonical test.
2. **probe fix** — the flows identity probe no longer imports `flows_integrations.flows_api` (whose startup guard refuses without an API key); it asserts the module is present via `importlib.util.find_spec`.
3. **release notes** — the images block names the eleven images by digest; flows joins the set with this version.
4. **freeze** — `validation_source` `7ba34a301`, `validation_run` [33993759054](https://github.com/Vexa-ai/vexa/actions/runs/33993759054): resolve with the identity check enforced, then image-identity, arm64, compose, mock-fsm, bot-spawn, lite, helm-k3s and v0.10-compat all green on the published rc.3 images; map re-hashed and re-pinned.

Earlier attempts on record: rc.1 (gateway build context, #1572), rc.2 (eleventh image missing, #1575; Docker Hub caps the `vexaai` account at 200 pulls per rolling hour — `docker-ratelimit-source: vexaai`, `200;w=3600` — which is what the "unauthenticated" message on the rc.2/rc.3 legs actually was).

Not in this PR, filed tonight from production: Vexa-ai/vexa#1576 (left_alone teardown hang), #1577 (Meet admission miss → billing exception).

COMMITMENTS IN THIS DRAFT — none.
<!-- vexa-agent -->

## Contribution rights
<!-- Select exactly ONE. This is a legal certification: an agent may explain the choices but
     must not select one for you. See CONTRIBUTOR_RIGHTS.md. -->

- [x] **Independent:** I created this contribution, or otherwise have the right to submit it
  under Apache-2.0, and it is not owned or controlled by an employer, client, or other entity.
  <!-- rights:independent -->
- [ ] **Employer/client authorization required:** an employer, client, or other entity owns or
  may control this contribution. I am requesting Vexa's private corporate-authorization process.
  <!-- rights:corporate -->
- [ ] **Unsure:** I need a private rights review before merge.
  <!-- rights:uncertain -->