### PR TITLE
fix(runtime): a reclaim that loses to a concurrent remover confirms absence instead of failing

### DIFF
--- a/core/runtime/src/runtime_kernel/api.py
+++ b/core/runtime/src/runtime_kernel/api.py
@@ -161,6 +161,9 @@ def create_app(
 
     @app.delete("/workloads/{workload_id}")
     def destroy(workload_id: str):
+        # Potentially multi-second: a reclaim that races a concurrent remover confirms the
+        # container's absence (bounded by RUNTIME_RECLAIM_CONFIRM_SEC) before returning. Sync
+        # route ⇒ it holds one threadpool slot, never the event loop.
         try:
             return dump(rt.destroy(workload_id))
         except KeyError:

--- a/core/runtime/src/runtime_kernel/config.v1.json
+++ b/core/runtime/src/runtime_kernel/config.v1.json
@@ -90,6 +90,13 @@
    "targets": []
   },
   {
+   "key": "RUNTIME_RECLAIM_CONFIRM_SEC",
+   "class": "defaulted",
+   "default": "10",
+   "description": "how long (s) a docker reclaim that lost to a concurrent remover waits for the container's confirmed absence before failing; clamped to 1..120",
+   "targets": []
+  },
+  {
    "key": "RUNTIME_K8S_TOLERATIONS",
    "class": "defaulted",
    "default": "(chart's global.tolerations, JSON — the runtime's own tolerations)",

--- a/core/runtime/src/runtime_kernel/docker_backend.py
+++ b/core/runtime/src/runtime_kernel/docker_backend.py
@@ -417,7 +417,11 @@ class DockerBackend:
             started = time.monotonic()
             deadline = started + confirm_sec
             inspected = False
-            while time.monotonic() < deadline:
+            # inspect-first, deadline-checked AFTER: the loop can never raise without a terminal
+            # inspect, so a container that vanishes in the window's last moments is still
+            # confirmed rather than misreported as a failed reclaim.
+            while True:
+                status = None
                 try:
                     # short per-request timeout: the window is the deadline's business — one
                     # stalled inspect must not stretch the bound by _req's default 30s.
@@ -430,15 +434,20 @@ class DockerBackend:
                     logger.debug(
                         "docker delete %s: inspect failed mid-confirm", h._impl, exc_info=True
                     )
-                    _reclaim_sleep(_RECLAIM_POLL_SEC)
-                    continue
-                inspected = True
+                else:
+                    # only a verdict-bearing answer counts as having observed the container:
+                    # a stream of inspect-500s must end as "absence could not be confirmed",
+                    # never as a claim that the container is still present
+                    if status in (200, 404):
+                        inspected = True
                 if status == 404:
                     logger.info(
                         "docker delete %s: absence confirmed after %.1fs (another remover "
                         "finished the reclaim)", h._impl, time.monotonic() - started,
                     )
                     return
+                if time.monotonic() >= deadline:
+                    break
                 _reclaim_sleep(_RECLAIM_POLL_SEC)
             elapsed = time.monotonic() - started
             if inspected:

--- a/core/runtime/src/runtime_kernel/docker_backend.py
+++ b/core/runtime/src/runtime_kernel/docker_backend.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import logging
 import os
+import time
 from typing import Any, Optional
 from urllib.parse import quote
 
@@ -40,6 +41,22 @@ def _stop_grace_sec() -> int:
         return max(1, int(float(os.getenv("RUNTIME_STOP_GRACE_SEC", "30"))))
     except ValueError:
         return 30
+
+
+def _reclaim_confirm_sec() -> float:
+    """How long ``cleanup`` waits for a removal-in-progress (DELETE → 409) to actually finish
+    before declaring the reclaim failed. Removal is normally sub-second, but unmounting a fat
+    writable layer on slow storage takes seconds — tunable like the stop grace, clamped to
+    1..120 (an unbounded window would hold a destroy threadpool slot forever)."""
+    try:
+        return min(120.0, max(1.0, float(os.getenv("RUNTIME_RECLAIM_CONFIRM_SEC", "10"))))
+    except ValueError:
+        return 10.0
+
+
+_RECLAIM_POLL_SEC = 0.2
+#: Test seam: the reclaim poll's sleeper (patching the stdlib ``time`` module would be process-wide).
+_reclaim_sleep = time.sleep
 
 
 def _worker_naming(workload_id: str) -> tuple[str, dict[str, str]]:
@@ -384,8 +401,55 @@ class DockerBackend:
     def cleanup(self, h: WorkloadHandle) -> None:
         # Reclaim MUST be truthful: a failed force-delete while the container may still be running
         # would let `destroy` report `destroyed` over a live bot. 404 = already gone (fine).
+        # 409 = another remover is finishing the reclaim (an operator's `rm -f`, a GC, another
+        # deployment sharing the daemon): what truthfulness needs is the container GONE, not our
+        # DELETE to be the one that won — so absence is confirmed within a bounded window, and a
+        # container still present at the deadline raises exactly like any other failed reclaim.
         r = self._req("DELETE", f"/containers/{h._impl}?force=true")  # type: ignore[attr-defined]
-        if r.status_code not in (204, 404):
-            raise RuntimeError(
-                f"docker delete {h._impl} failed ({r.status_code}): {r.text.strip()[:200]}"
+        if r.status_code in (204, 404):
+            return
+        if r.status_code == 409:
+            confirm_sec = _reclaim_confirm_sec()
+            logger.warning(
+                "docker delete %s: removal already in progress (concurrent remover) — "
+                "confirming absence for up to %.0fs", h._impl, confirm_sec,
             )
+            started = time.monotonic()
+            deadline = started + confirm_sec
+            inspected = False
+            while time.monotonic() < deadline:
+                try:
+                    # short per-request timeout: the window is the deadline's business — one
+                    # stalled inspect must not stretch the bound by _req's default 30s.
+                    status = self._req(  # type: ignore[attr-defined]
+                        "GET", f"/containers/{h._impl}/json", timeout=2
+                    ).status_code
+                except Exception:
+                    # a daemon blip mid-poll is not a verdict either way — keep confirming
+                    # until the deadline; the raises below stay the only failure paths
+                    logger.debug(
+                        "docker delete %s: inspect failed mid-confirm", h._impl, exc_info=True
+                    )
+                    _reclaim_sleep(_RECLAIM_POLL_SEC)
+                    continue
+                inspected = True
+                if status == 404:
+                    logger.info(
+                        "docker delete %s: absence confirmed after %.1fs (another remover "
+                        "finished the reclaim)", h._impl, time.monotonic() - started,
+                    )
+                    return
+                _reclaim_sleep(_RECLAIM_POLL_SEC)
+            elapsed = time.monotonic() - started
+            if inspected:
+                raise RuntimeError(
+                    f"docker delete {h._impl}: daemon reports a removal in progress, but the "
+                    f"container is still present after {elapsed:.1f}s ({r.text.strip()[:200]})"
+                )
+            raise RuntimeError(
+                f"docker delete {h._impl}: removal in progress, and absence could not be "
+                f"confirmed — every inspect failed for {elapsed:.1f}s (daemon unreachable?)"
+            )
+        raise RuntimeError(
+            f"docker delete {h._impl} failed ({r.status_code}): {r.text.strip()[:200]}"
+        )

--- a/core/runtime/tests/test_docker_backend.py
+++ b/core/runtime/tests/test_docker_backend.py
@@ -4,6 +4,7 @@ where the docker daemon is unavailable (e.g. CI without Docker)."""
 import shutil
 import os
 import subprocess
+import time
 import uuid
 
 import pytest
@@ -56,5 +57,54 @@ def test_docker_backend_real_container_lifecycle():
         rt.destroy(wid)
         assert rt.get(wid).state is RuntimeState.destroyed
         assert not _exists(name)                              # container actually removed
+    finally:
+        subprocess.run(["docker", "rm", "-f", name], capture_output=True)
+
+
+def test_docker_reclaim_races_a_real_concurrent_remover(caplog):
+    # The staged race behind the 409 reclaim contract, against the REAL daemon: another remover
+    # force-deletes the container at the same moment cleanup does. Whichever DELETE loses gets
+    # 409 "removal already in progress"; cleanup must succeed either way, and only because the
+    # container is provably GONE. The fat writable layer widens the removal window so the race
+    # reliably overlaps.
+    import threading
+
+    from runtime_kernel.backend import WorkloadHandle
+    from runtime_kernel.docker_backend import DockerBackend
+
+    name = f"vexa-rt-reclaimtest-{os.getpid()}-{uuid.uuid4().hex[:6]}"
+    subprocess.run(["docker", "rm", "-f", name], capture_output=True)  # clean slate
+    try:
+        subprocess.run(
+            ["docker", "run", "-d", "--name", name, "alpine",
+             "sh", "-c", "dd if=/dev/zero of=/big bs=1M count=300 2>/dev/null && sleep 300"],
+            check=True, capture_output=True,
+        )
+        # wait for the layer to be written, so removal has real work to do
+        for _ in range(100):
+            probe = subprocess.run(
+                ["docker", "exec", name, "test", "-f", "/big"], capture_output=True
+            )
+            if probe.returncode == 0:
+                break
+            time.sleep(0.1)
+        remover = threading.Thread(
+            target=subprocess.run, args=(["docker", "rm", "-f", name],),
+            kwargs={"capture_output": True},
+        )
+        remover.start()
+        # head start: let the remover's DELETE get in flight (CLI startup + API call), so
+        # cleanup's own DELETE arrives mid-removal and takes the 409 confirm-absence path —
+        # the fat layer keeps the removal window open far longer than this delay
+        time.sleep(0.5)
+        with caplog.at_level("WARNING", logger="runtime_kernel.docker_backend"):
+            DockerBackend().cleanup(WorkloadHandle(name, name))  # must not raise, whoever wins
+        remover.join(timeout=60)
+        assert not _exists(name)                              # absence, the only success condition
+        if not any("removal already in progress" in r.getMessage() for r in caplog.records):
+            # a lost race is still a valid pass of the invariant (cleanup succeeded, container
+            # gone) but it never entered the 409 branch — say so instead of passing silently;
+            # the scripted suite pins the branch deterministically either way
+            pytest.skip("race did not overlap on this host — 409 branch pinned by the scripted suite")
     finally:
         subprocess.run(["docker", "rm", "-f", name], capture_output=True)

--- a/core/runtime/tests/test_docker_reclaim.py
+++ b/core/runtime/tests/test_docker_reclaim.py
@@ -141,6 +141,41 @@ def test_cleanup_409_with_the_daemon_gone_says_so_instead_of_claiming_presence(m
         DockerBackend().cleanup(_H)
 
 
+def test_cleanup_409_always_ends_on_an_inspect_so_a_deadline_edge_vanish_still_confirms(monkeypatch):
+    # A removal that completes between the last poll and the deadline must not be misreported
+    # as a failed reclaim: the loop inspects FIRST and checks the deadline AFTER, so even a
+    # zero-width window gets one terminal inspect — here it finds the 404 and succeeds.
+    monkeypatch.setattr(docker_backend, "_reclaim_confirm_sec", lambda: 0.0)
+    be, calls = _scripted_backend(
+        monkeypatch,
+        [
+            _Resp(409, '{"message":"removal of container vexa-wl-1 is already in progress"}'),
+            _Resp(404),  # gone exactly at the deadline edge
+        ],
+    )
+    be.cleanup(_H)
+    assert calls == [
+        ("DELETE", "/containers/vexa-wl-1?force=true", None),
+        ("GET", "/containers/vexa-wl-1/json", 2),
+    ]
+
+
+def test_cleanup_409_with_only_inspect_errors_says_unconfirmed(monkeypatch):
+    # Inspect responses that carry no verdict (500s) are not observations of presence: a window
+    # of nothing but errors must end as "absence could not be confirmed", never "still present".
+    monkeypatch.setattr(docker_backend, "_reclaim_confirm_sec", lambda: 0.05)
+    be, calls = _scripted_backend(
+        monkeypatch,
+        [
+            _Resp(409, '{"message":"removal of container vexa-wl-1 is already in progress"}'),
+            _Resp(500, "inspect exploded"),  # repeated forever
+        ],
+    )
+    with pytest.raises(RuntimeError, match="could not be confirmed"):
+        be.cleanup(_H)
+    assert ("GET", "/containers/vexa-wl-1/json", 2) in calls
+
+
 def test_cleanup_other_errors_still_raise(monkeypatch):
     be, _calls = _scripted_backend(monkeypatch, [_Resp(500, "daemon exploded")])
     with pytest.raises(RuntimeError, match="daemon exploded"):

--- a/core/runtime/tests/test_docker_reclaim.py
+++ b/core/runtime/tests/test_docker_reclaim.py
@@ -1,0 +1,147 @@
+"""``DockerBackend.cleanup`` against a SCRIPTED daemon — the reclaim contract, no docker needed.
+
+The property under test: ``destroy`` may report ``destroyed`` only when the container is provably
+gone. A 409 "removal already in progress" means another remover (an operator's ``rm -f``, a GC,
+another deployment sharing the daemon) is finishing the reclaim — the reclaim is then judged by
+the container's ABSENCE, confirmed within a bounded window, never by whose DELETE won. Everything
+else keeps raising: an unconfirmed reclaim must never read as success.
+
+The daemon here is a scripted response sequence, so the concurrent remover is staged
+deterministically; ``test_docker_backend.py::test_docker_reclaim_races_a_real_concurrent_remover``
+stages the same race against a real daemon wherever docker is available.
+"""
+import pytest
+
+from runtime_kernel import docker_backend
+from runtime_kernel.backend import WorkloadHandle
+from runtime_kernel.docker_backend import DockerBackend
+
+
+class _Resp:
+    def __init__(self, status_code: int, text: str = ""):
+        self.status_code = status_code
+        self.text = text
+
+
+def _scripted_backend(monkeypatch, responses):
+    """A DockerBackend whose daemon plays back ``responses``, repeating the last one forever
+    (a container that lingers keeps answering the same inspect); returns (backend, calls-log).
+    Each call is logged as (method, path, timeout-or-None) so the poll's own bound is pinned."""
+    script = list(responses)
+    calls: list[tuple[str, str, object]] = []
+
+    def fake_req(self, method, path, **kw):
+        calls.append((method, path, kw.get("timeout")))
+        return script.pop(0) if len(script) > 1 else script[0]
+
+    monkeypatch.setattr(DockerBackend, "_req", fake_req)
+    monkeypatch.setattr(docker_backend, "_reclaim_sleep", lambda s: None)
+    return DockerBackend(), calls
+
+
+_H = WorkloadHandle("wl-1", "vexa-wl-1")
+
+
+def test_cleanup_returns_on_204_and_404(monkeypatch):
+    for code in (204, 404):
+        be, calls = _scripted_backend(monkeypatch, [_Resp(code)])
+        be.cleanup(_H)
+        assert calls == [("DELETE", "/containers/vexa-wl-1?force=true", None)]
+
+
+def test_cleanup_409_confirms_the_concurrent_removers_reclaim(monkeypatch):
+    # Staged race: our DELETE loses to another remover (409), the container lingers for one
+    # inspect, then is gone. cleanup returns success because ABSENCE was proven — not because
+    # our DELETE won.
+    be, calls = _scripted_backend(
+        monkeypatch,
+        [
+            _Resp(409, '{"message":"removal of container vexa-wl-1 is already in progress"}'),
+            _Resp(200),  # still being removed
+            _Resp(404),  # gone
+        ],
+    )
+    be.cleanup(_H)
+    # the poll's own 2s bound is part of the contract: _req's default 30s would let one
+    # stalled inspect stretch the confirm window far past its deadline
+    assert calls == [
+        ("DELETE", "/containers/vexa-wl-1?force=true", None),
+        ("GET", "/containers/vexa-wl-1/json", 2),
+        ("GET", "/containers/vexa-wl-1/json", 2),
+    ]
+
+
+def test_cleanup_409_keys_on_the_status_code_not_the_message(monkeypatch):
+    # The branch must never parse the daemon's message: a 409 with an empty or unfamiliar body
+    # takes the same confirm-absence path — success still requires the literal 404.
+    be, calls = _scripted_backend(monkeypatch, [_Resp(409, ""), _Resp(404)])
+    be.cleanup(_H)
+    assert calls == [
+        ("DELETE", "/containers/vexa-wl-1?force=true", None),
+        ("GET", "/containers/vexa-wl-1/json", 2),
+    ]
+
+
+def test_cleanup_409_with_a_container_that_never_leaves_raises(monkeypatch):
+    # The bounded window is the truthfulness line: a daemon that claims removal-in-progress
+    # while the container stays present must FAIL the reclaim, not report destroyed.
+    monkeypatch.setattr(docker_backend, "_reclaim_confirm_sec", lambda: 0.05)
+    be, calls = _scripted_backend(
+        monkeypatch,
+        [
+            _Resp(409, '{"message":"removal of container vexa-wl-1 is already in progress"}'),
+            _Resp(200),  # repeated forever — the container never leaves
+        ],
+    )
+    with pytest.raises(RuntimeError, match="still present"):
+        be.cleanup(_H)
+    # the window was spent POLLING, not merely waited out
+    assert calls[0] == ("DELETE", "/containers/vexa-wl-1?force=true", None)
+    assert ("GET", "/containers/vexa-wl-1/json", 2) in calls
+
+
+def test_cleanup_409_keeps_polling_through_a_daemon_blip(monkeypatch):
+    # A transient inspect failure mid-confirm is not a verdict: the poll continues and the
+    # later 404 still resolves the reclaim as success.
+    responses = [
+        _Resp(409, '{"message":"removal of container vexa-wl-1 is already in progress"}'),
+        ConnectionError("daemon restarting"),
+        _Resp(404),
+    ]
+    calls: list[tuple[str, str]] = []
+
+    def fake_req(self, method, path, **kw):
+        calls.append((method, path))
+        item = responses.pop(0) if len(responses) > 1 else responses[0]
+        if isinstance(item, Exception):
+            raise item
+        return item
+
+    monkeypatch.setattr(DockerBackend, "_req", fake_req)
+    monkeypatch.setattr(docker_backend, "_reclaim_sleep", lambda s: None)
+    DockerBackend().cleanup(_H)
+    assert len(calls) == 3
+
+
+def test_cleanup_409_with_the_daemon_gone_says_so_instead_of_claiming_presence(monkeypatch):
+    # When EVERY inspect fails, presence was never observed — the error must say the absence
+    # could not be confirmed, not send an operator hunting a phantom "still present" container.
+    monkeypatch.setattr(docker_backend, "_reclaim_confirm_sec", lambda: 0.05)
+    monkeypatch.setattr(docker_backend, "_reclaim_sleep", lambda s: None)
+    first = [True]
+
+    def fake_req(self, method, path, **kw):
+        if first[0]:
+            first[0] = False
+            return _Resp(409, '{"message":"removal of container vexa-wl-1 is already in progress"}')
+        raise ConnectionError("daemon gone")
+
+    monkeypatch.setattr(DockerBackend, "_req", fake_req)
+    with pytest.raises(RuntimeError, match="could not be confirmed"):
+        DockerBackend().cleanup(_H)
+
+
+def test_cleanup_other_errors_still_raise(monkeypatch):
+    be, _calls = _scripted_backend(monkeypatch, [_Resp(500, "daemon exploded")])
+    with pytest.raises(RuntimeError, match="daemon exploded"):
+        be.cleanup(_H)

--- a/docs/changelog.d/1579-docker-reclaim-409.md
+++ b/docs/changelog.d/1579-docker-reclaim-409.md
@@ -1,0 +1,6 @@
+- **`destroy` no longer fails when something else removes the container first (#1384).** The
+  docker backend treated the daemon's 409 "removal already in progress" as a failed reclaim, so
+  a concurrent remover — an operator's `docker rm -f`, a GC, another deployment sharing the
+  daemon — made teardown raise although the container was already going away. The reclaim is now
+  judged by the container's confirmed absence (bounded wait), and still fails loudly if the
+  container is genuinely stuck.


### PR DESCRIPTION
**Delivers issue:** #1384

## Contribution rights

- [x] **Independent:** I created this contribution, or otherwise have the right to submit it
  under Apache-2.0, and it is not owned or controlled by an employer, client, or other entity.
  <!-- rights:independent -->
- [ ] **Employer/client authorization required**
  <!-- rights:corporate -->
- [ ] **Unsure**
  <!-- rights:uncertain -->

The commit carries my DCO `Signed-off-by`.

## What & why

`DockerBackend.cleanup()` accepted only 204/404 from `DELETE ?force=true`, so the daemon's 409 `"removal of container … is already in progress"` — another remover finishing the same reclaim (an operator's `docker rm -f`, a GC, another deployment sharing the daemon) — made `destroy()` raise although the container was already going away (#1384 carries the full evidence chain).

The invariant the code states is kept, not weakened: truthfulness needs the container **gone**, not our DELETE to be the one that won. On 409 the reclaim is judged by confirmed absence — inspect until a literal 404, bounded by `RUNTIME_RECLAIM_CONFIRM_SEC` (default 10 s, floored at 1, mirroring `RUNTIME_STOP_GRACE_SEC`; declared in the runtime's config contract). The branch keys on the status code alone (no message parsing); each inspect carries a short timeout so one stalled request cannot stretch the bound; a transient inspect failure keeps polling instead of aborting the window; both ends of the race leave an operator breadcrumb (`warning` on entry, `info` with elapsed time on the confirming 404). A container still present at the deadline raises exactly like any other unconfirmed reclaim.

## Observation bundle

- **C1 — scripted daemon (deterministic staging)** · ran: `uv run pytest tests/test_docker_reclaim.py -q` · saw: **6 passed** — loser-confirms-absence (exact request sequence pinned), status-code-not-message (bare-body 409 takes the same path), never-leaves raises `"still present"` *and* provably polled, daemon-blip mid-confirm keeps polling to the 404, 204/404 fast paths and other-error raises unchanged · concluded: the contract holds without a daemon, in any CI; a message-parsing or no-poll mutant dies.
- **C2 — the real race, staged in-repo** · ran: `tests/test_docker_backend.py::test_docker_reclaim_races_a_real_concurrent_remover` (new; docker-gated like its siblings) 7× against a real daemon (docker 29.7.2) · saw: 7/7 passed, ~2–7 s each · concluded: the race is repeatable — a fat writable layer holds the removal window open, a competing `rm -f` gets a 0.5 s head start, cleanup must succeed with the container provably gone.
- **C3 — the 409 branch provably fires** (not a lucky race-free pass) · ran: the staged test 4× with every backend API call logged · saw, verbatim from the request log of passing runs:
  ```
  DELETE /containers/vexa-rt-reclaimtest-465941-880057?force=true -> 409
  GET    /containers/vexa-rt-reclaimtest-465941-880057/json       -> 404
  DELETE /containers/vexa-rt-reclaimtest-466390-08c113?force=true -> 409
  GET    /containers/vexa-rt-reclaimtest-466390-08c113/json       -> 404
  DELETE /containers/vexa-rt-reclaimtest-466808-274dce?force=true -> 409
  GET    /containers/vexa-rt-reclaimtest-466808-274dce/json       -> 404
  DELETE /containers/vexa-rt-reclaimtest-467119-e98362?force=true -> 409
  GET    /containers/vexa-rt-reclaimtest-467119-e98362/json       -> 404
  ```
  · concluded: 4/4 runs drew the 409 and resolved it by confirmed absence; on `main` each of these runs raises.
- **C4 — full suite** · ran: `uv run pytest -q -k "not real_pod"` · saw: **184 passed** (incl. both real-docker tests) · concluded: no adjacent regression. (`test_k8s_backend_real_pod_lifecycle` is a cold-cluster environment flake, untouched by this diff.)
- **C5 — gates** · pre-push static gates green, incl. `gate:config-contract` after declaring `RUNTIME_RECLAIM_CONFIRM_SEC` (the gate caught the undeclared read — the system working).

## Acceptance floor

| Row | Evidence |
|---|---|
| A1 (409 + gone ⇒ success) | `test_cleanup_409_confirms_the_concurrent_removers_reclaim` — exact request sequence asserted |
| A2 (status alone, never the message) | `test_cleanup_409_keys_on_the_status_code_not_the_message` — bare-body 409 |
| A3 (409 + never leaves ⇒ raise, and the window was spent polling) | `test_cleanup_409_with_a_container_that_never_leaves_raises` |
| A4 (transient inspect failure ≠ verdict) | `test_cleanup_409_keeps_polling_through_a_daemon_blip` |
| A5 (existing paths unchanged) | `test_cleanup_returns_on_204_and_404`, `test_cleanup_other_errors_still_raise` |
| A6 (real daemon, real remover, 409 proven) | `test_docker_reclaim_races_a_real_concurrent_remover` + the C3 request log |

## Docs diff (D6c)

`docs/changelog.d/1579-docker-reclaim-409.md` — the operator-visible change in the fragment convention. The new env knob is declared in `core/runtime/src/runtime_kernel/config.v1.json` beside its sibling grace knob.

## Security checks

No new dependencies; no lockfile change. The 409 path adds only read-only inspects against the same daemon socket; failure modes stay fail-loud; the destroy route notes it may now hold a threadpool slot for a few seconds (still never the event loop).

## Validation request

Any maintainer with docker: `uv run pytest tests/test_docker_backend.py -q` — the new staged-race test is red on `main` (409 → RuntimeError) and green here, no manual setup needed. Deployment validated: none (backend-internal); the live evidence above ran against a real daemon. Lite / compose / k8s / hosted honestly unclaimed.

## Authorship

Sole author: the human submitting this. No agent co-author trailers (D13).
Tooling disclosure: investigation, fix, and verification assisted by Claude Code; the request logs are from live runs against a real daemon.
