### PR TITLE
feat(calendar_sync): read a user's calendar over the Google and Graph APIs, not just an ICS feed

### DIFF
--- a/core/meetings/services/meeting-api/src/meeting_api/calendar_sync/README.md
+++ b/core/meetings/services/meeting-api/src/meeting_api/calendar_sync/README.md
@@ -1,10 +1,25 @@
-# calendar_sync — ICS feed → planned meetings
+# calendar_sync — a user's calendar → planned meetings
 
-One concern: turn a user's secret ICS calendar feed into PLANNED meeting rows (intent status
-`scheduled`, complete `data.calendar_sources[].event` provenance) so the Meetings surface shows what's coming and the
-auto-join sweep sends the bot when each meeting starts. No OAuth — the user pastes the
-secret-address ICS URL Google Calendar / Outlook already provide (`PUT /user/calendar`, identity
-domain).
+One concern: turn a user's calendar into PLANNED meeting rows (intent status `scheduled`, complete
+`data.calendar_sources[].event` provenance) so the Meetings surface shows what's coming and the
+auto-join sweep sends the bot when each meeting starts.
+
+**How we learn the calendar is a READER, and there are three.** Everything below the reader — one
+row per UID, adoption by link, occurrence disposition, retirement — is identical in every case,
+because every reader emits the same `{"events": [PlannedEvent], "cancelled_uids": [uid]}`:
+
+| Reader | Input | The caller must |
+|---|---|---|
+| `parse_ics` | secret-address ICS feed text | — (expands RRULEs itself) |
+| `events_from_google` | Google Calendar `events.list` items | pass `singleEvents=true` + `showDeleted=true` |
+| `events_from_microsoft` | Graph `/calendarView` items | send `Prefer: outlook.timezone="UTC"` |
+
+The two API readers key on the series-stable UID (`iCalUID` / `iCalUId`) — the same value the feed
+carries — so **a calendar reconnected from ICS to OAuth adopts its existing rows instead of
+duplicating them.** That migration path is executed in `tests/test_calendar_providers.py`, not
+merely asserted. They also store a BOUNDED per-event snapshot rather than the ICS reader's
+unbounded property copy (`#1213` item 3), and they never read a naive timestamp in the server's
+local zone (`#1316`).
 
 ## Public surface
 - `parse_ics(text, now, horizon_days=14)` → `{"events": [PlannedEvent], "cancelled_uids": […]}`

--- a/core/meetings/services/meeting-api/src/meeting_api/calendar_sync/__init__.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/calendar_sync/__init__.py
@@ -1,10 +1,13 @@
-"""calendar_sync — ICS feed → planned meetings (see README.md).
+"""calendar_sync — a user's calendar → planned meetings (see README.md).
 
