### PR TITLE
distribution: Claude Code plugin, MCP registry server.json, glama.json

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,17 @@
+{
+  "name": "vexa",
+  "owner": { "name": "Vexa", "url": "https://github.com/Vexa-ai" },
+  "plugins": [
+    {
+      "name": "vexa",
+      "source": "./clients/claude-plugin",
+      "description": "Send a bot to a Google Meet, Teams or Zoom call and read the transcript, live or after, with speakers labelled. Hosted or self-hosted.",
+      "version": "0.1.0",
+      "category": "productivity",
+      "tags": ["meetings", "transcription", "google-meet", "microsoft-teams", "zoom", "mcp"],
+      "homepage": "https://docs.vexa.ai/vexa-mcp",
+      "repository": "https://github.com/Vexa-ai/vexa",
+      "license": "Apache-2.0"
+    }
+  ]
+}

--- a/architecture.calm.json
+++ b/architecture.calm.json
@@ -730,6 +730,7 @@
     }
    ]
   },
+    {"unique-id": "claude-plugin", "node-type": "webclient", "name": "claude-plugin", "description": "claude-plugin — client (Claude Code plugin: manifest, skills, hosted MCP config; no code)", "metadata": [{"path": "clients/claude-plugin"}]},
   {
    "unique-id": "terminal",
    "node-type": "webclient",

--- a/architecture.seal.json
+++ b/architecture.seal.json
@@ -1,3 +1,3 @@
 {
-  "architecture.calm.json": "694a169f064da425267ead9db7ac6cf85c160a8db258ae6150016159e8b3ed63"
+  "architecture.calm.json": "c70ada9e738f2865aa5f78bd344caf5b7b3d7e4fe0b2f7f27a12d557434ceeaf"
 }

--- a/clients/claude-plugin/.claude-plugin/plugin.json
+++ b/clients/claude-plugin/.claude-plugin/plugin.json
@@ -1,0 +1,34 @@
+{
+  "name": "vexa",
+  "displayName": "Vexa",
+  "version": "0.1.0",
+  "description": "Send a bot to a Google Meet, Teams or Zoom call and read the transcript, live or after, with speakers labelled. Hosted at api.cloud.vexa.ai, or point it at your own self-hosted Vexa.",
+  "author": { "name": "Vexa", "url": "https://github.com/Vexa-ai" },
+  "homepage": "https://docs.vexa.ai/vexa-mcp",
+  "repository": "https://github.com/Vexa-ai/vexa",
+  "license": "Apache-2.0",
+  "keywords": ["meetings", "transcription", "google-meet", "microsoft-teams", "zoom", "meeting-bot", "mcp"],
+  "userConfig": {
+    "vexa_api_key": {
+      "type": "string",
+      "title": "Vexa API key",
+      "description": "From https://vexa.ai/account (hosted) or printed by `make all` on a self-hosted stack. Or open https://vexa.ai/connect and paste the prompt into Claude Code instead of installing this plugin.",
+      "sensitive": true,
+      "required": true
+    },
+    "vexa_mcp_url": {
+      "type": "string",
+      "title": "Vexa MCP URL",
+      "description": "Hosted: https://api.cloud.vexa.ai/mcp. Self-hosted: your gateway's /mcp, e.g. http://localhost:18056/mcp.",
+      "default": "https://api.cloud.vexa.ai/mcp",
+      "required": false
+    }
+  },
+  "mcpServers": {
+    "vexa": {
+      "type": "http",
+      "url": "${user_config.vexa_mcp_url}",
+      "headers": { "Authorization": "Bearer ${user_config.vexa_api_key}" }
+    }
+  }
+}

--- a/clients/claude-plugin/README.md
+++ b/clients/claude-plugin/README.md
@@ -1,0 +1,13 @@
+# Vexa plugin for Claude Code
+
+Claude Code plugin that connects the Vexa MCP server (meeting bot + transcripts for Google Meet, Microsoft Teams and Zoom) and ships two skills: working with meetings, and setup.
+
+Install from the Claude plugin directory, or from this repo:
+
+```
+/plugin marketplace add Vexa-ai/vexa
+```
+
+Configuration: a Vexa API key (hosted: https://vexa.ai/account; self-hosted: printed by `make all`), and optionally the MCP URL for a self-hosted stack.
+
+Docs: https://docs.vexa.ai/vexa-mcp

--- a/clients/claude-plugin/README.md
+++ b/clients/claude-plugin/README.md
@@ -6,6 +6,7 @@ Install from the Claude plugin directory, or from this repo:
 
 ```
 /plugin marketplace add Vexa-ai/vexa
+/plugin install vexa@vexa
 ```
 
 Configuration: a Vexa API key (hosted: https://vexa.ai/account; self-hosted: printed by `make all`), and optionally the MCP URL for a self-hosted stack.

--- a/clients/claude-plugin/skills/README.md
+++ b/clients/claude-plugin/skills/README.md
@@ -1,0 +1,3 @@
+# skills
+
+Skills bundled with the Vexa Claude Code plugin. Each subfolder is one skill (`SKILL.md`): `meetings` — working with meetings through the Vexa MCP tools; `setup` — connecting the plugin to a hosted or self-hosted Vexa.

--- a/clients/claude-plugin/skills/meetings/README.md
+++ b/clients/claude-plugin/skills/meetings/README.md
@@ -1,0 +1,3 @@
+# meetings
+
+Skill: send a bot to a call, follow the transcript while it runs, write meetings into the user's notes with speakers and action items, search across meetings. See `SKILL.md`.

--- a/clients/claude-plugin/skills/meetings/SKILL.md
+++ b/clients/claude-plugin/skills/meetings/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: vexa-meetings
+description: Work with the user's meetings through the Vexa MCP tools — send a bot to a call, follow the transcript while it runs, and write meetings into their notes (Obsidian, Notion, plain markdown) with speakers and action items. Use whenever the user mentions a meeting, a call, a transcript, meeting notes, or asks what was said.
+---
+
+# Vexa meetings
+
+The `vexa` MCP server is connected. Start with `whats_waiting` — it says what the user's Vexa needs right now.
+
+## Send a bot to a call
+
+1. `parse_meeting_link(meeting_url)` → platform + native_meeting_id.
+2. `request_meeting_bot(meeting_url)`. A human in the call must admit the bot; expect a delay between `requested` and `active`.
+3. `get_meeting_transcript(platform, native_meeting_id)` while the meeting runs. Pass `since_index` to read only what is new. A meeting that is `active` with zero segments usually means the bot is not admitted yet or nobody has spoken.
+4. `stop_bot(platform, native_meeting_id)` when done.
+
+Every tool returns `platform` + `native_meeting_id`; feed one tool's output straight into the next.
+
+## Write a meeting into the user's notes
+
+When asked to sync, log, or file a meeting:
+
+- `list_meetings` (filters: status, platform, metadata) to find it; `get_meeting_transcript` for the segments; `get_meeting_participants` is not a tool — participants come from the segments' speaker names.
+- Write one note per meeting, dated, in the user's existing format if there is one (look at a recent note first). Include: title, date, participants (from speaker labels), a short summary, decisions, action items with owners, and the transcript or a link to it. Keep speaker labels as they are — do not guess names the transcript does not carry.
+- Ask before writing outside the folder the user named.
+
+## Search across meetings
+
+`search_transcripts` returns ranked snippets of what was said, not whole transcripts. Use it for "what did we decide about X", then open the meeting for context.
+
+## Make the data durable
+
+`annotate_meeting` attaches a title and metadata (a CRM id, a ticket, tags). Anything you put there is findable later with `list_meetings(metadata_filter=...)`. If you learn something durable about a meeting, write it back.
+
+## Do not
+
+- Do not call `speak_in_meeting` unless the user asked for that exact thing to be said. It is audible to everyone present and irreversible.
+- Do not read a meeting's `meetings_failed`-style counters as reliability; a meeting ends in many states that are not errors.

--- a/clients/claude-plugin/skills/setup/README.md
+++ b/clients/claude-plugin/skills/setup/README.md
@@ -1,0 +1,3 @@
+# setup
+
+Skill: where the Vexa API key comes from (hosted account page, self-hosted `make all`, or the door at vexa.ai/connect), the hosted vs self-hosted MCP URL, and how to check the connection. See `SKILL.md`.

--- a/clients/claude-plugin/skills/setup/SKILL.md
+++ b/clients/claude-plugin/skills/setup/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: vexa-setup
+description: Set up or fix the Vexa MCP connection for this plugin — where the API key comes from, hosted vs self-hosted URL, and how to check the connection. Use when the vexa server is missing, returns 401, or the user asks how to connect Vexa.
+---
+
+# Vexa setup
+
+The plugin needs one value: **Vexa API key** (`vexa_api_key`), and optionally the **MCP URL** (`vexa_mcp_url`).
+
+- **Hosted**: sign in at https://vexa.ai/account and create a key. URL stays `https://api.cloud.vexa.ai/mcp`.
+- **Self-hosted**: `make all` in the Vexa repo prints a key when the stack is up; set the URL to your gateway's `/mcp` (Docker Compose default `http://localhost:18056/mcp`). Docs: https://docs.vexa.ai/deployment
+- **The door**: https://vexa.ai/connect mints a key and registers the server for the user's agent without this plugin; either path works.
+
+Check the connection by calling `whats_waiting`. A 401 means the key is missing or wrong; a connection error usually means the URL points at a stack that is not up.
+
+Do not paste keys into chat or files. Tell the user to enter the key in the plugin's settings (it is stored in the OS keychain).

--- a/docs/views/containers.mmd
+++ b/docs/views/containers.mmd
@@ -39,6 +39,7 @@ flowchart LR
   end
   slim["slim"]
   extension["extension"]
+  claude_plugin["claude-plugin"]
   terminal["terminal"]
   dashboard["dashboard (deprecated)"]
   meeting_api -->|"write"| segments_table

--- a/docs/views/egress.mmd
+++ b/docs/views/egress.mmd
@@ -13,6 +13,7 @@ flowchart LR
     mcp["mcp"]
     slim["slim"]
     extension["extension"]
+    claude_plugin["claude-plugin"]
     terminal["terminal"]
     segments_table["transcription_segments (table)"]
     runtime["runtime"]

--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": ["DmitriyG228"]
+}

--- a/server.json
+++ b/server.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-  "name": "io.github.vexa-ai/vexa",
+  "name": "ai.vexa/vexa",
   "title": "Vexa",
   "description": "Meeting bot and transcripts for Google Meet, Teams and Zoom. Live or after, speakers labelled.",
   "version": "0.12.27",

--- a/server.json
+++ b/server.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.vexa-ai/vexa",
+  "title": "Vexa",
+  "description": "Meeting bot and transcripts for Google Meet, Microsoft Teams and Zoom: send a bot, read the transcript live or after with speakers labelled, search what was said. Hosted or self-hosted (Apache-2.0).",
+  "version": "0.12.27",
+  "repository": { "url": "https://github.com/Vexa-ai/vexa", "source": "github" },
+  "websiteUrl": "https://docs.vexa.ai/vexa-mcp",
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://api.cloud.vexa.ai/mcp",
+      "headers": [
+        { "name": "Authorization", "description": "Bearer <Vexa API key> — from https://vexa.ai/account", "isRequired": true, "isSecret": true }
+      ]
+    }
+  ]
+}

