### PR TITLE
mcp: forward the Zoom join URL to the bots API — request_meeting_bot could never start a Zoom bot (#1630)

### DIFF
--- a/core/meetings/services/mcp/src/vexa_mcp/app.py
+++ b/core/meetings/services/mcp/src/vexa_mcp/app.py
@@ -281,7 +281,8 @@ class RequestMeetingBot(BaseModel):
             "The meeting identifier.\n"
             "- Google Meet: meeting code like 'abc-defg-hij'\n"
             "- Microsoft Teams: numeric meeting ID only (10-15 digits) from teams.live.com/meet/<id>\n"
-            "- Zoom: numeric meeting ID only (10-11 digits)\n"
+            "- Zoom: ALWAYS pass meeting_url (the full join link, host included) — meeting-api needs the\n"
+            "  host to build the join; a bare numeric id is rejected (422)\n"
             "- Jitsi: ALWAYS pass meeting_url (the full room URL) — a jitsi room is deployment-scoped,\n"
             "  so a bare room name is rejected (422); the id is derived from the URL"
         ),
@@ -294,7 +295,7 @@ class RequestMeetingBot(BaseModel):
         description=(
             "Meeting passcode.\n"
             "- Teams: passcode is the value of the `?p=` parameter in your Teams meeting link.\n"
-            "- Zoom: passcode is the value of the `?pwd=` parameter (optional).\n"
+            "- Zoom: taken from the `?pwd=` parameter of meeting_url; pass meeting_url, not the id.\n"
             "- Jitsi: the room password, when the room is protected (optional)."
         ),
     )
@@ -777,6 +778,13 @@ def create_app(
             # Forward raw URL for long Teams legacy links.
             if parsed.meeting_url:
                 payload["meeting_url"] = parsed.meeting_url
+            elif parsed.platform == "zoom":
+                # A Zoom join URL carries its host (us05web.zoom.us, a hosted front door such as
+                # zoom-lfx…), so meeting-api cannot construct one from the id and REFUSES a zoom
+                # request without meeting_url (bot_spawn/router.py → 422). The parser keeps
+                # meeting_url only for long Teams links and Jitsi; for Zoom, forward the caller's
+                # URL verbatim (#1630 — prod 2026-09-06: every Zoom request from an agent 422'd).
+                payload["meeting_url"] = meeting_url
             # Forward enterprise hostname for short Teams links.
             if parsed.teams_base_host:
                 payload["teams_base_host"] = parsed.teams_base_host

--- a/core/meetings/services/mcp/tests/test_app.py
+++ b/core/meetings/services/mcp/tests/test_app.py
@@ -90,6 +90,20 @@ def test_request_meeting_bot_with_url_parses_teams(client, gateway, auth):
     assert "meeting_url" not in body  # only legacy long Teams links forward the raw URL
 
 
+def test_request_meeting_bot_with_url_forwards_zoom_join_url(client, gateway, auth):
+    # #1630: meeting-api refuses a zoom request without meeting_url (the join URL carries its host),
+    # and the parser keeps meeting_url only for long Teams links and Jitsi — so the MCP must
+    # forward the caller's Zoom URL verbatim, or no agent can ever start a Zoom bot.
+    url = "https://us05web.zoom.us/j/87914358542?pwd=fdqOBxbHLR80RmXAPIvVhZVfnyROP1.1"
+    r = client.post("/request-meeting-bot", headers=auth, json={"meeting_url": url})
+    assert r.status_code == 200
+    body = gateway.last_json()
+    assert body["platform"] == "zoom"
+    assert body["native_meeting_id"] == "87914358542"
+    assert body["passcode"] == "fdqOBxbHLR80RmXAPIvVhZVfnyROP1.1"
+    assert body["meeting_url"] == url
+
+
 def test_request_meeting_bot_url_and_id_rejected(client, auth):
     r = client.post(
         "/request-meeting-bot",

--- a/docs/changelog.d/1630-mcp-zoom-meeting-url.md
+++ b/docs/changelog.d/1630-mcp-zoom-meeting-url.md
@@ -1,0 +1,4 @@
+- **MCP: `request_meeting_bot` can start a Zoom bot again (#1630).** The tool forwards the
+  caller's full Zoom join link to the bots API, which needs the link's host to join; before, it
+  kept only the numeric id and every Zoom request from an agent was refused with 422. Pass the
+  full `meeting_url` for Zoom, as for Jitsi.


### PR DESCRIPTION
Closes Vexa-ai/vexa#1630. Found by the v0.12.27 release witness on production (17:33Z): every Zoom request from an agent → meeting-api 422.

- `request_meeting_bot` now forwards the caller's Zoom join URL verbatim when the parser returns none (it keeps `meeting_url` only for long Teams links and Jitsi); meeting-api needs the URL's host to join and refuses a zoom request without it (`bot_spawn/router.py`).
- Tool descriptions: Zoom takes `meeting_url`, like Jitsi; the passcode comes from its `?pwd=`.
- Regression test: a Zoom link reaches `POST /bots` with platform, id, passcode and `meeting_url`.
- Changelog fragment `docs/changelog.d/1630-mcp-zoom-meeting-url.md`.

MCP suite: 140 passed locally (`uv run --frozen pytest tests/test_app.py tests/test_parse_meeting_link.py`).

Release: rides rc.4 with the seq-34 packet; the founder ruled this ships before the 0.12.27 publish.

COMMITMENTS IN THIS DRAFT — none.
<!-- vexa-agent -->

## Contribution rights
<!-- Select exactly ONE. This is a legal certification: an agent may explain the choices but
     must not select one for you. See CONTRIBUTOR_RIGHTS.md. -->

- [x] **Independent:** I created this contribution, or otherwise have the right to submit it
  under Apache-2.0, and it is not owned or controlled by an employer, client, or other entity.
  <!-- rights:independent -->
- [ ] **Employer/client authorization required:** an employer, client, or other entity owns or
  may control this contribution. I am requesting Vexa's private corporate-authorization process.
  <!-- rights:corporate -->
- [ ] **Unsure:** I need a private rights review before merge.
  <!-- rights:uncertain -->