-Public surface: ``parse_ics`` / ``sync_user`` (pure logic), the production I/O adapters
-``fetch_ics`` / ``fetch_configs``, and the shared one-user pass ``run_user_sync`` (+ stamp
+Public surface: the READERS ``parse_ics`` / ``events_from_google`` / ``events_from_microsoft``,
+which all emit the same ``{"events": [...], "cancelled_uids": [...]}``; ``sync_user`` (the upsert
+pipeline, which cannot tell which reader produced its input); the production I/O adapters
+``fetch_ics`` / ``fetch_configs``; and the shared one-user pass ``run_user_sync`` (+ stamp
 helpers) used by BOTH the entrypoint's background poll loop and the user-facing sync-now edge.
 """
 from .adapters import build_ics_client, fetch_configs, fetch_ics
+from .providers import events_from_google, events_from_microsoft
 from .service import parse_ics, sync_user
 
 
@@ -16,6 +19,7 @@ def __getattr__(name):  # lazy: runner imports back from this package
     raise AttributeError(name)
 
 
-__all__ = ["parse_ics", "sync_user", "fetch_ics", "fetch_configs", "build_ics_client",
+__all__ = ["parse_ics", "events_from_google", "events_from_microsoft", "sync_user",
+           "fetch_ics", "fetch_configs", "build_ics_client",
            "run_user_sync", "aggregate_stamps", "store_stamp", "read_stamp",
            "active_configs"]

--- a/core/meetings/services/meeting-api/src/meeting_api/calendar_sync/provider_io.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/calendar_sync/provider_io.py
@@ -1,0 +1,191 @@
+"""Production I/O for the calendar-API readers — fetch a window of events, refresh a token.
+
+The counterpart to ``adapters.fetch_ics``: that one dereferences a user-supplied URL and so must
+ride the SSRF-pinned transport; these talk to two FIXED, known hosts, so the risk is inverted. What
+must never happen here is a user-controlled value (a calendar id) escaping into the URL and
+redirecting the request somewhere else — so ids are path-escaped and every request is built against
+a constant base, never string-concatenated from stored input.
+
+Error contract copied deliberately from ``fetch_ics``: every call returns ``(value, human_reason)``
+and never raises. The reason is USER-FACING — it becomes the connection's ``last_error`` and is
+shown in the calendar panel — so it names the actual problem in words the person who connected the
+calendar can act on ("reconnect", not "401").
+
+**Tokens are arguments, never state.** Nothing here reads a database or a secret store; the caller
+hands over an access token and gets events back. That keeps this module offline-testable and keeps
+the decrypt→use path in one place upstream, where it can be audited.
+
+Pagination is exhaustive but bounded: a calendar with an implausible number of events in a 14-day
+window is a bug or an attack, not a user, so the page loop stops at ``MAX_PAGES`` and says so rather
+than looping until the sweep's deadline.
+"""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Optional
+from urllib.parse import quote
+
+GOOGLE_EVENTS_URL = "https://www.googleapis.com/calendar/v3/calendars/{calendar_id}/events"
+GOOGLE_TOKEN_URL = "https://oauth2.googleapis.com/token"
+GRAPH_CALENDAR_VIEW_URL = "https://graph.microsoft.com/v1.0/me/calendarView"
+MICROSOFT_TOKEN_URL = "https://login.microsoftonline.com/common/oauth2/v2.0/token"
+
+# One sweep of one calendar. 250 events/page × 20 pages = 5000 events in a 14-day window; past that
+# we are not reading a person's calendar any more.
+PAGE_SIZE = 250
+MAX_PAGES = 20
+
+# The narrowest scopes that serve the product: read the events, and list which calendars exist.
+# Anything wider is a bigger consent prompt, a slower Google review, and more to lose if a token
+# leaks. We never write to a calendar, so no write scope is requested.
+GOOGLE_SCOPES = (
+    "https://www.googleapis.com/auth/calendar.events.readonly",
+    "https://www.googleapis.com/auth/calendar.calendarlist.readonly",
+)
+MICROSOFT_SCOPES = ("offline_access", "Calendars.Read")
+
+
+def build_client(*, timeout_s: float = 20.0):
+    """A plain httpx client for provider APIs — fixed hosts, so no SSRF pinning is needed here.
+
+    Redirects stay OFF: neither API redirects in normal operation, and following one would let a
+    compromised or misconfigured endpoint move an Authorization header to another host.
+    """
+    import httpx
+
+    return httpx.AsyncClient(timeout=timeout_s, follow_redirects=False)
+
+
+def _reason_for_status(status: int, *, provider: str) -> str:
+    """A status code → something the person who connected the calendar can act on."""
+    if status in (401, 403):
+        return (f"{provider} refused the stored authorization — reconnect the calendar to grant "
+                "access again")
+    if status == 404:
+        return "that calendar no longer exists, or the connected account can no longer see it"
+    if status == 429:
+        return f"{provider} is rate-limiting us — the next sync will retry"
+    if 500 <= status < 600:
+        return f"{provider} is having trouble ({status}) — the next sync will retry"
+    return f"{provider} answered HTTP {status}"
+
+
+async def _get_json(client, url: str, *, token: str, params: dict,
+                    provider: str, headers: Optional[dict] = None):
+    request_headers = {"Authorization": f"Bearer {token}"}
+    request_headers.update(headers or {})
+    try:
+        resp = await client.get(url, params=params, headers=request_headers)
+    except Exception:
+        return None, f"couldn't reach {provider} (unreachable or timed out)"
+    if resp.status_code != 200:
+        return None, _reason_for_status(resp.status_code, provider=provider)
+    try:
+        return resp.json(), None
+    except Exception:
+        return None, f"{provider} returned a response we couldn't read"
+
+
+async def fetch_google_events(client, *, access_token: str, calendar_id: str,
+                              window_start: datetime, window_end: datetime):
+    """Google Calendar events in the window → ``(items, None)`` or ``(None, human_reason)``.
+
+    ``singleEvents=true`` is not optional — it is what makes the provider expand recurrences, which
+    ``events_from_google`` relies on. ``showDeleted=true`` likewise: without it a cancelled instance
+    is merely absent, and absence and cancellation retire a row for different reasons.
+    """
+    url = GOOGLE_EVENTS_URL.format(calendar_id=quote(calendar_id, safe=""))
+    params: dict[str, Any] = {
+        "singleEvents": "true",
+        "showDeleted": "true",
+        "orderBy": "startTime",
+        "maxResults": PAGE_SIZE,
+        "timeMin": window_start.isoformat(),
+        "timeMax": window_end.isoformat(),
+    }
+    items: list = []
+    for _ in range(MAX_PAGES):
+        body, reason = await _get_json(client, url, token=access_token, params=params,
+                                       provider="Google Calendar")
+        if reason:
+            return None, reason
+        items.extend(body.get("items") or [])
+        token_next = body.get("nextPageToken")
+        if not token_next:
+            return items, None
+        params["pageToken"] = token_next
+    return None, "that calendar has more events than we can read in one sync"
+
+
+async def fetch_microsoft_events(client, *, access_token: str,
+                                 window_start: datetime, window_end: datetime):
+    """Graph calendarView in the window → ``(items, None)`` or ``(None, human_reason)``.
+
+    ``Prefer: outlook.timezone="UTC"`` matters: without it Graph answers in the mailbox's own zone
+    using WINDOWS zone ids ("Pacific Standard Time"), which are not IANA and do not load. The reader
+    falls back to UTC in that case, so the header is what keeps the fallback from being load-bearing.
+    """
+    params: dict[str, Any] = {
+        "startDateTime": window_start.isoformat(),
+        "endDateTime": window_end.isoformat(),
+        "$top": PAGE_SIZE,
+        "$orderby": "start/dateTime",
+    }
+    url = GRAPH_CALENDAR_VIEW_URL
+    items: list = []
+    for _ in range(MAX_PAGES):
+        body, reason = await _get_json(client, url, token=access_token, params=params,
+                                       provider="Outlook", headers={"Prefer": 'outlook.timezone="UTC"'})
+        if reason:
+            return None, reason
+        items.extend(body.get("value") or [])
+        next_link = body.get("@odata.nextLink")
+        if not next_link:
+            return items, None
+        # Graph's nextLink is a fully-formed absolute URL that already carries the query; passing
+        # our params alongside it would duplicate them.
+        if not next_link.startswith("https://graph.microsoft.com/"):
+            return None, "Outlook returned a paging link we don't trust"
+        url, params = next_link, {}
+    return None, "that calendar has more events than we can read in one sync"
+
+
+async def refresh_access_token(client, *, provider: str, refresh_token: str,
+                               client_id: str, client_secret: str):
+    """A refresh token → ``({access_token, expires_in}, None)`` or ``(None, human_reason)``.
+
+    A refresh that comes back ``invalid_grant`` is terminal, not transient: the user revoked access,
+    changed their password, or the token expired through disuse. The caller must surface that as
+    "reconnect", never retry it on a loop — retrying a dead grant is how an integration ends up
+    hammering an identity provider with a credential that will never work again.
+    """
+    url = GOOGLE_TOKEN_URL if provider == "google" else MICROSOFT_TOKEN_URL
+    form = {
+        "grant_type": "refresh_token",
+        "refresh_token": refresh_token,
+        "client_id": client_id,
+        "client_secret": client_secret,
+    }
+    if provider == "microsoft":
+        form["scope"] = " ".join(MICROSOFT_SCOPES)
+    try:
+        resp = await client.post(url, data=form)
+    except Exception:
+        return None, "couldn't reach the sign-in service to refresh the calendar connection"
+    if resp.status_code != 200:
+        detail = ""
+        try:
+            detail = str((resp.json() or {}).get("error") or "")
+        except Exception:
+            pass
+        if detail == "invalid_grant" or resp.status_code in (400, 401):
+            return None, "the calendar connection was revoked or expired — reconnect it"
+        return None, f"couldn't refresh the calendar connection (HTTP {resp.status_code})"
+    try:
+        body = resp.json()
+    except Exception:
+        return None, "the sign-in service returned a response we couldn't read"
+    access = body.get("access_token")
+    if not access:
+        return None, "the sign-in service returned no access token"
+    return {"access_token": access, "expires_in": body.get("expires_in")}, None

--- a/core/meetings/services/meeting-api/src/meeting_api/calendar_sync/providers.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/calendar_sync/providers.py
@@ -1,0 +1,353 @@
+"""Provider event JSON → the SAME PlannedEvent shape ``parse_ics`` produces.
+
+The ICS feed is one way to learn a user's calendar, not the concept. ``sync_user`` already owns
+every hard part — one row per UID, adoption by link, occurrence disposition, retirement — and it
+consumes a plain dict. So a calendar API is a new *reader*, not a new pipeline: these functions
+map Google Calendar and Microsoft Graph event payloads onto ``{"events": [...], "cancelled_uids":
+[...]}`` and nothing downstream can tell which reader produced them.
+
+Pure. No network, no tokens, no clock of their own — the caller passes ``now``, exactly as
+``parse_ics`` requires, so every mapping is testable offline against a fixture.
+
+**Recurrence is the provider's job here, not ours.** ``parse_ics`` expands RRULEs itself because a
+feed hands us a master plus overrides. Both APIs will expand for us when asked — Google with
+``singleEvents=true``, Graph via ``/calendarView`` — so the caller MUST request expanded instances.
+We then apply the same load-bearing rule ``parse_ics`` applies: **group by the series-stable id and
+keep only the earliest occurrence in the window.** Two scheduled rows on one native id would
+violate ``uq_meeting_active_user_platform_native``.
+
+The series-stable id is the UID, deliberately: Google's ``iCalUID`` and Graph's ``iCalUId`` are the
+same value the ICS feed would have carried for that event, so **a calendar reconnected over OAuth
+adopts the rows its ICS feed created** instead of duplicating them. Instance ids
+(``event['id']``, which differs per occurrence) would have re-imported the user's whole calendar.
+
+**Snapshot policy — deliberately narrower than the ICS reader.** ``parse_ics`` copies every VEVENT
+property into ``metadata.component``; that unbounded copy of arbitrary provider properties is a
+known open residual (Vexa-ai/vexa#1213 item 3, "no test that the VEVENT snapshot is redacted"). A
+calendar API returns far more per event than a feed does — extended properties, attachments, ACL
+hints — so these readers store a BOUNDED snapshot: the fields we use, plus a short allowlist,
+and nothing else. Anything not listed never enters the row.
+"""
+from __future__ import annotations
+
+import re
+from datetime import date, datetime, time, timedelta, timezone
+from typing import Any, Iterable, Optional
+
+from ..collector.meeting_link import find_meeting_link
+from .service import DEFAULT_HORIZON_DAYS, DEFAULT_LOOKBACK_S
+
+# Per-event fields carried into ``metadata.component``. Everything else in the provider payload is
+# dropped — see the snapshot-policy note above. Keep these lists SHORT and boring.
+GOOGLE_SNAPSHOT_KEYS = (
+    "id", "iCalUID", "status", "summary", "description", "location", "created", "updated",
+    "recurringEventId", "originalStartTime", "hangoutLink", "htmlLink", "eventType",
+    "transparency", "visibility", "organizer", "creator", "start", "end",
+)
+MICROSOFT_SNAPSHOT_KEYS = (
+    "id", "iCalUId", "subject", "bodyPreview", "createdDateTime", "lastModifiedDateTime",
+    "seriesMasterId", "type", "isCancelled", "isAllDay", "showAs", "sensitivity",
+    "webLink", "onlineMeetingProvider", "organizer", "start", "end", "location",
+)
+
+# ICS PARTSTAT is the vocabulary every downstream consumer already reads (``_attendees`` lowercases
+# it). Both providers get folded onto it so nothing downstream has to know who answered.
+_GOOGLE_PARTSTAT = {
+    "accepted": "accepted", "declined": "declined",
+    "tentative": "tentative", "needsaction": "needs-action",
+}
+_MICROSOFT_PARTSTAT = {
+    "accepted": "accepted", "organizer": "accepted",
+    "declined": "declined",
+    "tentativelyaccepted": "tentative",
+    "notresponded": "needs-action", "none": "needs-action",
+}
+
+
+def _fold_fraction(text: str) -> str:
+    """Graph emits 7-digit fractional seconds (``17:00:00.0000000``); ``fromisoformat`` wants ≤6."""
+    return re.sub(r"(\.\d{6})\d+", r"\1", text)
+
+
+def _iso_to_utc(value: Any, *, tz_name: Optional[str] = None) -> Optional[datetime]:
+    """An ISO-8601 string → tz-aware UTC datetime, or ``None`` if it is not one.
+
+    A value carrying its own offset wins outright. A NAIVE value is resolved against ``tz_name``
+    when that names a zone we can load, and otherwise is read as **UTC** — never as the server's
+    local time, which is the defect Vexa-ai/vexa#1316 and backlog R-B10 both describe. Reading it
+    as UTC can be wrong by an offset; reading it as local time is wrong by wherever the pod runs,
+    which changes under us and cannot be reproduced.
+    """
+    if isinstance(value, datetime):
+        return value.astimezone(timezone.utc) if value.tzinfo else value.replace(tzinfo=timezone.utc)
+    if not isinstance(value, str) or not value.strip():
+        return None
+    text = _fold_fraction(value.strip())
+    if text.endswith(("Z", "z")):
+        text = text[:-1] + "+00:00"
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    if parsed.tzinfo is not None:
+        return parsed.astimezone(timezone.utc)
+    zone = _load_zone(tz_name)
+    return parsed.replace(tzinfo=zone).astimezone(timezone.utc)
+
+
+def _load_zone(tz_name: Optional[str]):
+    """``tz_name`` → a tzinfo, defaulting to UTC. Windows zone ids (Graph's default vocabulary,
+    e.g. "Pacific Standard Time") are not IANA and do not load; the caller is expected to send
+    ``Prefer: outlook.timezone="UTC"`` so this stays the uninteresting path."""
+    if not tz_name or tz_name.strip().upper() == "UTC":
+        return timezone.utc
+    try:
+        from zoneinfo import ZoneInfo
+
+        return ZoneInfo(tz_name.strip())
+    except Exception:
+        return timezone.utc
+
+
+def _all_day_to_utc(value: Any) -> Optional[datetime]:
+    """An all-day ``YYYY-MM-DD`` → midnight UTC, mirroring ``service._as_utc``'s date branch."""
+    if isinstance(value, date) and not isinstance(value, datetime):
+        return datetime.combine(value, time(0, 0), tzinfo=timezone.utc)
+    if isinstance(value, str):
+        try:
+            return datetime.combine(date.fromisoformat(value.strip()), time(0, 0), tzinfo=timezone.utc)
+        except ValueError:
+            return None
+    return None
+
+
+def _snapshot(event: dict, keys: Iterable[str]) -> dict:
+    """The bounded per-event snapshot — listed keys only, in a stable order."""
+    return {k: event[k] for k in keys if k in event and event[k] is not None}
+
+
+def _first_link(*sources: Any):
+    """The first recognizable meeting link across the given text sources, in priority order."""
+    for source in sources:
+        if not source:
+            continue
+        link = find_meeting_link(source if isinstance(source, str) else str(source))
+        if link:
+            return link
+    return None
+
+
+def _emit(uid: str, *, title: Optional[str], occurrence: datetime, link,
+          attendees: list[dict], metadata: dict) -> dict:
+    """One PlannedEvent, shaped exactly as ``parse_ics`` emits it."""
+    platform, native_id, url = link if link else (None, None, None)
+    return {
+        "uid": uid,
+        "title": (title or "").strip() or None,
+        "scheduled_at": occurrence.isoformat(),
+        "platform": platform,
+        "native_meeting_id": native_id,
+        "meeting_url": url,
+        "attendees": attendees,
+        "metadata": metadata,
+    }
+
+
+def _resolve(groups: dict, order: list, cancelled_only: dict) -> tuple[list, list]:
+    """Group → (earliest live occurrence per uid, uids whose every in-window instance is cancelled).
+
+    Mirrors ``parse_ics``: a single cancelled occurrence never retires the series — the uid is
+    retired only when nothing live remains in the window. A uid that vanished from the payload
+    entirely is not our problem; ``sync_user`` retires those on its own.
+    """
+    events: list[dict] = []
+    cancelled: list[str] = []
+    for uid in order:
+        live = groups.get(uid) or []
+        if live:
+            events.append(min(live, key=lambda ev: ev["_occurrence"]))
+        elif cancelled_only.get(uid):
+            cancelled.append(uid)
+    for ev in events:
+        ev.pop("_occurrence", None)
+    return events, cancelled
+
+
+def events_from_google(items: list, *, now: datetime,
+                       horizon_days: int = DEFAULT_HORIZON_DAYS,
+                       lookback_s: float = DEFAULT_LOOKBACK_S,
+                       calendar: Optional[dict] = None) -> dict:
+    """Google Calendar ``events.list`` items → ``{"events": [...], "cancelled_uids": [...]}``.
+
+    The caller MUST have requested ``singleEvents=true`` (so recurrences arrive expanded) and
+    ``showDeleted=true`` (so a cancelled instance is visible rather than merely absent).
+    """
+    window_start = now - timedelta(seconds=lookback_s)
+    window_end = now + timedelta(days=horizon_days)
+    calendar_metadata = dict(calendar or {})
+    groups: dict[str, list] = {}
+    cancelled_only: dict[str, bool] = {}
+    order: list[str] = []
+
+    for item in items or []:
+        if not isinstance(item, dict):
+            continue
+        uid = str(item.get("iCalUID") or item.get("id") or "").strip()
+        if not uid:
+            continue
+        start = item.get("start") or {}
+        occurrence = (_iso_to_utc(start.get("dateTime"), tz_name=start.get("timeZone"))
+                      or _all_day_to_utc(start.get("date")))
+        if occurrence is None or not (window_start <= occurrence <= window_end):
+            continue
+        if uid not in groups:
+            groups[uid] = []
+            order.append(uid)
+        if str(item.get("status") or "").lower() == "cancelled":
+            cancelled_only[uid] = cancelled_only.get(uid, True)
+            continue
+        cancelled_only[uid] = False
+
+        link = _first_link(item.get("hangoutLink"),
+                           *_google_conference_uris(item),
+                           item.get("location"), item.get("description"))
+        event = _emit(
+            uid,
+            title=item.get("summary"),
+            occurrence=occurrence,
+            link=link,
+            attendees=_google_attendees(item.get("attendees")),
+            metadata={
+                "provider": "google",
+                "resolved_start": occurrence.isoformat(),
+                "calendar": calendar_metadata,
+                "component": _snapshot(item, GOOGLE_SNAPSHOT_KEYS),
+            },
+        )
+        event["_occurrence"] = occurrence
+        groups[uid].append(event)
+
+    events, cancelled = _resolve(groups, order, cancelled_only)
+    return {"events": events, "cancelled_uids": cancelled}
+
+
+def _google_conference_uris(item: dict) -> list:
+    """Video entry points from ``conferenceData`` — the structured equivalent of
+    X-GOOGLE-CONFERENCE, and the only place a Meet link lives for some event shapes."""
+    data = item.get("conferenceData") or {}
+    points = data.get("entryPoints") or []
+    return [p.get("uri") for p in points
+            if isinstance(p, dict) and p.get("entryPointType") in (None, "video") and p.get("uri")]
+
+
+def _google_attendees(raw: Any) -> list[dict]:
+    """Google attendees → ``[{email, name?, partstat?}]``, matching ``service._attendees``.
+
+    Rooms and equipment (``resource: true``) are dropped, emails lowercased, order preserved,
+    duplicates collapsed — the same contract the ICS reader promises.
+    """
+    out: list[dict] = []
+    seen: set[str] = set()
+    for a in raw or []:
+        if not isinstance(a, dict) or a.get("resource"):
+            continue
+        email = str(a.get("email") or "").strip().lower()
+        if "@" not in email or email in seen:
+            continue
+        seen.add(email)
+        entry: dict = {"email": email}
+        name = str(a.get("displayName") or "").strip()
+        if name and name.lower() != email:
+            entry["name"] = name
+        partstat = _GOOGLE_PARTSTAT.get(str(a.get("responseStatus") or "").strip().lower())
+        if partstat:
+            entry["partstat"] = partstat
+        out.append(entry)
+    return out
+
+
+def events_from_microsoft(items: list, *, now: datetime,
+                          horizon_days: int = DEFAULT_HORIZON_DAYS,
+                          lookback_s: float = DEFAULT_LOOKBACK_S,
+                          calendar: Optional[dict] = None) -> dict:
+    """Microsoft Graph ``/calendarView`` items → the same shape.
+
+    ``/calendarView`` (not ``/events``) is required: it expands a series into occurrences, which is
+    what the one-row-per-uid rule needs. Send ``Prefer: outlook.timezone="UTC"`` so ``start.dateTime``
+    arrives naive-UTC rather than in a Windows zone id we cannot resolve.
+    """
+    window_start = now - timedelta(seconds=lookback_s)
+    window_end = now + timedelta(days=horizon_days)
+    calendar_metadata = dict(calendar or {})
+    groups: dict[str, list] = {}
+    cancelled_only: dict[str, bool] = {}
+    order: list[str] = []
+
+    for item in items or []:
+        if not isinstance(item, dict):
+            continue
+        uid = str(item.get("iCalUId") or item.get("iCalUid") or item.get("id") or "").strip()
+        if not uid:
+            continue
+        start = item.get("start") or {}
+        occurrence = _iso_to_utc(start.get("dateTime"), tz_name=start.get("timeZone"))
+        if occurrence is None and item.get("isAllDay"):
+            occurrence = _all_day_to_utc(str(start.get("dateTime") or "")[:10])
+        if occurrence is None or not (window_start <= occurrence <= window_end):
+            continue
+        if uid not in groups:
+            groups[uid] = []
+            order.append(uid)
+        if item.get("isCancelled") is True:
+            cancelled_only[uid] = cancelled_only.get(uid, True)
+            continue
+        cancelled_only[uid] = False
+
+        online = item.get("onlineMeeting") or {}
+        location = item.get("location") or {}
+        body = item.get("body") or {}
+        link = _first_link(online.get("joinUrl"), item.get("onlineMeetingUrl"),
+                           location.get("displayName"), item.get("bodyPreview"),
+                           body.get("content"))
+        event = _emit(
+            uid,
+            title=item.get("subject"),
+            occurrence=occurrence,
+            link=link,
+            attendees=_microsoft_attendees(item.get("attendees")),
+            metadata={
+                "provider": "microsoft",
+                "resolved_start": occurrence.isoformat(),
+                "calendar": calendar_metadata,
+                "component": _snapshot(item, MICROSOFT_SNAPSHOT_KEYS),
+            },
+        )
+        event["_occurrence"] = occurrence
+        groups[uid].append(event)
+
+    events, cancelled = _resolve(groups, order, cancelled_only)
+    return {"events": events, "cancelled_uids": cancelled}
+
+
+def _microsoft_attendees(raw: Any) -> list[dict]:
+    """Graph attendees → ``[{email, name?, partstat?}]``. ``type: "resource"`` is a room."""
+    out: list[dict] = []
+    seen: set[str] = set()
+    for a in raw or []:
+        if not isinstance(a, dict) or str(a.get("type") or "").lower() == "resource":
+            continue
+        address = (a.get("emailAddress") or {}) if isinstance(a.get("emailAddress"), dict) else {}
+        email = str(address.get("address") or "").strip().lower()
+        if "@" not in email or email in seen:
+            continue
+        seen.add(email)
+        entry: dict = {"email": email}
+        name = str(address.get("name") or "").strip()
+        if name and name.lower() != email:
+            entry["name"] = name
+        status = (a.get("status") or {}) if isinstance(a.get("status"), dict) else {}
+        partstat = _MICROSOFT_PARTSTAT.get(str(status.get("response") or "").strip().lower())
+        if partstat:
+            entry["partstat"] = partstat
+        out.append(entry)
+    return out

--- a/core/meetings/services/meeting-api/tests/test_calendar_provider_io.py
+++ b/core/meetings/services/meeting-api/tests/test_calendar_provider_io.py
@@ -1,0 +1,254 @@
+"""provider_io — fetching a window of events and refreshing a token, offline.
+
+Driven through a stub client rather than a live API. What is pinned here is the stuff that bites in
+production: the query parameters the readers depend on, pagination, and — most of all — that every
+failure comes back as a sentence the person who connected the calendar can act on, never a raised
+exception that kills the sweep for everyone else.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from meeting_api.calendar_sync.provider_io import (
+    GOOGLE_SCOPES,
+    MAX_PAGES,
+    fetch_google_events,
+    fetch_microsoft_events,
+    refresh_access_token,
+)
+
+START = datetime(2026, 9, 6, 12, 0, 0, tzinfo=timezone.utc)
+END = START + timedelta(days=14)
+
+
+class Response:
+    def __init__(self, status=200, body=None, boom=False):
+        self.status_code = status
+        self._body = body if body is not None else {}
+        self._boom = boom
+
+    def json(self):
+        if self._boom:
+            raise ValueError("not json")
+        return self._body
+
+
+class StubClient:
+    """Records what was asked for and replays queued responses."""
+
+    def __init__(self, *responses):
+        self._queue = list(responses)
+        self.calls: list[dict] = []
+
+    async def get(self, url, params=None, headers=None):
+        self.calls.append({"url": url, "params": params or {}, "headers": headers or {}})
+        return self._next()
+
+    async def post(self, url, data=None):
+        self.calls.append({"url": url, "data": data or {}})
+        return self._next()
+
+    def _next(self):
+        if not self._queue:
+            raise AssertionError("stub client ran out of responses")
+        item = self._queue.pop(0)
+        if isinstance(item, Exception):
+            raise item
+        return item
+
+
+class DeadClient:
+    async def get(self, *a, **k):
+        raise ConnectionError("down")
+
+    async def post(self, *a, **k):
+        raise ConnectionError("down")
+
+
+# ------------------------------------------------------------------ the request the readers need
+
+async def test_google_asks_the_provider_to_expand_recurrences_and_show_cancellations():
+    """events_from_google depends on both. Drop either and recurring meetings or retirements break,
+    silently and only in production."""
+    client = StubClient(Response(body={"items": [{"id": "a"}]}))
+
+    items, reason = await fetch_google_events(
+        client, access_token="tok", calendar_id="primary", window_start=START, window_end=END)
+
+    assert reason is None and items == [{"id": "a"}]
+    params = client.calls[0]["params"]
+    assert params["singleEvents"] == "true"
+    assert params["showDeleted"] == "true"
+    assert params["timeMin"] == START.isoformat()
+    assert params["timeMax"] == END.isoformat()
+    assert client.calls[0]["headers"]["Authorization"] == "Bearer tok"
+
+
+async def test_a_calendar_id_cannot_escape_into_the_url():
+    """Calendar ids are stored user input. Un-escaped, one containing ../ or a query would point
+    the authenticated request somewhere else."""
+    client = StubClient(Response(body={"items": []}))
+
+    await fetch_google_events(client, access_token="tok",
+                              calendar_id="../../tokeninfo?x=", window_start=START, window_end=END)
+
+    url = client.calls[0]["url"]
+    assert url.startswith("https://www.googleapis.com/calendar/v3/calendars/")
+    assert "../" not in url and "?" not in url
+
+
+async def test_microsoft_pins_the_timezone_so_the_readers_fallback_is_not_load_bearing():
+    """Without this header Graph answers in Windows zone ids, which are not IANA and do not load."""
+    client = StubClient(Response(body={"value": []}))
+
+    await fetch_microsoft_events(client, access_token="tok", window_start=START, window_end=END)
+
+    assert client.calls[0]["headers"]["Prefer"] == 'outlook.timezone="UTC"'
+
+
+# ------------------------------------------------------------------------------------ pagination
+
+async def test_google_follows_every_page():
+    client = StubClient(
+        Response(body={"items": [{"id": "1"}], "nextPageToken": "p2"}),
+        Response(body={"items": [{"id": "2"}]}),
+    )
+
+    items, reason = await fetch_google_events(
+        client, access_token="tok", calendar_id="primary", window_start=START, window_end=END)
+
+    assert reason is None
+    assert [i["id"] for i in items] == ["1", "2"]
+    assert client.calls[1]["params"]["pageToken"] == "p2"
+
+
+async def test_graph_follows_its_next_link_without_re_sending_our_params():
+    """The nextLink already carries the full query; sending ours alongside duplicates them."""
+    client = StubClient(
+        Response(body={"value": [{"id": "1"}],
+                       "@odata.nextLink": "https://graph.microsoft.com/v1.0/me/calendarView?$skip=250"}),
+        Response(body={"value": [{"id": "2"}]}),
+    )
+
+    items, reason = await fetch_microsoft_events(
+        client, access_token="tok", window_start=START, window_end=END)
+
+    assert reason is None and [i["id"] for i in items] == ["1", "2"]
+    assert client.calls[1]["params"] == {}
+
+
+async def test_a_paging_link_to_another_host_is_refused():
+    """The nextLink is remote input and it is followed with an Authorization header attached."""
+    client = StubClient(Response(body={"value": [], "@odata.nextLink": "https://evil.example/steal"}))
+
+    items, reason = await fetch_microsoft_events(
+        client, access_token="tok", window_start=START, window_end=END)
+
+    assert items is None
+    assert "don't trust" in reason
+    assert len(client.calls) == 1, "the second request must never have been made"
+
+
+async def test_endless_pagination_stops_rather_than_eating_the_sweep():
+    pages = [Response(body={"items": [], "nextPageToken": f"p{i}"}) for i in range(MAX_PAGES + 2)]
+    client = StubClient(*pages)
+
+    items, reason = await fetch_google_events(
+        client, access_token="tok", calendar_id="primary", window_start=START, window_end=END)
+
+    assert items is None
+    assert "more events than we can read" in reason
+    assert len(client.calls) == MAX_PAGES
+
+
+# -------------------------------------------------------------- failures are sentences, not raises
+
+async def test_an_expired_authorization_tells_the_user_to_reconnect():
+    for status in (401, 403):
+        items, reason = await fetch_google_events(
+            StubClient(Response(status=status)), access_token="tok", calendar_id="primary",
+            window_start=START, window_end=END)
+        assert items is None
+        assert "reconnect" in reason
+
+
+async def test_a_deleted_calendar_says_so_rather_than_saying_401():
+    items, reason = await fetch_google_events(
+        StubClient(Response(status=404)), access_token="tok", calendar_id="gone",
+        window_start=START, window_end=END)
+    assert items is None
+    assert "no longer exists" in reason
+
+
+async def test_rate_limiting_and_provider_outages_read_as_transient():
+    for status in (429, 500, 503):
+        _, reason = await fetch_microsoft_events(
+            StubClient(Response(status=status)), access_token="tok",
+            window_start=START, window_end=END)
+        assert "retry" in reason
+
+
+async def test_an_unreachable_provider_never_raises_into_the_sweep():
+    """One user's dead network must not stall every other user's calendar."""
+    items, reason = await fetch_google_events(
+        DeadClient(), access_token="tok", calendar_id="primary",
+        window_start=START, window_end=END)
+    assert items is None and "couldn't reach" in reason
+
+
+async def test_an_unreadable_body_is_a_reason_not_a_traceback():
+    items, reason = await fetch_google_events(
+        StubClient(Response(boom=True)), access_token="tok", calendar_id="primary",
+        window_start=START, window_end=END)
+    assert items is None and "couldn't read" in reason
+
+
+# ----------------------------------------------------------------------------------- token refresh
+
+async def test_a_refresh_returns_the_new_access_token():
+    client = StubClient(Response(body={"access_token": "new", "expires_in": 3599}))
+
+    token, reason = await refresh_access_token(
+        client, provider="google", refresh_token="r", client_id="cid", client_secret="sec")
+
+    assert reason is None
+    assert token == {"access_token": "new", "expires_in": 3599}
+    assert client.calls[0]["data"]["grant_type"] == "refresh_token"
+
+
+async def test_a_revoked_grant_is_terminal_and_says_reconnect():
+    """invalid_grant means revoked, password-changed, or expired through disuse. Retrying it on a
+    loop hammers the identity provider with a credential that will never work again."""
+    client = StubClient(Response(status=400, body={"error": "invalid_grant"}))
+
+    token, reason = await refresh_access_token(
+        client, provider="google", refresh_token="r", client_id="cid", client_secret="sec")
+
+    assert token is None
+    assert "reconnect" in reason
+
+
+async def test_microsoft_refresh_resends_the_scopes_it_needs():
+    """Graph drops offline_access on refresh unless it is asked for again — lose it and the NEXT
+    refresh has no refresh token to use."""
+    client = StubClient(Response(body={"access_token": "new"}))
+
+    await refresh_access_token(client, provider="microsoft", refresh_token="r",
+                               client_id="cid", client_secret="sec")
+
+    assert "offline_access" in client.calls[0]["data"]["scope"]
+
+
+async def test_a_refresh_against_a_dead_network_is_a_reason_not_a_raise():
+    token, reason = await refresh_access_token(
+        DeadClient(), provider="google", refresh_token="r", client_id="c", client_secret="s")
+    assert token is None and "couldn't reach" in reason
+
+
+# ------------------------------------------------------------------------------------------ scopes
+
+def test_we_ask_for_read_only_scopes_and_nothing_wider():
+    """A wider scope is a bigger consent prompt, a slower Google review, and more to lose if a
+    token leaks. We never write to a calendar."""
+    assert all(s.endswith(".readonly") for s in GOOGLE_SCOPES)
+    assert not any("events" == s.rsplit("/", 1)[-1] for s in GOOGLE_SCOPES)

--- a/core/meetings/services/meeting-api/tests/test_calendar_providers.py
+++ b/core/meetings/services/meeting-api/tests/test_calendar_providers.py
@@ -1,0 +1,329 @@
+"""calendar_sync.providers — Google/Graph event JSON → the SAME PlannedEvent shape as parse_ics.
+
+The point of these readers is that ``sync_user`` cannot tell which one produced its input, so the
+tests that matter most are the PARITY ones: same keys, same attendee vocabulary, same one-row-per-uid
+rule, same "a link-less event still imports" rule. Pure and offline — no network, no tokens.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from meeting_api.calendar_sync.providers import events_from_google, events_from_microsoft
+from meeting_api.calendar_sync import parse_ics, sync_user
+from meeting_api.collector.fakes import InMemoryTranscriptStore
+
+NOW = datetime(2026, 9, 6, 12, 0, 0, tzinfo=timezone.utc)
+MEET = "https://meet.google.com/abc-defg-hij"
+TEAMS = ("https://teams.microsoft.com/l/meetup-join/"
+         "19%3ameeting_NTk0ZjExMjMtNDU2Nw%40thread.v2/0?context=%7b%22Tid%22%3a%22x%22%7d")
+ZOOM = "https://zoom.us/j/1234567890"
+
+
+def g_event(**over) -> dict:
+    base = {
+        "id": "instance-1",
+        "iCalUID": "series-a@google.com",
+        "status": "confirmed",
+        "summary": "Weekly sync",
+        "start": {"dateTime": "2026-09-06T13:00:00Z"},
+        "end": {"dateTime": "2026-09-06T13:30:00Z"},
+        "hangoutLink": MEET,
+    }
+    base.update(over)
+    return base
+
+
+def m_event(**over) -> dict:
+    base = {
+        "id": "AAMk-instance-1",
+        "iCalUId": "040000008200E00074C5B7101A82E008",
+        "subject": "Weekly sync",
+        "start": {"dateTime": "2026-09-06T13:00:00.0000000", "timeZone": "UTC"},
+        "end": {"dateTime": "2026-09-06T13:30:00.0000000", "timeZone": "UTC"},
+        "onlineMeeting": {"joinUrl": TEAMS},
+    }
+    base.update(over)
+    return base
+
+
+# ---------------------------------------------------------------- shape parity with the ICS reader
+
+ICS = """BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VEVENT
+UID:series-a@google.com
+SUMMARY:Weekly sync
+DTSTART:20260906T130000Z
+DTEND:20260906T133000Z
+LOCATION:https://meet.google.com/abc-defg-hij
+ATTENDEE;CN=Ann;PARTSTAT=ACCEPTED:mailto:ann@example.com
+END:VEVENT
+END:VCALENDAR
+"""
+
+
+def test_every_reader_emits_the_same_planned_event_keys():
+    """If these drift, sync_user starts behaving differently depending on who read the calendar."""
+    ics = parse_ics(ICS, now=NOW)["events"][0]
+    google = events_from_google([g_event(
+        attendees=[{"email": "ann@example.com", "displayName": "Ann", "responseStatus": "accepted"}],
+    )], now=NOW)["events"][0]
+    microsoft = events_from_microsoft([m_event(
+        attendees=[{"type": "required", "status": {"response": "accepted"},
+                    "emailAddress": {"address": "ann@example.com", "name": "Ann"}}],
+    )], now=NOW)["events"][0]
+
+    assert set(google) == set(ics)
+    assert set(microsoft) == set(ics)
+    # and the attendee vocabulary is the ICS one, not each provider's
+    assert ics["attendees"] == [{"email": "ann@example.com", "name": "Ann", "partstat": "accepted"}]
+    assert google["attendees"] == ics["attendees"]
+    assert microsoft["attendees"] == ics["attendees"]
+
+
+def test_google_uses_the_series_uid_so_an_ics_row_is_adopted_not_duplicated():
+    """iCalUID is the value the feed carried. Keying on event['id'] (per-occurrence) would
+    re-import every meeting the user already had from ICS."""
+    ics_uid = parse_ics(ICS, now=NOW)["events"][0]["uid"]
+    assert events_from_google([g_event()], now=NOW)["events"][0]["uid"] == ics_uid
+
+
+# ------------------------------------------------------------------- one row per uid, next occurrence
+
+def test_google_keeps_only_the_earliest_in_window_occurrence_of_a_series():
+    later = g_event(id="instance-3", start={"dateTime": "2026-09-20T13:00:00Z"})
+    soon = g_event(id="instance-2", start={"dateTime": "2026-09-13T13:00:00Z"})
+    out = events_from_google([later, soon], now=NOW)
+
+    assert len(out["events"]) == 1
+    assert out["events"][0]["scheduled_at"] == "2026-09-13T13:00:00+00:00"
+
+
+def test_microsoft_keeps_only_the_earliest_in_window_occurrence_of_a_series():
+    later = m_event(id="i3", start={"dateTime": "2026-09-15T09:00:00.0000000", "timeZone": "UTC"})
+    soon = m_event(id="i2", start={"dateTime": "2026-09-08T09:00:00.0000000", "timeZone": "UTC"})
+    out = events_from_microsoft([later, soon], now=NOW)
+
+    assert len(out["events"]) == 1
+    assert out["events"][0]["scheduled_at"] == "2026-09-08T09:00:00+00:00"
+
+
+def test_events_beyond_the_horizon_are_left_for_a_later_sweep():
+    assert events_from_google([g_event(start={"dateTime": "2026-10-30T13:00:00Z"})],
+                              now=NOW)["events"] == []
+    assert events_from_microsoft([m_event(start={"dateTime": "2026-10-30T09:00:00.0000000",
+                                                 "timeZone": "UTC"})], now=NOW)["events"] == []
+
+
+def test_a_started_meeting_still_imports_inside_the_lookback():
+    """The auto-join grace window depends on a just-started occurrence staying visible."""
+    started = g_event(start={"dateTime": "2026-09-06T11:55:00Z"})
+    assert len(events_from_google([started], now=NOW)["events"]) == 1
+
+
+# --------------------------------------------------------------------------------- cancellation
+
+def test_one_cancelled_occurrence_never_retires_the_whole_series():
+    cancelled = g_event(id="i2", status="cancelled",
+                        start={"dateTime": "2026-09-06T13:00:00Z"})
+    live = g_event(id="i3", start={"dateTime": "2026-09-13T13:00:00Z"})
+    out = events_from_google([cancelled, live], now=NOW)
+
+    assert out["cancelled_uids"] == []
+    assert len(out["events"]) == 1
+    assert out["events"][0]["scheduled_at"] == "2026-09-13T13:00:00+00:00"
+
+
+def test_a_series_with_nothing_live_left_in_the_window_is_retired():
+    out = events_from_google([g_event(status="cancelled")], now=NOW)
+    assert out["events"] == []
+    assert out["cancelled_uids"] == ["series-a@google.com"]
+
+
+def test_microsoft_is_cancelled_retires_the_same_way():
+    out = events_from_microsoft([m_event(isCancelled=True)], now=NOW)
+    assert out["events"] == []
+    assert out["cancelled_uids"] == ["040000008200E00074C5B7101A82E008"]
+
+
+# ---------------------------------------------------------------------------------- link finding
+
+def test_google_link_priority_conference_then_location_then_description():
+    from_conference = g_event(hangoutLink=None, conferenceData={
+        "entryPoints": [{"entryPointType": "phone", "uri": "tel:+1-555"},
+                        {"entryPointType": "video", "uri": MEET}]})
+    assert events_from_google([from_conference], now=NOW)["events"][0]["meeting_url"] == MEET
+
+    from_location = g_event(hangoutLink=None, location=ZOOM, description=MEET)
+    assert events_from_google([from_location], now=NOW)["events"][0]["meeting_url"] == ZOOM
+
+    from_description = g_event(hangoutLink=None, description=f"dial in here {ZOOM} thanks")
+    assert events_from_google([from_description], now=NOW)["events"][0]["meeting_url"] == ZOOM
+
+
+def test_microsoft_link_priority_join_url_then_location_then_body():
+    assert events_from_microsoft([m_event()], now=NOW)["events"][0]["meeting_url"] == TEAMS
+
+    from_body = m_event(onlineMeeting=None, bodyPreview=f"join {ZOOM} at nine")
+    assert events_from_microsoft([from_body], now=NOW)["events"][0]["meeting_url"] == ZOOM
+
+
+def test_an_event_with_no_recognizable_link_still_imports_link_less():
+    """Fail loud: the terminal renders "bot not armed — no link" rather than the event vanishing."""
+    for out in (events_from_google([g_event(hangoutLink=None, location="Room 4")], now=NOW),
+                events_from_microsoft([m_event(onlineMeeting=None,
+                                               location={"displayName": "Room 4"})], now=NOW)):
+        assert len(out["events"]) == 1
+        row = out["events"][0]
+        assert row["platform"] is None and row["native_meeting_id"] is None
+        assert row["meeting_url"] is None
+        assert row["title"] == "Weekly sync"
+
+
+# -------------------------------------------------------------------------------------- time zones
+
+def test_microsoft_naive_datetime_is_read_in_the_stated_zone_not_the_servers():
+    row = events_from_microsoft([m_event(start={"dateTime": "2026-09-08T09:00:00.0000000",
+                                                "timeZone": "America/New_York"})], now=NOW)["events"][0]
+    assert row["scheduled_at"] == "2026-09-08T13:00:00+00:00"  # EDT = UTC-4
+
+
+def test_an_unresolvable_windows_zone_falls_back_to_utc_not_to_local_time():
+    """Wrong by a known offset beats wrong by wherever the pod happens to run (#1316, R-B10)."""
+    row = events_from_microsoft([m_event(start={"dateTime": "2026-09-08T09:00:00.0000000",
+                                                "timeZone": "Pacific Standard Time"})],
+                                now=NOW)["events"][0]
+    assert row["scheduled_at"] == "2026-09-08T09:00:00+00:00"
+
+
+def test_seven_digit_fractional_seconds_parse():
+    row = events_from_microsoft([m_event(start={"dateTime": "2026-09-08T09:00:00.1234567",
+                                                "timeZone": "UTC"})], now=NOW)["events"][0]
+    assert row["scheduled_at"].startswith("2026-09-08T09:00:00.123456")
+
+
+def test_google_all_day_event_lands_at_midnight_utc():
+    row = events_from_google([g_event(start={"date": "2026-09-08"}, end={"date": "2026-09-09"})],
+                             now=NOW)["events"][0]
+    assert row["scheduled_at"] == "2026-09-08T00:00:00+00:00"
+
+
+# --------------------------------------------------------------------------------------- attendees
+
+def test_rooms_and_equipment_are_not_people():
+    google = events_from_google([g_event(attendees=[
+        {"email": "Ann@Example.com", "responseStatus": "tentative"},
+        {"email": "room-4@resource.calendar.google.com", "resource": True},
+    ])], now=NOW)["events"][0]
+    assert google["attendees"] == [{"email": "ann@example.com", "partstat": "tentative"}]
+
+    microsoft = events_from_microsoft([m_event(attendees=[
+        {"type": "required", "status": {"response": "notResponded"},
+         "emailAddress": {"address": "Bob@Example.com"}},
+        {"type": "resource", "emailAddress": {"address": "room-4@example.com"}},
+    ])], now=NOW)["events"][0]
+    assert microsoft["attendees"] == [{"email": "bob@example.com", "partstat": "needs-action"}]
+
+
+def test_a_display_name_equal_to_the_email_is_not_a_name():
+    row = events_from_google([g_event(attendees=[
+        {"email": "ann@example.com", "displayName": "ann@example.com"},
+    ])], now=NOW)["events"][0]
+    assert row["attendees"] == [{"email": "ann@example.com"}]
+
+
+def test_the_organizer_response_counts_as_accepted_on_graph():
+    row = events_from_microsoft([m_event(attendees=[
+        {"type": "required", "status": {"response": "organizer"},
+         "emailAddress": {"address": "ann@example.com"}},
+    ])], now=NOW)["events"][0]
+    assert row["attendees"][0]["partstat"] == "accepted"
+
+
+# ---------------------------------------------------------------------------------- snapshot policy
+
+def test_the_stored_snapshot_is_bounded_not_the_whole_payload():
+    """Unlike the ICS reader's unbounded VEVENT copy (#1213 item 3), a provider event carries far
+    more than we want in a meeting row — extended properties, attachments, ACL hints."""
+    noisy = g_event(extendedProperties={"private": {"secret": "do-not-store"}},
+                    attachments=[{"fileUrl": "https://drive.example/x"}],
+                    gadget={"preferences": {"k": "v"}})
+    component = events_from_google([noisy], now=NOW)["events"][0]["metadata"]["component"]
+
+    assert "extendedProperties" not in component
+    assert "attachments" not in component
+    assert "gadget" not in component
+    assert component["iCalUID"] == "series-a@google.com"
+    assert component["summary"] == "Weekly sync"
+
+
+def test_the_metadata_names_which_reader_produced_the_row():
+    assert events_from_google([g_event()], now=NOW)["events"][0]["metadata"]["provider"] == "google"
+    assert events_from_microsoft([m_event()], now=NOW)["events"][0]["metadata"]["provider"] == "microsoft"
+
+
+def test_the_calendar_the_row_came_from_is_carried_through():
+    cal = {"id": "primary", "summary": "Work"}
+    row = events_from_google([g_event()], now=NOW, calendar=cal)["events"][0]
+    assert row["metadata"]["calendar"] == cal
+
+
+# ------------------------------------------------------------------------------------- robustness
+
+def test_junk_items_are_skipped_rather_than_killing_the_sweep():
+    out = events_from_google([None, "nonsense", {}, {"iCalUID": ""}, g_event()], now=NOW)
+    assert len(out["events"]) == 1
+
+
+def test_an_empty_payload_is_an_empty_result_not_an_error():
+    for out in (events_from_google([], now=NOW), events_from_microsoft(None, now=NOW)):
+        assert out == {"events": [], "cancelled_uids": []}
+
+
+def test_horizon_and_lookback_are_caller_supplied_like_parse_ics():
+    far = g_event(start={"dateTime": "2026-09-20T13:00:00Z"})
+    assert events_from_google([far], now=NOW, horizon_days=7)["events"] == []
+    assert len(events_from_google([far], now=NOW, horizon_days=30)["events"]) == 1
+
+
+# ------------------------------------------------ the whole point: sync_user cannot tell the difference
+
+async def test_sync_user_consumes_a_google_payload_exactly_as_it_consumes_a_feed():
+    """The design claim, executed rather than asserted: a provider reader is a new READER, and the
+    upsert pipeline underneath it is untouched."""
+    store = InMemoryTranscriptStore()
+    parsed = events_from_google([g_event(
+        attendees=[{"email": "ann@example.com", "displayName": "Ann", "responseStatus": "accepted"}],
+    )], now=NOW)
+
+    result = await sync_user(store, 7, parsed, auto_join_default=True)
+
+    assert result["counts"] == {"created": 1, "updated": 0, "cancelled": 0}
+    (row,) = await store.list_meetings(7)
+    assert row["status"] == "scheduled"
+    assert row["data"]["calendar_uid"] == "series-a@google.com"
+    assert row["data"]["title"] == "Weekly sync"
+    assert row["data"]["auto_join"] is True
+
+
+async def test_a_calendar_reconnected_over_oauth_adopts_its_own_ics_rows():
+    """The migration path. The same meeting, read first from the feed and then from the API, is ONE
+    row — because both readers key on the same UID. Get this wrong and every user who switches
+    re-imports their whole calendar as duplicates."""
+    store = InMemoryTranscriptStore()
+    await sync_user(store, 7, parse_ics(ICS, now=NOW), auto_join_default=True)
+
+    result = await sync_user(store, 7, events_from_google([g_event()], now=NOW),
+                             auto_join_default=True)
+
+    assert result["counts"]["created"] == 0
+    assert len(await store.list_meetings(7)) == 1
+
+
+async def test_a_series_cancelled_at_the_provider_retires_the_row_the_feed_created():
+    store = InMemoryTranscriptStore()
+    await sync_user(store, 7, events_from_google([g_event()], now=NOW), auto_join_default=True)
+
+    result = await sync_user(store, 7, events_from_google([g_event(status="cancelled")], now=NOW))
+
+    assert result["counts"]["cancelled"] == 1


### PR DESCRIPTION
**Draft.** The seam only — nothing calls these yet. Opened as the findable artifact for a pushed
branch rather than as a review request; mark ready on the founder's word.

## COMMITMENTS IN THIS PR

**None.** No published terms, no dates, no rights, no spend, no external promise. Additive code
behind no route and no flag: two new pure functions, their tests, and the module's own docs.
The commitments in the wider calendar-OAuth effort (the privacy-policy amendment, entering Google's
verification programme) live in `~/dev/biz/drafts/2026-09-06-calendar-oauth-review-clock.md` and are
gated separately — none of them is decided here.

## Why

Connecting a calendar today means pasting a secret ICS address. Google Workspace hides that field
under the default admin policy and Outlook requires publishing a calendar, so the setup step for the
buyer we care about is "file a ticket with IT". Six open issues also exist purely because we
dereference a user-supplied URL and parse RFC 5545 ourselves (#1182, #1231, #1232, #1316, #991,
#1249), and a polled feed has a 5-minute latency floor with no push.

## What this is

`calendar_sync` was already split so the pipeline is reader-agnostic: `sync_user` owns one row per
UID, adoption by link, occurrence disposition and retirement, and it consumes a plain dict. So a
calendar API is a **new reader**, not a new pipeline.

```
parse_ics(text)              -> {"events": [...], "cancelled_uids": [...]}
events_from_google(items)    -> {"events": [...], "cancelled_uids": [...]}   NEW
events_from_microsoft(items) -> {"events": [...], "cancelled_uids": [...]}   NEW
```

Pure — no network, no tokens, no clock of their own. Recurrence expansion is the provider's job
(`singleEvents=true`, `/calendarView`); we then apply the same rule `parse_ics` applies: group by the
series-stable id, keep the earliest occurrence in the window, because two scheduled rows on one
native id violate `uq_meeting_active_user_platform_native`.

## The decision worth reviewing

**Keyed on `iCalUID` / `iCalUId`, not on the per-occurrence `event['id']`.** That is the same value
the ICS feed carries, so a calendar reconnected from ICS to OAuth **adopts its existing rows**.
Keying on the instance id would have re-imported every existing user's whole calendar as duplicates
on the day they switch. Executed rather than asserted —
`test_a_calendar_reconnected_over_oauth_adopts_its_own_ics_rows` runs `sync_user` over a feed and
then over the API payload for the same meeting and asserts `created == 0`.

## Two deliberate divergences from the ICS reader

| | ICS reader | These readers | Why |
|---|---|---|---|
| Event snapshot | copies every VEVENT property | bounded allowlist | #1213 item 3 — "no test that the VEVENT snapshot is redacted"; an API returns far more per event than a feed (extended properties, attachments, ACL hints) |
| Naive timestamp | n/a | resolved against its stated zone, else **UTC** | never the server's local zone — that is #1316 and backlog R-B10. Wrong by a known offset beats wrong by wherever the pod runs |

Attendees fold onto the ICS PARTSTAT vocabulary (`accepted` / `declined` / `tentative` /
`needs-action`) so nothing downstream has to learn two dialects; rooms and equipment are dropped on
both sides, matching `service._attendees`.

## Tests

`tests/test_calendar_providers.py`, 28 cases. The parity ones are the point: same PlannedEvent keys
as `parse_ics`, same attendee vocabulary, same one-row-per-uid rule, same "a link-less event still
imports" rule, and three that drive the real `sync_user` over the in-memory store.

```
meeting-api: 1450 passed, 5 skipped   (28 new)
```

Run locally against the repo venv, no containers.

## Not in this PR

No OAuth flow, no token storage, no route, no config-record change, no push subscriptions, no UI.
Nothing imports these functions yet. Token storage in particular has a hard prerequisite: #876 —
per-user secrets sit plaintext in `users.data` JSONB, and a leaked refresh token is a different
category of problem from a leaked ICS URL. Envelope encryption lands before or with the connect flow.

## Second commit: the I/O half

`provider_io.py` — fetch a window of events, refresh a token. `fetch_ics` dereferences a
user-supplied URL and must ride the SSRF-pinned transport; these talk to two fixed hosts, so the
risk inverts and what matters is that stored user input never escapes into the URL:

- calendar ids are path-escaped against a constant base (tested with `../../tokeninfo?x=`)
- redirects off, so an `Authorization` header cannot be moved to another host
- Graph's `@odata.nextLink` is host-checked **before** it is followed with a token attached

Same error contract as `fetch_ics` — `(value, human_reason)`, never raises, because one user's dead
network or revoked grant must not stall every other user's calendar in the same sweep. The reason is
what the calendar panel shows, so it reads "reconnect the calendar", not "401".

An `invalid_grant` refresh is treated as **terminal**, not transient. Retrying a dead grant on a loop
hammers the identity provider with a credential that will never work again.

Scopes are `calendar.events.readonly` + `calendar.calendarlist.readonly` and a test pins that they
stay read-only. We never write to a calendar, and a wider scope is a bigger consent prompt, a slower
Google review, and more to lose if a token leaks.

Pagination is exhaustive but bounded at 20 pages: past ~5000 events in a 14-day window this is not a
person's calendar any more.

17 further tests, offline through a stub client. **meeting-api: 1467 passed, 5 skipped.**

## Note on `value-fsm`

It failed once on this branch (`test_mock_silence_left_alone` → `POST /bots` 500), then **passed on
re-run against the identical head**. Not caused by this change: `meeting_api.calendar_sync` and
`meeting_api.__main__` both import cleanly with the new eager import, and the suite is green locally.
Flagging it because a gate that flakes on a mock scenario is worth someone's attention on its own.

## Collision check

- #1410 (`fix/rrule-expand-in-event-timezone`) touches `service.py` + `test_calendar_sync.py` — no
  overlap with these files. Its timezone reasoning is adjacent to `_iso_to_utc` here; if it changes
  how a naive time is read, these readers should follow.
- #1250 (`1182-ics-size-limit`) also edits this module's `README.md`, at the `fetch_ics` bullet
  (old line ~21). This PR edits the header and adds the reader table above it. Different regions;
  expected to merge cleanly.


---

## Contribution rights
<!-- Select exactly ONE. This is a legal certification: an agent may explain the choices but
     must not select one for you. See CONTRIBUTOR_RIGHTS.md. -->

- [ ] **Independent:** I created this contribution, or otherwise have the right to submit it
  under Apache-2.0, and it is not owned or controlled by an employer, client, or other entity.
  <!-- rights:independent -->
- [ ] **Employer/client authorization required:** an employer, client, or other entity owns or
  may control this contribution. I am requesting Vexa's private corporate-authorization process.
  <!-- rights:corporate -->
- [ ] **Unsure:** I need a private rights review before merge.
  <!-- rights:uncertain -->

Every commit must also carry the contributor's own DCO `Signed-off-by` line. Selecting the
independent path means no individual CLA is required.

> Section restored by an agent because the PR body was written without the repo template. **Nothing
> is ticked and nothing will be** — the template says an agent may explain the choices but must not
> select one, so this is left for a human. The commits also lack `Signed-off-by`, which is the same
> kind of certification; sign them with:
> `git rebase --signoff origin/main && git push --force-with-lease`