--- a/server.json
+++ b/server.json
@@ -2,16 +2,24 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.vexa-ai/vexa",
   "title": "Vexa",
-  "description": "Meeting bot and transcripts for Google Meet, Microsoft Teams and Zoom: send a bot, read the transcript live or after with speakers labelled, search what was said. Hosted or self-hosted (Apache-2.0).",
+  "description": "Meeting bot and transcripts for Google Meet, Teams and Zoom. Live or after, speakers labelled.",
   "version": "0.12.27",
-  "repository": { "url": "https://github.com/Vexa-ai/vexa", "source": "github" },
+  "repository": {
+    "url": "https://github.com/Vexa-ai/vexa",
+    "source": "github"
+  },
   "websiteUrl": "https://docs.vexa.ai/vexa-mcp",
   "remotes": [
     {
       "type": "streamable-http",
       "url": "https://api.cloud.vexa.ai/mcp",
       "headers": [
-        { "name": "Authorization", "description": "Bearer <Vexa API key> — from https://vexa.ai/account", "isRequired": true, "isSecret": true }
+        {
+          "name": "Authorization",
+          "description": "Bearer <Vexa API key> \u2014 from https://vexa.ai/account",
+          "isRequired": true,
+          "isSecret": true
+        }
       ]
     }
   ]


### PR DESCRIPTION
Three distribution files, no product code.

- `clients/claude-plugin/` — a Claude Code plugin: the hosted MCP server over HTTP with a bearer key from the plugin's user config (URL overridable for a self-hosted stack) and two skills (meetings, setup). `claude plugin validate` clean. Submitted to the Anthropic plugin directory after merge (subdirectory source).
- `server.json` — remote-only entry for the official MCP registry as `io.github.vexa-ai/vexa`; publishing needs an org-owner `mcp-publisher login github`.
- `glama.json` — claims the auto-indexed Glama listing so its description can be corrected.

Capability claims in the plugin text are at the verified rung: hosted MCP at api.cloud.vexa.ai/mcp with a bearer key (docs.vexa.ai/vexa-mcp, 21 tools, probed 2026-09-06); self-hosted `/mcp` on the gateway (Compose 0.12.18+).

## Contribution rights
<!-- Select exactly ONE. This is a legal certification: an agent may explain the choices but
     must not select one for you. See CONTRIBUTOR_RIGHTS.md. -->

- [x] **Independent:** I created this contribution, or otherwise have the right to submit it
  under Apache-2.0, and it is not owned or controlled by an employer, client, or other entity.
  <!-- rights:independent -->
- [ ] **Employer/client authorization required:** an employer, client, or other entity owns or
  may control this contribution. I am requesting Vexa's private corporate-authorization process.
  <!-- rights:corporate -->
- [ ] **Unsure:** I need a private rights review before merge.
  <!-- rights:uncertain -->

Every commit must also carry the contributor's own DCO `Signed-off-by` line. Selecting the
independent path means no individual CLA is required. Corporate and unsure paths do not stop
technical review, but they do block merge until resolved.

docs: none — distribution files only; the docs MCP page was updated separately on the surface (Vexa-ai/docs 7e5e6bb, 2026-09-06).

<!-- vexa-agent -->

