### PR TITLE
Ad-hoc group meeting: a bot requested inside a workspace is the workspace's meeting, live for every member

### DIFF
--- a/behavior/asks/first-visit.md
+++ b/behavior/asks/first-visit.md
@@ -46,7 +46,9 @@ Two or three gaps, one line each — the ones that would change what you could d
 
 Then a single question about the work. **Never *"paste a meeting link"*** — this person did not come
 to install a tool, they came because something in this company already involves them. If they truly
-have nothing here yet, the question is what they want Vexa in: their own meetings, or a colleague's.
+have nothing here yet, the question is what they want Vexa in: their own meetings, a colleague's, or
+a group's — a meeting a bot joins from a shared workspace belongs to that workspace, and everyone in
+it sees the call as it happens, so "a team's meetings" is a real answer and not a later upgrade.
 
 Then stop. No tour, no feature list, no second offer in the same turn.
 

--- a/behavior/asks/minutes-review-invite.md
+++ b/behavior/asks/minutes-review-invite.md
@@ -180,3 +180,17 @@ applies:
      in another deployment. If the mail names none, say you will find out rather than guess.
 A yes that produces neither a booking nor that one line is the failure this section exists to
 prevent.
+
+**A BOT CAN BELONG TO A GROUP, AND IN A GROUP CHAT IT ALREADY DOES.** Founder, 2026-09-06, in a
+workspace chat: *"i mean can we issue a bot that belongs to the group?"* — and then, of the bot that
+went out on his own account instead, *"[the member] can't see the call — in their terminal"*.
+`bot_send` and `bot_schedule` bind the meeting to the workspace this conversation is working in,
+with nothing to pass, and from that moment it is the GROUP's meeting: every member sees it in their
+own terminal while it runs — in their meeting list, on the meeting page, in the live transcript, and
+the bot's status as it changes — and the write-up reaches all of them, not only whoever asked.
+
+So never answer *"a bot cannot belong to a group"*, and never offer to share it afterwards as if
+that were the same thing. **Say that it binds, and name the workspace**, in one line, in the same
+turn you send it: the person cannot see the binding anywhere else, and *"assign it to the group"* is
+a request this already satisfies. `workspace="personal"` on the call is how a meeting stays theirs
+alone — offer that only if they ask for it.

--- a/behavior/global/flows/post_meeting.md
+++ b/behavior/global/flows/post_meeting.md
@@ -360,6 +360,16 @@ def email_minutes(ctx: StepCtx):
                     "minted_by": str(ctx.refs["uid"])})
     mid = notify(organizer, f"Minutes: {_mail_title(ctx)}", body, link=link)
     mx.register_thread(db, mid, ctx.refs["uid"], f"meet-{ctx.refs['meeting_id']}")
+    # AND EVERYONE ELSE IN THE WORKSPACE THIS MEETING BELONGS TO. A meeting bound to a workspace
+    # is the GROUP's, so its write-up is the group's too — mailing it to the requester alone is
+    # the founder's *"it was mailed to <the admin> not to <the member>"*: the subject line named
+    # the workspace and exactly one person received it.
+    #
+    # AFTER the organiser's mail and never in place of it. That one is this step's contract — its
+    # message id is the receipt — so the fan-out cannot fail it, and each member is mailed inside
+    # its own guard: one bad address must not cost the rest of the group their notes.
+    _mail_group_members(ctx, row, subject=f"Minutes: {_mail_title(ctx)}", body=body,
+                        already=organizer, row_id=row_id)
     return Done({"message_id": mid, "link": link}, provider_ref=mid)
 ```
 

--- a/clients/terminal/src/minutes/WorkspaceReadmePanel.tsx
+++ b/clients/terminal/src/minutes/WorkspaceReadmePanel.tsx
@@ -641,6 +641,45 @@ export function WorkspaceReadmePanel(p: { slug?: string; path: string; title?: s
           )}
       </Section>
 
+      {/* THIS GROUP'S MEETINGS, LIVE ONES FIRST. A bot requested inside a workspace makes the
+          WORKSPACE's meeting, so this is the same list for every member — not "the ones I asked
+          for". It exists because a member watching their own group's call had nowhere that said it
+          was happening: the founder's *"[the member] can't see the call — in their terminal"*.
+
+          A LIVE ROW SAYS SO IN A WORD, not a colour: this panel is read in both themes and the one
+          fact that matters here is whether the call is on RIGHT NOW. Rows a member reaches through
+          the workspace rather than by owning them are marked, so nobody mistakes a colleague's
+          meeting for one of their own. */}
+      {facts.kind === "group" && (
+        <Section id="meetings" name="Meetings">
+          {facts.meetings.length === 0 ? (
+            <div data-ws-meetings="none" style={{ ...ty.body, color: "var(--t2)", lineHeight: 1.5 }}>
+              No meetings belong to this workspace yet. A bot sent from a chat here joins as this
+              group&apos;s, and everyone in it sees the call while it runs.
+            </div>
+          ) : (
+            <div data-ws-meetings="group">
+              {facts.meetings.map((m) => (
+                <div key={m.id} data-ws-meeting={m.id} style={{ ...rowS, gap: 6, flexWrap: "wrap" }}>
+                  <Icon name="cal" size={12} style={{ color: "var(--t3)" }} />
+                  <span style={{ ...valS, flex: "0 1 auto" }}>{m.title}</span>
+                  {m.live && (
+                    <span data-ws-meeting-live style={{ ...ty.meta, flex: "none", color: "var(--t1)" }}>
+                      live now
+                    </span>
+                  )}
+                  {m.shared && (
+                    <span data-ws-meeting-shared style={{ ...ty.meta, flex: "none" }}>
+                      from a colleague
+                    </span>
+                  )}
+                </div>
+              ))}
+            </div>
+          )}
+        </Section>
+      )}
+
       {/* THE REPO. THREE STATES, AND THEY ARE THREE (#1628 point 3): a repo is attached · none is ·
           the read broke. `_global` for the administrator was rendering the second as the third —
           `not readable`, with `Could not read the GitHub state.` in red at the foot — on a workspace

--- a/clients/terminal/src/minutes/__tests__/workspaceReadme.test.tsx
+++ b/clients/terminal/src/minutes/__tests__/workspaceReadme.test.tsx
@@ -57,7 +57,7 @@ vi.mock("../../surfaces/workspaceApi", async (importOriginal) => ({
 }));
 
 import { PagesPanel } from "../PagesPanel";
-import { boundSeries, countPages, isWorkspaceReadme, policySentence } from "../workspaceReadme";
+import { boundSeries, countPages, isWorkspaceReadme, policySentence, workspaceMeetings } from "../workspaceReadme";
 import type { Page } from "../types";
 
 /** The three sentences the panel lifts out of the seeded `behavior/global/POLICIES.md`, in the
@@ -177,6 +177,48 @@ describe("the counts and the bindings", () => {
       { key: "cal:u1", title: "Tuesday sync", recurring: true, runs: 2, latest: "2026-09-08" },
       { key: "row:3", title: "One-off review", recurring: false, runs: 1, latest: "2026-08-30" },
     ]);
+  });
+});
+
+// A bot requested inside a workspace makes the WORKSPACE's meeting (Vexa-ai/vexa#1648), so the front
+// page lists the group's calls rather than the reader's own — and says which one is on RIGHT NOW.
+describe("the workspace's own meetings", () => {
+  const ROWS = [
+    { id: 1, status: "completed", data: { workspace_id: "w", title: "Last week's review" }, start_time: "2026-09-01" },
+    { id: 2, status: "active", shared: true, data: { workspace_id: "w", title: "Group call" }, start_time: "2026-09-06" },
+    { id: 3, status: "scheduled", data: { workspace_id: "w", title: "Next Tuesday" }, start_time: "2026-09-30" },
+    { id: 4, status: "active", data: { workspace_id: "other", title: "Another group's" }, start_time: "2026-09-06" },
+  ];
+
+  it("lists only this workspace's meetings, live ones first", () => {
+    // #3 is SCHEDULED for the 30th — the furthest-future start_time in the set. It must still sort
+    // BELOW the live call, which is the whole reason the live lift is its own sort key and not a
+    // time comparison: on a pure time sort the meeting that has not happened wins the top row.
+    expect(workspaceMeetings(ROWS, "w").map((m) => [m.title, m.live])).toEqual([
+      ["Group call", true],
+      ["Next Tuesday", false],
+      ["Last week's review", false],
+    ]);
+  });
+
+  it("marks a colleague's meeting as reaching this reader through the workspace", () => {
+    const [live] = workspaceMeetings(ROWS, "w");
+    expect(live).toMatchObject({ id: "2", shared: true, when: "2026-09-06" });
+  });
+
+  it("treats every phase of the bot arriving and leaving as live", () => {
+    for (const status of ["requested", "joining", "awaiting_admission", "active", "stopping"]) {
+      const rows = [{ id: 9, status, data: { workspace_id: "w", title: "x" } }];
+      expect(workspaceMeetings(rows, "w")[0].live).toBe(true);
+    }
+    for (const status of ["completed", "failed", "idle", "scheduled"]) {
+      const rows = [{ id: 9, status, data: { workspace_id: "w", title: "x" } }];
+      expect(workspaceMeetings(rows, "w")[0].live).toBe(false);
+    }
+  });
+
+  it("answers with nothing when no slug is named, rather than everything", () => {
+    expect(workspaceMeetings(ROWS, "")).toEqual([]);
   });
 });
 

--- a/clients/terminal/src/minutes/__tests__/workspaceStrip.test.tsx
+++ b/clients/terminal/src/minutes/__tests__/workspaceStrip.test.tsx
@@ -146,15 +146,21 @@ describe("the strip takes the header and no more", () => {
       .toBe("Jane Smith changed the governing board page 2 hours ago");
   });
 
-  it("opens the three sections at once — the reader asked for the history, not for a menu", async () => {
+  it("opens every section at once — the reader asked for the history, not for a menu", async () => {
     const { container } = panel();
     await openDetails(container);
 
-    // ALL THREE, in reading order, and no fourth: the kind, the page count and the last change are
-    // said once each in the header above, and saying them again here is the strip returning.
-    expect(openIds(container)).toEqual(["people", "repo", "history"]);
+    // IN READING ORDER, AND NOTHING THAT REPEATS THE HEADER. That is the rule, and the rule was
+    // never a count: the kind, the page count and the last change are said once each in the header
+    // above, and saying them again here is the strip returning.
+    //
+    // Meetings is the fourth, on a GROUP only (Vexa-ai/vexa#1648). It says nothing the header says,
+    // and it carries the one fact a member could not get anywhere in this client before it: that
+    // their group's call is happening RIGHT NOW. The founder, watching a member's terminal during a
+    // meeting they were in: *"can't see the call — in their terminal"*.
+    expect(openIds(container)).toEqual(["people", "meetings", "repo", "history"]);
     expect([...container.querySelectorAll("[data-ws-section-name]")].map((h) => h.textContent))
-      .toEqual(["People", "Repo", "History"]);
+      .toEqual(["People", "Meetings", "Repo", "History"]);
     await waitFor(() => expect(container.querySelector('[data-ws-fact="remote"]')).toBeTruthy());
     expect(container.querySelector("[data-ws-member]")).toBeTruthy();
     expect(container.querySelector("[data-ws-history]")).toBeTruthy();

--- a/clients/terminal/src/minutes/workspaceReadme.ts
+++ b/clients/terminal/src/minutes/workspaceReadme.ts
@@ -98,12 +98,64 @@ export interface MeetingRow {
   id?: number | string;
   status?: string;
   start_time?: string | null;
+  /** set by meeting-api when the row reaches this caller through a share or a workspace membership
+   *  rather than by owning it — i.e. it is a colleague's meeting in this group */
+  shared?: boolean;
   data?: {
     workspace_id?: string | null;
     calendar_uid?: string | null;
     title?: string | null;
     scheduled_at?: string | null;
   } | null;
+}
+
+/** One of this workspace's meetings, as the front page lists it. */
+export interface WorkspaceMeeting {
+  id: string;
+  title: string;
+  /** live NOW — the bot is on its way in, in the room, or leaving */
+  live: boolean;
+  /** when it ran, else when it is due, else "" */
+  when: string;
+  /** owned by another member and reaching this reader through the workspace */
+  shared: boolean;
+}
+
+/** Statuses that mean the meeting is happening RIGHT NOW, from the bot being asked for to the bot
+ *  leaving. Mirrors `LIVE_PHASE_STATUSES` in `../surfaces/meetingModel`, kept as its own literal
+ *  because this module is deliberately dependency-free (it is unit-tested with no store). */
+const LIVE_NOW = new Set([
+  "requested", "joining", "awaiting_admission", "active", "needs_human_help", "needs_help",
+  "stopping",
+]);
+
+/** THIS WORKSPACE'S MEETINGS, LIVE ONES FIRST — the answer to "what is my group doing right now".
+ *
+ *  A bot requested inside a workspace makes the WORKSPACE's meeting, so `GET /api/meetings` already
+ *  serves it to every member (owner ∪ transcript-share ∪ bound-workspace member, evaluated in SQL);
+ *  a row a member reaches through the workspace rather than by owning it arrives flagged `shared`.
+ *  Before this the front page ran those same rows through `boundSeries` alone, which collapses runs
+ *  into series and sorts purely by time — so a member had nowhere that said their group's call was
+ *  happening right now, which is what "can't see the call" meant.
+ *
+ *  LIVE FIRST IS NOT THE SAME AS SORTING BY TIME: an upcoming meeting's `start_time` is in the
+ *  future and outranks a live one on any pure time sort, so the live lift has to be its own key.
+ *  Same two-key shape the chat rail already uses, for the same reason. */
+export function workspaceMeetings(rows: readonly MeetingRow[], slug: string): WorkspaceMeeting[] {
+  const out: WorkspaceMeeting[] = [];
+  for (const r of rows) {
+    const d = r?.data ?? {};
+    if (!slug || String(d.workspace_id ?? "") !== slug) continue;
+    out.push({
+      id: String(r.id ?? ""),
+      title: String(d.title ?? "").trim() || "Untitled meeting",
+      live: LIVE_NOW.has(String(r.status ?? "")),
+      when: String(r.start_time ?? d.scheduled_at ?? ""),
+      shared: r.shared === true,
+    });
+  }
+  return out.sort((a, b) =>
+    (b.live ? 1 : 0) - (a.live ? 1 : 0) || b.when.localeCompare(a.when));
 }
 
 /** One thing this workspace is bound to: a recurring invite (every run of it shares a
@@ -180,6 +232,9 @@ export interface WorkspaceFacts {
    *  guess; the clause is then dropped rather than filled with the word "the admin". */
   admin: InstanceAdmin | null;
   bound: BoundSeries[];
+  /** THIS WORKSPACE'S MEETINGS, live ones first — every member sees the group's calls here, not
+   *  only the ones they themselves asked for. Empty outside a group. */
+  meetings: WorkspaceMeeting[];
   /** this reader's own role in a shared workspace (`null` for a desk / the company layer) */
   myRole: Role | null;
   /** the roster — `null` when this reader may not read it (a reader of a group may not) */
@@ -302,6 +357,7 @@ export async function loadWorkspaceFacts(docSlug: string | undefined): Promise<W
   let myRole: Role | null = null;
   let members: WorkspaceMember[] | null = null;
   let bound: BoundSeries[] = [];
+  let wsMeetings: WorkspaceMeeting[] = [];
   if (kind === "group") {
     const [mine, roster, meetings] = await Promise.allSettled([
       listSharedMemberships(), listWorkspaceMembers(slug), meetingRows(),
@@ -313,7 +369,10 @@ export async function loadWorkspaceFacts(docSlug: string | undefined): Promise<W
     // A READER MAY NOT READ THE ROSTER, and that is the design rather than a failure — the members
     // route is contributor+. So a rejection here is silent, and the section says what it does know.
     if (roster.status === "fulfilled") members = roster.value;
-    if (meetings.status === "fulfilled") bound = boundSeries(meetings.value, slug);
+    if (meetings.status === "fulfilled") {
+      bound = boundSeries(meetings.value, slug);
+      wsMeetings = workspaceMeetings(meetings.value, slug);
+    }
     else note("Could not read what this workspace is bound to.");
   }
 
@@ -332,7 +391,7 @@ export async function loadWorkspaceFacts(docSlug: string | undefined): Promise<W
     company: companyName(company.status === "fulfilled" ? company.value : null),
     me: me.status === "fulfilled" ? me.value : null,
     admin: admin.status === "fulfilled" ? admin.value : null,
-    bound, myRole, members,
+    bound, meetings: wsMeetings, myRole, members,
     remote: remote.status === "fulfilled" ? remote.value : null,
     remoteFailure,
     owner, notes,

--- a/core/agent/control_plane/api_shared.py
+++ b/core/agent/control_plane/api_shared.py
@@ -1536,20 +1536,35 @@ def _http_email_subject_lookup(admin_api_url: str, internal_secret: str, admin_t
 
 
 def _http_meeting_owner_lookup(meeting_api_url: str):
-    """Build the default owner-lookup: GET {meeting_api_url}/meetings/{id} with the caller's X-User-Id.
-    Returns a callable ``(user_id: str, meeting_id: str) -> dict | None`` (the owned meeting record, or
-    None when the row is absent / owned by someone else / meeting-api is unreachable — fail-closed)."""
+    """Build the default meeting ACCESS lookup: GET {meeting_api_url}/meetings/{id} as the caller.
+    Returns a callable ``(user_id, meeting_id, workspaces=None) -> dict | None`` — the meeting record
+    the caller may read, or None when the row is absent / not theirs / meeting-api is unreachable
+    (fail-closed).
+
+    ``workspaces`` is the caller's OWN memberships, forwarded as ``X-User-Workspaces`` so meeting-api
+    can run the third branch of its access union (member of the meeting's bound workspace) instead of
+    owner + transcript-share only. This is the grant the SSE route's own comment named as "the clean
+    seam" and deliberately left unhonoured: a bot requested inside a workspace makes the WORKSPACE's
+    meeting, so a member asking to watch it is not a stranger.
+
+    Omitting the argument keeps the previous, strictly narrower answer — the header is simply absent
+    and every existing caller behaves exactly as before. It stays a LOOKUP rather than a local check
+    because this function knows neither the row's binding nor the caller's role; meeting-api knows
+    both, and one decision made in one place cannot disagree with itself."""
     import urllib.error
     import urllib.request
 
     base = (meeting_api_url or "").rstrip("/")
 
-    def _lookup(user_id: str, meeting_id: str) -> "dict | None":
+    def _lookup(user_id: str, meeting_id: str, workspaces=None) -> "dict | None":
         if not base or not user_id or not str(meeting_id).isdigit():
             return None  # non-numeric row id can't be an owned meeting row → fail closed
+        headers = {"X-User-Id": str(user_id)}
+        ws = ",".join(str(w).strip() for w in (workspaces or []) if str(w).strip())
+        if ws:
+            headers["X-User-Workspaces"] = ws
         try:
-            req = urllib.request.Request(
-                f"{base}/meetings/{int(meeting_id)}", headers={"X-User-Id": str(user_id)})
+            req = urllib.request.Request(f"{base}/meetings/{int(meeting_id)}", headers=headers)
             with urllib.request.urlopen(req, timeout=5) as resp:
                 if resp.status != 200:
                     return None

--- a/core/agent/control_plane/routers/meetings.py
+++ b/core/agent/control_plane/routers/meetings.py
@@ -28,6 +28,44 @@ def build(**d) -> APIRouter:
     subject_of = d['subject_of']
     wsr = d['wsr']
 
+    def _caller_workspaces(subject: str) -> list[str]:
+        """The workspaces this caller is a member of — the grant that lets the routes below answer for
+        a meeting the caller does not own but their workspace does.
+
+        READ FROM `policy/members.json`, not from a request header. The header the gateway injects
+        would be the cheaper source, but agent-api is reachable directly in the dev/self-host topology
+        (see `subject_of`'s TOPOLOGY BOUNDARY note), where identity headers are spoofable — and this
+        value decides who may read a live transcript. The on-disk roster is the same authoritative
+        store `assert_may_manage` and the mount builder already trust, and it is local.
+
+        NEVER RAISES. A membership scan that fails must narrow access to owner-only, never open it and
+        never 500 a meeting the owner is entitled to watch."""
+        try:
+            from control_plane.workspace_membership import list_memberships
+            return [str(m["workspace_id"]) for m in list_memberships(wsr.root, str(subject))
+                    if m.get("workspace_id")]
+        except Exception:  # noqa: BLE001 — fail CLOSED to the previous owner-only answer
+            return []
+
+    # `_meeting_owner_lookup` is an INJECTED seam: the shipped one takes the caller's workspaces as a
+    # third argument, and the fakes five test modules hand in take two. Ask the callable which it is,
+    # once, rather than calling three-arg and rescuing `TypeError` — that rescue would also swallow a
+    # genuine TypeError raised INSIDE the lookup and silently downgrade it to "not authorized".
+    try:
+        import inspect as _inspect
+        _lookup_takes_workspaces = len(
+            _inspect.signature(_meeting_owner_lookup).parameters) >= 3
+    except (TypeError, ValueError):  # C-implemented or otherwise unintrospectable → narrower call
+        _lookup_takes_workspaces = False
+
+    def _meeting_access(subject: str, meeting_id) -> "dict | None":
+        """THE ONE ACCESS DECISION every route in this file makes: the meeting record this caller may
+        read, or None. Owner, transcript-share recipient, or member of the workspace the meeting is
+        bound to — meeting-api evaluates all three, this only says who is asking."""
+        if _lookup_takes_workspaces:
+            return _meeting_owner_lookup(subject, meeting_id, _caller_workspaces(subject))
+        return _meeting_owner_lookup(subject, meeting_id)
+
     @router.get("/api/meeting/relay-health")
     def meeting_relay_health(request: Request):
         """P18 (ADR 0010) — the transcript relay's observable health: is the numeric→native resolve OK,
@@ -61,7 +99,7 @@ def build(**d) -> APIRouter:
         Both are `""` for every report written before the widget existed, and that absence is what
         keeps those meetings on the two-page room they have today instead of losing the transcript."""
         subject = subject_of(request)   # 401 if no (gateway-injected) identity — fail closed
-        row = _meeting_owner_lookup(subject, meeting_id)
+        row = _meeting_access(subject, meeting_id)
         if row is None:
             raise HTTPException(status_code=403, detail="not authorized for this meeting")
         return meeting_note_mod.describe(wsr.root, subject, row)
@@ -85,7 +123,7 @@ def build(**d) -> APIRouter:
         ints and this creates a file on a DESK."""
         subject = subject_of(request)   # 401 if no (gateway-injected) identity — fail closed
         meeting_id = str((body or {}).get("meeting_id") or (body or {}).get("meeting") or "").strip()
-        row = _meeting_owner_lookup(subject, meeting_id)
+        row = _meeting_access(subject, meeting_id)
         if row is None:
             raise HTTPException(status_code=403, detail="not authorized for this meeting")
         return meeting_mint_mod.mint(wsr.root, subject, row,
@@ -115,7 +153,7 @@ def build(**d) -> APIRouter:
         `/api/meeting/stream` below, and for the same reason: row ids are sequential ints, and this
         answers with what was said on somebody's DESK."""
         subject = subject_of(request)   # 401 if no (gateway-injected) identity — fail closed
-        row = _meeting_owner_lookup(subject, meeting_id)
+        row = _meeting_access(subject, meeting_id)
         if row is None:
             raise HTTPException(status_code=403, detail="not authorized for this meeting")
         return meeting_terms_mod.read(wsr.root, subject, meeting_id)
@@ -136,7 +174,7 @@ def build(**d) -> APIRouter:
         annotates, so one publish is one object rather than a query string beside a payload."""
         subject = subject_of(request)   # 401 if no (gateway-injected) identity — fail closed
         meeting_id = str((body or {}).get("meeting_id") or (body or {}).get("meeting") or "").strip()
-        row = _meeting_owner_lookup(subject, meeting_id)
+        row = _meeting_access(subject, meeting_id)
         if row is None:
             raise HTTPException(status_code=403, detail="not authorized for this meeting")
         terms = (body or {}).get("terms")
@@ -169,12 +207,19 @@ def build(**d) -> APIRouter:
         # caller identity (`subject_of` → 401 on no gateway-injected X-User-Id) and verify the caller OWNS
         # the requested row (meeting-api `GET /meetings/{id}` owner-scopes in SQL: `Meeting.user_id ==
         # user_id` → 404 for a foreign/absent row). Fail CLOSED (403) BEFORE the stream opens.
-        # OWNER-ONLY for now (matches the WS path today); a shared-workspace membership grant would extend
-        # `_meeting_owner_lookup` — the clean seam — but is intentionally NOT honored here yet.
+        #
+        # THE SHARED-WORKSPACE GRANT IS NOW HONOURED HERE — this comment used to end "intentionally NOT
+        # honored here yet", and that gap is the bug: a bot requested inside a workspace makes the
+        # WORKSPACE's meeting, so every member is entitled to watch it, and owner-only scoping meant a
+        # member watching their own group's call saw an empty page while it was happening. The grant
+        # arrives through the seam the old comment named — `_meeting_access` → `_meeting_owner_lookup`
+        # with the caller's memberships — so the widening is meeting-api's ONE access union, not a
+        # second rule invented at this route. A caller who is neither owner, share recipient nor member
+        # is refused exactly as before.
         subject = subject_of(request)  # 401 if no (gateway-injected) identity — fail closed
-        owned = _meeting_owner_lookup(subject, meeting_id)
+        owned = _meeting_access(subject, meeting_id)
         if owned is None:
-            # Absent row, or a row owned by a DIFFERENT tenant → refuse (404-equivalent, no stream opened).
+            # Absent row, or a row this caller has no claim on → refuse (404-equivalent, no stream opened).
             raise HTTPException(status_code=403, detail="not authorized for this meeting")
         # `session_uid` is ALSO caller-supplied. The terminal passes the ROW id as `session_uid` for
         # live rows (liveMeetings.ts `session_uid = live ? id : undefined`); the meeting's own native

--- a/core/agent/tests/test_meeting_workspace_access.py
+++ b/core/agent/tests/test_meeting_workspace_access.py
@@ -1,0 +1,148 @@
+"""A member of the meeting's bound workspace may open it, watch it, and annotate it (Vexa-ai/vexa#1648).
+
+A bot requested from inside a workspace makes the WORKSPACE's meeting, so the four routes in
+`routers/meetings.py` — the note (read + mint), the terms (read + publish) and the live SSE — must
+answer for every member of that workspace, not only for the row's owner. They all decide access
+through ONE seam, `_meeting_owner_lookup`, whose own comment used to read *"a shared-workspace
+membership grant would extend `_meeting_owner_lookup` — the clean seam — but is intentionally NOT
+honored here yet"*. This is that grant, and these are its tests.
+
+Offline (fakes + tmp dirs, no docker, no runtime, no DB, no meeting-api).
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from control_plane.api import create_app  # noqa: E402
+from control_plane.api_shared import _http_meeting_owner_lookup  # noqa: E402
+from control_plane.dispatch import Dispatcher  # noqa: E402
+from control_plane.workspace_reader import WorkspaceReader  # noqa: E402
+from shared.config import load_settings  # noqa: E402
+
+OWNER, MEMBER, STRANGER = "301", "302", "303"
+WS, ROW = "team-notes", "5150"
+
+
+class _FakeRuntime:
+    def launch(self, *a, **k): raise AssertionError("no runtime in these tests")
+
+
+class _FakeIdentity:
+    def mint(self, subject, launcher, workspaces, tools): return "tok"
+
+
+@pytest.fixture()
+def client(tmp_path) -> TestClient:
+    """One shared workspace whose roster names OWNER and MEMBER, and a lookup that behaves like
+    meeting-api's access union: the owner always, a member only when the caller's workspaces reach
+    the row's binding, nobody else."""
+    for uid in (OWNER, MEMBER, STRANGER):
+        (tmp_path / uid).mkdir(parents=True)
+    ws = tmp_path / WS
+    (ws / "policy").mkdir(parents=True)
+    (ws / "policy" / "members.json").write_text(json.dumps([
+        {"subject": OWNER, "role": "owner", "email": "owner@example.test"},
+        {"subject": MEMBER, "role": "reader", "email": "member@example.test"},
+    ]))
+
+    def _access(user_id, meeting_id, workspaces=None):
+        if str(meeting_id) != ROW:
+            return None
+        row = {"id": ROW, "native_meeting_id": "96088138284",
+               "user_id": OWNER, "data": {"workspace_id": WS}}
+        if str(user_id) == OWNER:
+            return row
+        return row if WS in (workspaces or []) else None
+
+    # `redis_url` is set so the SSE route reaches its ACCESS gate: without one it answers 501 before
+    # deciding anything, and a test that accepted that would be asserting nothing about access. No
+    # redis is ever contacted — every caller here is refused, or reads a route that needs none.
+    return TestClient(create_app(
+        Dispatcher(load_settings(workspaces_dir=str(tmp_path)), _FakeRuntime(), _FakeIdentity()),
+        reader=WorkspaceReader(str(tmp_path)), meeting_owner_lookup=_access,
+        redis_url="redis://127.0.0.1:6379/0"))
+
+
+# ── the seam itself ──────────────────────────────────────────────────────────────────────────────
+
+def test_the_lookup_forwards_the_callers_workspaces_and_omits_them_when_there_are_none():
+    """`X-User-Workspaces` is what lets meeting-api run the third branch of its access union. It is
+    sent only when the caller HAS memberships: an empty header is not the same as no header, and a
+    caller with none must get exactly the owner-scoped answer it got before."""
+    seen: list[dict] = []
+
+    class _Resp:
+        status = 200
+        def read(self): return b'{"id": "5150"}'
+        def __enter__(self): return self
+        def __exit__(self, *a): return False
+
+    import urllib.request
+    real = urllib.request.urlopen
+    urllib.request.urlopen = lambda req, timeout=None: (seen.append(dict(req.headers)), _Resp())[1]
+    try:
+        lookup = _http_meeting_owner_lookup("http://meeting-api")
+        assert lookup(OWNER, ROW, [WS, "other"]) == {"id": "5150"}
+        assert seen[-1].get("X-user-workspaces") == f"{WS},other"
+
+        lookup(OWNER, ROW)
+        assert "X-user-workspaces" not in seen[-1]
+        lookup(OWNER, ROW, [])
+        assert "X-user-workspaces" not in seen[-1]
+        # blank entries are dropped rather than sent as a workspace named ""
+        lookup(OWNER, ROW, ["", "  "])
+        assert "X-user-workspaces" not in seen[-1]
+    finally:
+        urllib.request.urlopen = real
+
+
+def test_a_row_id_that_is_not_a_row_is_refused_before_any_hop():
+    """Unchanged, and it matters: this is the guard that keeps a caller from walking sequential ids."""
+    lookup = _http_meeting_owner_lookup("http://meeting-api")
+    assert lookup(OWNER, "not-a-number", [WS]) is None
+    assert lookup("", ROW, [WS]) is None
+
+
+# ── the routes ───────────────────────────────────────────────────────────────────────────────────
+
+@pytest.mark.parametrize("method,path,body", [
+    ("get", f"/api/meeting/note?meeting_id={ROW}", None),
+    ("post", "/api/meeting/note", {"meeting_id": ROW}),
+    ("get", f"/api/meeting/terms?meeting_id={ROW}", None),
+    ("post", "/api/meeting/terms", {"meeting_id": ROW, "terms": []}),
+])
+def test_a_member_is_not_refused_where_only_the_owner_used_to_pass(client, method, path, body):
+    """Every route that gates on the seam. A reader ("viewer") is included deliberately: the founder's
+    rule is that owner and contributor see everything and a reader reads, so a reader must not be
+    turned away from their own group's meeting."""
+    call = getattr(client, method)
+    for uid in (OWNER, MEMBER):
+        r = call(path, headers={"X-User-Id": uid}, **({"json": body} if body else {}))
+        assert r.status_code != 403, f"{uid} was refused {path}: {r.text}"
+
+    refused = call(path, headers={"X-User-Id": STRANGER}, **({"json": body} if body else {}))
+    assert refused.status_code == 403, f"a non-member reached {path}"
+
+
+def test_the_live_transcript_refuses_a_non_member_before_the_stream_opens(client):
+    """The SSE gate is the one that leaked a live transcript cross-tenant, so its refusal is the one
+    that must not regress while the membership grant widens it."""
+    r = client.get(f"/api/meeting/stream?meeting_id={ROW}&session_uid={ROW}",
+                   headers={"X-User-Id": STRANGER})
+    assert r.status_code == 403
+
+
+def test_membership_comes_from_the_roster_on_disk_not_from_a_header(client):
+    """`_caller_workspaces` reads `policy/members.json`, so a client cannot talk its way into a
+    meeting by declaring a workspace: agent-api is reachable directly in the dev/self-host topology,
+    where identity headers are spoofable, and this value decides who may read a live transcript."""
+    r = client.get(f"/api/meeting/note?meeting_id={ROW}",
+                   headers={"X-User-Id": STRANGER, "X-User-Workspaces": WS})
+    assert r.status_code == 403

--- a/core/flows/src/flows_defs/production.py
+++ b/core/flows/src/flows_defs/production.py
@@ -1556,8 +1556,75 @@ def build(reg: Registry, db) -> None:
                         "minted_by": str(ctx.refs["uid"])})
         mid = notify(organizer, f"Minutes: {_mail_title(ctx)}", body, link=link)
         mx.register_thread(db, mid, ctx.refs["uid"], f"meet-{ctx.refs['meeting_id']}")
+        # AND EVERYONE ELSE IN THE WORKSPACE THIS MEETING BELONGS TO. A meeting bound to a workspace
+        # is the GROUP's, so its write-up is the group's too — mailing it to the requester alone is
+        # the founder's *"it was mailed to <the admin> not to <the member>"*: the subject line named
+        # the workspace and exactly one person received it.
+        #
+        # AFTER the organiser's mail and never in place of it. That one is this step's contract — its
+        # message id is the receipt — so the fan-out cannot fail it, and each member is mailed inside
+        # its own guard: one bad address must not cost the rest of the group their notes.
+        _mail_group_members(ctx, row, subject=f"Minutes: {_mail_title(ctx)}", body=body,
+                            already=organizer, row_id=row_id)
         return Done({"message_id": mid, "link": link}, provider_ref=mid)
 
+
+    def _mail_group_members(ctx, row, *, subject: str, body: str, already: str, row_id) -> int:
+        """Send the write-up to the OTHER members of the workspace this meeting is bound to. Returns
+        how many were mailed; NEVER raises.
+
+        A bot requested inside a workspace makes the workspace's meeting, and a group's notes that
+        reach one person are not the group's notes. This is the mail half of that: the access half
+        (the list, the meeting page, the live transcript, the bot status) is enforced in meeting-api
+        against the same `data.workspace_id` this reads.
+
+        UNBOUND MEETINGS ARE UNTOUCHED — no bind, no roster, no extra mail — so every meeting that
+        exists today behaves exactly as it does today. The bind is the whole trigger.
+
+        EACH MEMBER GETS THEIR OWN SCAFFOLD. The link in this mail signs its reader in, so a shared
+        one would hand every member the organiser's session. `mint_scaffold` is per address, and that
+        is why this cannot be one `notify` with many recipients.
+
+        THREE THINGS ARE NOT DONE HERE, deliberately. The organiser is skipped — they were mailed by
+        the caller. A member whose `mail_minutes` is off is skipped, because that setting is a
+        person's answer about minutes mail and this is minutes mail. And nothing is registered as a
+        mail thread: a reply arriving on a member's copy would thread onto the ORGANISER's meeting
+        conversation, which is a different person's chat."""
+        ws = ((row or {}).get("data") or {}).get("workspace_id") if isinstance(row, dict) else None
+        if not ws:
+            return 0
+        uid = str(ctx.refs["uid"])
+        try:
+            raw = ws_file(uid, "policy/members.json", str(ws))
+            members = json.loads(raw) if raw else []
+            if not isinstance(members, list):
+                return 0
+        except Exception as e:  # noqa: BLE001 — an unreadable roster is not a reason to fail the step
+            logger.warning("group minutes: roster unreadable for workspace %s (uid %s): %s", ws, uid, e)
+            return 0
+        sent = 0
+        for member in members:
+            if not isinstance(member, dict):
+                continue
+            addr = str(member.get("email") or "").strip()
+            them = str(member.get("subject") or "").strip()
+            if not addr or addr.lower() == str(already or "").strip().lower() or them == uid:
+                continue
+            try:
+                if them and not setting(them, "mail_minutes"):
+                    continue
+                their_link = mint_scaffold(
+                    "post-meeting", addr, opening="minutes-review",
+                    meeting_id=row_id or ctx.refs["meeting_id"],
+                    refs=_scaffold_refs(ctx, uid),
+                    provenance={"flow": "post_meeting", "step": "email_minutes_group",
+                                "reaction_id": str(getattr(ctx, "reaction_id", "") or ""),
+                                "minted_by": uid, "workspace": str(ws)})
+                notify(addr, subject, body, link=their_link)
+                sent += 1
+            except Exception as e:  # noqa: BLE001 — one member's mail never costs the others theirs
+                logger.warning("group minutes: member mail failed in workspace %s (uid %s): %s", ws, uid, e)
+        return sent
 
 
     def _mail_the_recording(ctx: StepCtx):

--- a/core/flows/tests/test_group_minutes_mail.py
+++ b/core/flows/tests/test_group_minutes_mail.py
@@ -1,0 +1,175 @@
+"""THE WRITE-UP OF A GROUP'S MEETING REACHES THE GROUP — Vexa-ai/vexa#1648.
+
+Founder, 2026-09-06, ninety seconds after sending a bot into a call from inside a shared workspace:
+*"it was mailed to [the admin] not to [the member]"*. The deployment's mail sink showed the cause —
+a `Minutes: <the workspace>` mail whose subject names the workspace and whose recipient list is one
+address. `_organizer_address` answers with a single address and falls back to the requester's own
+for an ad-hoc meeting, so a meeting that belongs to a group was written up for whoever asked for it.
+
+Four properties:
+
+  1. THE BIND IS THE WHOLE TRIGGER. No `data.workspace_id`, no roster read, no extra mail — so every
+     meeting that exists today behaves exactly as it does today.
+  2. EVERY OTHER MEMBER GETS IT, and each gets THEIR OWN scaffold link. The link in this mail signs
+     its reader in; one shared link would hand every member the organiser's session.
+  3. THE ORGANISER IS MAILED ONCE. They are the step's contract and the caller already sent to them.
+  4. THE FAN-OUT CANNOT COST THE ORGANISER THEIR MAIL. An unreadable roster, or one member's send
+     failing, must not fail a step whose receipt is the organiser's message id.
+
+Offline like the rest of the suite: no network, no clock, no SMTP.
+"""
+from __future__ import annotations
+
+import json
+
+import flows_defs.production as production
+import flows_steps.mailtext as mailtext
+import flows_steps.notify as notify_mod
+import pytest
+from flows import Done, Reaction, Registry, StepCtx
+
+from test_link_loop import FakeChannel, FakeScaffolds, _StubDB
+
+WS = "team-notes"
+ORGANISER, MEMBER, READER = "anna@bank.test", "ben@bank.test", "cara@bank.test"
+REFS = {"uid": "7", "organizer": ORGANISER, "title": "Group call", "meeting_id": 97,
+        "start": 1_700_003_600.0}
+PRIOR = {"process_meeting": {"report": "## Decided\n- ship it\n", "group": WS, "room_read": []}}
+
+ROSTER = [
+    {"subject": "7", "role": "owner", "email": ORGANISER},
+    {"subject": "8", "role": "contributor", "email": MEMBER},
+    {"subject": "9", "role": "reader", "email": READER},
+]
+
+
+@pytest.fixture(autouse=True)
+def scaffolds(monkeypatch):
+    fake = FakeScaffolds()
+    monkeypatch.setattr(production, "mint_scaffold", fake)
+    return fake
+
+
+def _ctx(refs: dict, prior: dict | None = None) -> StepCtx:
+    r = Reaction("rid", "sid", "e", refs, "f", 1, "step", "running", 1, 0.0, None, None, None)
+    return StepCtx(reaction=r, effect_key="rid:step", prior=prior or {},
+                   clock_now=1_700_000_000.0, scratch={}, flow=None)
+
+
+def _rig(monkeypatch, *, bound=WS, roster=ROSTER, settings=None):
+    """`bound` is the meeting's `data.workspace_id` — None for an unbound meeting. `roster` is what
+    that workspace's `policy/members.json` holds; a string is served verbatim (for the unreadable
+    case) and an exception instance is raised."""
+    reg = Registry()
+    production.build(reg, _StubDB())
+    ch = FakeChannel()
+    notify_mod.use(ch)
+
+    def read(uid, path, slug=None):
+        if slug == "_global":
+            return "# Acme Bank\n\nthe org handbook" if path == "README.md" else None
+        if path == "policy/members.json" and slug == WS:
+            if isinstance(roster, Exception):
+                raise roster
+            return roster if isinstance(roster, str) else json.dumps(roster)
+        return None
+
+    monkeypatch.setattr(production, "ws_file", read)
+    monkeypatch.setattr(mailtext, "ws_file", read)
+    monkeypatch.setattr(production, "setting",
+                        settings or (lambda uid, key: "" if key == "timezone" else True))
+    row = {"id": 97, **({"data": {"workspace_id": bound}} if bound else {})}
+    monkeypatch.setattr(production.mt, "meeting_row", lambda uid, mid, native=None: row)
+    return reg, ch
+
+
+def teardown_function():
+    notify_mod.use(None)
+
+
+def _sent_to(ch):
+    return sorted(m["to"] for m in ch.sent)
+
+
+# ── 1 · the bind is the trigger ──────────────────────────────────────────────────────────────
+def test_an_unbound_meeting_is_written_up_for_its_organiser_alone(monkeypatch):
+    reg, ch = _rig(monkeypatch, bound=None)
+    out = reg.steps["email_minutes"](_ctx(dict(REFS), PRIOR))
+    assert isinstance(out, Done)
+    assert _sent_to(ch) == [ORGANISER]
+
+
+# ── 2 · a bound meeting reaches its members, each with their own link ────────────────────────
+def test_a_bound_meeting_reaches_every_member(monkeypatch):
+    reg, ch = _rig(monkeypatch)
+    out = reg.steps["email_minutes"](_ctx(dict(REFS), PRIOR))
+
+    assert _sent_to(ch) == sorted([ORGANISER, MEMBER, READER])
+    # A READER IS INCLUDED. Owner and contributor see everything and a reader reads; the notes are
+    # a read, so leaving them out would be a rule nobody wrote.
+    assert READER in _sent_to(ch)
+    # one report, three copies — the same words reach everybody in the room
+    assert len({m["body"] for m in ch.sent}) == 1
+    assert "## Decided" in ch.sent[0]["body"]
+    # THE RECEIPT IS STILL THE ORGANISER'S MAIL — the first one sent, and the step's contract. A
+    # fan-out that overwrote it would make the receipt name a message the organiser never got.
+    assert out.result["message_id"] == "<fake-1@test>"
+    assert ch.sent[0]["to"] == ORGANISER
+
+
+def test_every_member_gets_their_own_sign_in_link(monkeypatch):
+    """The link signs its reader in. One shared link would hand every member the organiser's
+    session — which is the same class of mistake as forwarding an invite."""
+    reg, ch = _rig(monkeypatch)
+    reg.steps["email_minutes"](_ctx(dict(REFS), PRIOR))
+    links = [m["link"] for m in ch.sent]
+    assert len(links) == 3 and len(set(links)) == 3
+
+
+# ── 3 · the organiser is mailed once ─────────────────────────────────────────────────────────
+def test_the_organiser_is_not_mailed_twice_by_being_on_the_roster(monkeypatch):
+    reg, ch = _rig(monkeypatch)
+    reg.steps["email_minutes"](_ctx(dict(REFS), PRIOR))
+    assert [m["to"] for m in ch.sent].count(ORGANISER) == 1
+
+
+def test_a_member_who_turned_minutes_mail_off_is_skipped(monkeypatch):
+    """`mail_minutes` is a person's answer about minutes mail, and this is minutes mail. Subject 8
+    is the contributor."""
+    def settings(uid, key):
+        if key == "timezone":
+            return ""
+        return False if (key == "mail_minutes" and str(uid) == "8") else True
+
+    reg, ch = _rig(monkeypatch, settings=settings)
+    reg.steps["email_minutes"](_ctx(dict(REFS), PRIOR))
+    assert _sent_to(ch) == sorted([ORGANISER, READER])
+
+
+# ── 4 · the fan-out never costs the organiser their mail ─────────────────────────────────────
+@pytest.mark.parametrize("roster", [
+    RuntimeError("agent door refused"),      # the roster read blew up
+    "{not json at all",                      # …or came back as something that is not a roster
+    "{}",                                    # …or as an object where a list belongs
+])
+def test_an_unreadable_roster_still_writes_the_organiser_up(monkeypatch, roster):
+    reg, ch = _rig(monkeypatch, roster=roster)
+    out = reg.steps["email_minutes"](_ctx(dict(REFS), PRIOR))
+    assert isinstance(out, Done)
+    assert _sent_to(ch) == [ORGANISER]
+
+
+def test_one_members_send_failing_costs_only_that_member(monkeypatch):
+    """One bad address must not cost the rest of the group their notes, and must not fail the step."""
+    reg, ch = _rig(monkeypatch)
+    real = production.notify
+
+    def flaky(to, subject, body, link=None, **kw):
+        if to == MEMBER:
+            raise RuntimeError("that mailbox does not exist")
+        return real(to, subject, body, link=link, **kw)
+
+    monkeypatch.setattr(production, "notify", flaky)
+    out = reg.steps["email_minutes"](_ctx(dict(REFS), PRIOR))
+    assert isinstance(out, Done)
+    assert _sent_to(ch) == sorted([ORGANISER, READER])

--- a/core/flows/tests/test_workspace_invite_mail.py
+++ b/core/flows/tests/test_workspace_invite_mail.py
@@ -359,3 +359,24 @@ def test_a_fact_with_no_link_ends_terminal_and_mails_nobody(monkeypatch):
     assert st["status"] == "failed"
     assert "asks somebody to do nothing" in (st["reason"] or "")
     assert ch.sent == []
+
+
+# ── 6 · the invite goes to the INVITEE, and never to the inviter (Vexa-ai/vexa#1648) ─────────
+def test_the_invite_is_addressed_to_the_invitee_and_never_to_the_inviter(monkeypatch):
+    """The failure this rules out was suspected on 2026-09-06, when a founder reported an invite as
+    having reached his own mailbox instead of the person's. It had not — the mail sink showed the
+    invitee in both the `To` header and the SMTP envelope, and the real defect was one surface
+    further on, in the MEETING WRITE-UP. But the failure mode is a real one and nothing pinned it:
+    the refs carry an address AND a uid, `uid` IS THE INVITER, and a step that mailed `uid` would
+    mail the sender their own invitation (`publish.invite_refs` says exactly that in prose).
+
+    So: the recipient is `email` and it tracks `email`, while `uid` and `inviter` move under it
+    without ever becoming the address."""
+    reg, ch = _rig(monkeypatch)
+    refs = dict(REFS, email="marvin@example.test", uid="176", inviter="admin@example.test")
+    reg.steps["mail_workspace_invite"](_ctx(refs))
+
+    assert [m["to"] for m in ch.sent] == ["marvin@example.test"]
+    # the inviter appears in the SUBJECT (it is their invitation) and nowhere in the addressing
+    assert "admin@example.test" in ch.sent[0]["subject"]
+    assert ch.sent[0]["to"] != refs["inviter"] and ch.sent[0]["to"] != refs["uid"]

--- a/core/gateway/services/gateway/src/gateway/app.py
+++ b/core/gateway/services/gateway/src/gateway/app.py
@@ -1111,8 +1111,22 @@ async def run_multiplex(ws: WebSocket, authorizer: Authorizer, redis: RedisBus) 
     # frame is needed: the identity is resolved at connect. This reuses the SAME verbatim `fan_in`
     # path as the per-meeting channels — the gateway is a thin raw forwarder for the user channel
     # exactly as it is for tc:/bm:/va:. Per-meeting subscriptions below are unchanged.
+    #
+    # AND to every workspace this identity is a member of — `w:{workspace_id}:meetings`, carrying the
+    # status frames of meetings BOUND to that workspace. A bot requested inside a workspace makes the
+    # workspace's meeting, so its transitions belong to every member's list, not only the requester's.
+    # The membership list comes from the SAME connect-time identity resolve as `user_id` above
+    # (`user_data["workspaces"]`, which identity builds from `users.data.memberships[]`), so a client
+    # cannot name a workspace it does not belong to — it sends no subscribe frame at all. Membership
+    # is therefore evaluated per CONNECTION: a member added mid-session picks the channel up on their
+    # next connect, which is the same freshness the rest of this socket's identity already has.
     user_channel = f"u:{user_id}:meetings"
-    user_sub_task = asyncio.create_task(fan_in([user_channel]))
+    member_channels = [
+        f"w:{str(w).strip()}:meetings"
+        for w in (user_data.get("workspaces") or [])
+        if str(w).strip()
+    ]
+    user_sub_task = asyncio.create_task(fan_in([user_channel, *member_channels]))
 
     try:
         while True:

--- a/core/meetings/services/meeting-api/src/meeting_api/app.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/app.py
@@ -856,6 +856,12 @@ def _mount_lifecycle(
                 # terminal's list surface gets every bot-FSM transition over WS (superset of bm:; it
                 # also carries the pre-FSM idle/scheduled states). KEEP bm: above for the open-meeting
                 # tab. Best-effort: never fail the lifecycle callback.
+                #
+                # A meeting BOUND TO A WORKSPACE also goes to `w:{workspace_id}:meetings`, the channel
+                # every member's socket joins at connect. This is the transition members actually need
+                # — requested → joining → active is the bot arriving in THEIR call — and publishing it
+                # only to the owner is why a member's terminal showed nothing happening while the
+                # meeting ran.
                 user_id = meeting_row.get("user_id")
                 if user_id is not None:
                     user_frame = {
@@ -865,14 +871,17 @@ def _mount_lifecycle(
                         "status": rec.status.value,
                         "when": frame["ts"],
                     }
-                    try:
-                        await redis.publish(
-                            f"u:{user_id}:meetings", _json.dumps(user_frame)
-                        )
-                    except Exception as e:  # noqa: BLE001 — publish is best-effort
-                        log_event("user_meeting_status_publish_failed", audience="system",
-                                  level="warning", span="lifecycle.callback",
-                                  fields={"error": str(e)})
+                    workspace_id = (meeting_row.get("data") or {}).get("workspace_id")
+                    channels = [f"u:{user_id}:meetings"]
+                    if workspace_id:
+                        channels.append(f"w:{workspace_id}:meetings")
+                    for channel in channels:
+                        try:
+                            await redis.publish(channel, _json.dumps(user_frame))
+                        except Exception as e:  # noqa: BLE001 — publish is best-effort
+                            log_event("user_meeting_status_publish_failed", audience="system",
+                                      level="warning", span="lifecycle.callback",
+                                      fields={"error": str(e), "channel": channel})
         # COPILOT REAP (Bug 3): the moment a meeting lands TERMINAL, emit the `session_end` marker onto
         # the meeting copilot transcript feed — the EXACT stream the meeting copilot worker
         # (agent worker/meeting.py, via VEXA_TRANSCRIPT_STREAM) blocks on. The worker reaps immediately

--- a/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/router.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/router.py
@@ -270,6 +270,9 @@ def build_router(
         request: Request,
         x_user_id: Optional[str] = Header(default=None),
         x_user_limits: Optional[str] = Header(default=None),
+        # The caller's workspace memberships, injected by the gateway from identity. Read ONLY to
+        # authorize an explicit `workspace_id` in the body against real membership.
+        x_user_workspaces: Optional[str] = Header(default=None),
         x_user_webhook_url: Optional[str] = Header(default=None),
         x_user_webhook_secret: Optional[str] = Header(default=None),
         x_user_webhook_events: Optional[str] = Header(default=None),
@@ -454,6 +457,27 @@ def build_router(
         # STOPS THE SPAWN: a name is a nicety, joining the call is the product.
         bot_name = body.get("bot_name")
 
+        # WHICH WORKSPACE THIS MEETING BELONGS TO. Optional and additive: a caller that sends nothing
+        # gets exactly the meeting it got before — its own, visible to itself alone.
+        #
+        # The caller's OWN membership is what makes this safe to accept from a request body. The
+        # gateway resolves the api key to an identity and injects `x-user-workspaces` from that
+        # identity's memberships; the body cannot forge that header. So a `workspace_id` the caller
+        # does not belong to is REFUSED here rather than persisted — without the check, anyone with an
+        # api key could publish a meeting into a workspace they are not in, and every member of it
+        # would find a stranger's call in their list, on their meeting page and in its live
+        # transcript, since `data.workspace_id` is exactly what those surfaces trust.
+        workspace_id = body.get("workspace_id")
+        if workspace_id is not None:
+            if not isinstance(workspace_id, str) or not workspace_id.strip():
+                raise HTTPException(
+                    status_code=422, detail="'workspace_id' must be a non-empty string")
+            workspace_id = workspace_id.strip()
+            member_of = {w.strip() for w in (x_user_workspaces or "").split(",") if w.strip()}
+            if workspace_id not in member_of:
+                raise HTTPException(
+                    status_code=403, detail=f"not a member of workspace '{workspace_id}'")
+
         try:
             meeting = await request_bot(
                 repo,
@@ -476,6 +500,7 @@ def build_router(
                 # has no additionalProperties:false), so the wire is not rejected; documenting it as
                 # a public typed field needs a vN+1 (lane:contract) — see the bot_spawn README.
                 continue_meeting=bool(body.get("continue_meeting", False)),
+                workspace_id=workspace_id,
                 max_concurrent=max_concurrent,
                 webhook_url=x_user_webhook_url,
                 webhook_secret=x_user_webhook_secret,

--- a/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/service.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/bot_spawn/service.py
@@ -431,6 +431,18 @@ async def request_bot(
     webhook_url: Optional[str] = None,
     webhook_secret: Optional[str] = None,
     webhook_events: Optional[dict] = None,
+    # THE MEETING'S WORKSPACE, decided at spawn. A bot requested from inside a workspace makes the
+    # WORKSPACE's meeting, not the requester's private one: `data.workspace_id` is the single fact
+    # every member-facing surface reads (`list_meetings`' third access branch, `GET /meetings/{id}`,
+    # the live SSE, the status fan-out, the write-up's recipients). Before this, an ad-hoc spawn had
+    # no way to say which workspace it belonged to — `POST /bots` took no such field and nothing
+    # called `POST /meetings/{platform}/{native}/workspace` — so every ad-hoc meeting was owner-only
+    # by construction and a member "could not see the call" in their own terminal.
+    #
+    # Written on the FRESH-INSERT path only. `continue_meeting` reopens a row that already carries
+    # whatever bind it was created with, and re-binding it here would let a later spawn move
+    # somebody else's meeting between workspaces on a path that never asked about membership.
+    workspace_id: Optional[str] = None,
     # Fresh-meeting stream hygiene: purge tc:meeting:{new_row_id} on a FRESH insert so a new meeting
     # never inherits a prior generation's transcript (a reused row id after a DB reset would otherwise
     # carry a stale session_end → "Meeting ended" before the first word). Injected (redis-backed in
@@ -699,6 +711,11 @@ async def request_bot(
         if transcription_provider is not None:
             meeting_data["transcription_provider"] = transcription_provider
         meeting_data["service_authority"] = authority_record
+        # The workspace bind (see the parameter's note). Same key, same shape and same readers as the
+        # one `bind_workspace` writes after the fact — this only writes it EARLY, so the meeting is
+        # the workspace's from its first row rather than from whenever someone remembered to bind it.
+        if workspace_id:
+            meeting_data["workspace_id"] = workspace_id
         # The serialization key for authenticated spawns — find_active_by_userdata matches on it.
         if authenticated and auth_userdata_path:
             meeting_data["auth_userdata_path"] = auth_userdata_path

--- a/core/meetings/services/meeting-api/src/meeting_api/collector/app.py
+++ b/core/meetings/services/meeting-api/src/meeting_api/collector/app.py
@@ -82,10 +82,24 @@ async def _publish_user_meeting_status(
     status: str,
     when: Optional[str],
     log_event: Callable[..., dict],
+    workspace_id: Optional[str] = None,
 ) -> None:
     """Best-effort publish of a FLAT ``meeting.status`` frame to the user-scoped channel
     ``u:{user_id}:meetings`` so the terminal's list surface gets every status change over WS
-    (the gateway forwards the redis payload verbatim). No-op if redis is down / args missing."""
+    (the gateway forwards the redis payload verbatim). No-op if redis is down / args missing.
+
+    A meeting BOUND TO A WORKSPACE is additionally published to ``w:{workspace_id}:meetings``. That
+    is the second channel every member's socket is subscribed to at connect, and it is why a member
+    watching their group's call sees the bot go joining → active in their own terminal instead of a
+    row frozen at whatever it said when the page loaded.
+
+    The alternative — resolving the workspace's roster here and publishing once per member — was
+    rejected: this service does not hold the roster (it lives in the agent's `policy/members.json`),
+    it would add a membership read to a hot best-effort path, and a member added mid-meeting would
+    receive nothing until the next publish. One channel per workspace has none of that: the socket
+    subscribes from the member's OWN identity at connect, so the fan-out follows membership for free.
+    The owner publish is unconditional and unchanged — an owner who is also a member gets the frame
+    on both channels, and the terminal keys the list by meeting id, so a duplicate is idempotent."""
     if redis is None or user_id is None or meeting_id is None:
         return
     import json as _json
@@ -97,11 +111,15 @@ async def _publish_user_meeting_status(
         "status": status,
         "when": when,
     }
-    try:
-        await redis.publish(f"u:{user_id}:meetings", _json.dumps(frame))
-    except Exception as e:  # noqa: BLE001 — publish is best-effort
-        log_event("user_meeting_status_publish_failed", audience="system", level="warning",
-                  span="meetings.intent.publish", fields={"error": str(e)})
+    channels = [f"u:{user_id}:meetings"]
+    if workspace_id:
+        channels.append(f"w:{workspace_id}:meetings")
+    for channel in channels:
+        try:
+            await redis.publish(channel, _json.dumps(frame))
+        except Exception as e:  # noqa: BLE001 — publish is best-effort
+            log_event("user_meeting_status_publish_failed", audience="system", level="warning",
+                      span="meetings.intent.publish", fields={"error": str(e), "channel": channel})
 
 
 def _resolve_user_id(x_user_id: Optional[str]) -> int:
@@ -347,17 +365,27 @@ def build_router(
     # --- GET /meetings/{meeting_id} → the single meeting (api.v1; the meeting-detail page fetches it).
     # Constrained by id IN SQL under the same access union, so a non-owner still cannot read another's
     # meeting — but one row is read instead of the caller's entire history (#803). Full `data` is
-    # retained: this IS the detail view. ---
+    # retained: this IS the detail view.
+    #
+    # `x-user-workspaces` is read here for the SAME reason `GET /meetings` reads it: without it this
+    # route ran the access union with its third branch missing, so a member of the meeting's bound
+    # workspace got a 404 on a meeting their own LIST had just shown them — the row is in the list
+    # (that route passes membership) and absent from its own detail page. Every consumer of the
+    # owner-lookup seam inherited that hole: the meeting page, the live SSE, `/api/meeting/note` and
+    # `/api/meeting/terms` all decide access by calling this route. ---
     @router.get("/meetings/{meeting_id}")
     async def get_meeting(
         request: Request,
         meeting_id: int,
         x_user_id: Optional[str] = Header(default=None),
+        x_user_workspaces: Optional[str] = Header(default=None),
     ):
         from .projection import project_response_data
 
         user_id = _resolve_user_id(x_user_id)
-        meetings = await store.list_meetings(user_id, meeting_id=meeting_id)
+        member_workspaces = {w.strip() for w in (x_user_workspaces or "").split(",") if w.strip()}
+        meetings = await store.list_meetings(
+            user_id, meeting_id=meeting_id, member_workspaces=member_workspaces)
         meeting = next((m for m in meetings if m.get("id") == meeting_id), None)
         if meeting is None:
             return JSONResponse(status_code=404, content={"detail": "Meeting not found"})

--- a/core/meetings/services/meeting-api/tests/test_bot_spawn.py
+++ b/core/meetings/services/meeting-api/tests/test_bot_spawn.py
@@ -1251,3 +1251,59 @@ async def test_spawn_threads_capture_signal_from_bot_context(monkeypatch, ctx, e
                       token_secret=SECRET)
     inv = json.loads(runtime.specs[0]["env"]["BOT_CONFIG"])
     assert inv["captureSignalEnabled"] is expected
+
+
+# ── the workspace a bot belongs to (Vexa-ai/vexa#1648) ───────────────────────────────────────────
+# A bot requested from inside a workspace makes the WORKSPACE's meeting: `data.workspace_id` is
+# written AT SPAWN, and it is the single fact every member-facing surface reads afterwards. Before
+# this, `POST /bots` took no such field and nothing called the after-the-fact bind endpoint, so an
+# ad-hoc meeting was owner-only by construction.
+
+def _spawn(client, body, workspaces=None):
+    headers = dict(HEADERS)
+    if workspaces is not None:
+        headers["x-user-workspaces"] = ",".join(workspaces)
+    return client.post("/bots", headers=headers, json=body)
+
+
+def test_spawn_binds_the_meeting_to_the_callers_workspace(monkeypatch):
+    monkeypatch.setenv("ADMIN_TOKEN", SECRET)
+    repo = InMemoryMeetingRepo()
+    r = _spawn(_client(repo), {"platform": "google_meet", "native_meeting_id": "grp-aaaa-bbb",
+                               "workspace_id": "team-notes"}, ["team-notes", "other-ws"])
+    assert r.status_code == 201, r.text
+    assert r.json()["data"]["workspace_id"] == "team-notes"
+
+
+def test_spawn_without_a_workspace_is_the_meeting_it_has_always_been(monkeypatch):
+    """The bind is additive. A caller that names no workspace gets its own private meeting, exactly
+    as before — which is what keeps every existing integration behaving as it does today."""
+    monkeypatch.setenv("ADMIN_TOKEN", SECRET)
+    r = _spawn(_client(), {"platform": "google_meet", "native_meeting_id": "solo-aaaa-bbb"},
+               ["team-notes"])
+    assert r.status_code == 201, r.text
+    assert "workspace_id" not in (r.json().get("data") or {})
+
+
+def test_spawn_refuses_a_workspace_the_caller_is_not_in(monkeypatch):
+    """THE BODY CANNOT FORGE MEMBERSHIP. `x-user-workspaces` is injected by the gateway from the
+    resolved identity; without this check anyone with an api key could publish a meeting into a
+    workspace they do not belong to, and every member of it would find a stranger's call in their
+    list, on their meeting page and in its live transcript."""
+    monkeypatch.setenv("ADMIN_TOKEN", SECRET)
+    r = _spawn(_client(), {"platform": "google_meet", "native_meeting_id": "sneak-aaaa-bbb",
+                           "workspace_id": "someone-elses"}, ["team-notes"])
+    assert r.status_code == 403
+    assert "someone-elses" in r.json()["detail"]
+
+    # and with no membership header at all — the direct/unresolved caller — it is still refused
+    assert _spawn(_client(), {"platform": "google_meet", "native_meeting_id": "sneak2-aaaa-bbb",
+                              "workspace_id": "team-notes"}).status_code == 403
+
+
+@pytest.mark.parametrize("bad", ["", "   ", 7, [], {}])
+def test_spawn_refuses_a_workspace_id_that_is_not_a_slug(monkeypatch, bad):
+    monkeypatch.setenv("ADMIN_TOKEN", SECRET)
+    r = _spawn(_client(), {"platform": "google_meet", "native_meeting_id": "bad-aaaa-bbb",
+                           "workspace_id": bad}, ["team-notes"])
+    assert r.status_code == 422, r.text

--- a/core/meetings/services/meeting-api/tests/test_meeting_workspace_bind.py
+++ b/core/meetings/services/meeting-api/tests/test_meeting_workspace_bind.py
@@ -59,3 +59,41 @@ def test_unbound_meeting_is_owner_only():
     client, _ = _client()  # never bound
     assert _authz(client, OWNER)["authorized"]                      # owner still fine
     assert not _authz(client, MEMBER, ["team-notes"])["authorized"] # nobody rides in without a binding
+
+
+# ── the meeting PAGE, not just the subscribe (Vexa-ai/vexa#1648) ─────────────────────────────────
+# `GET /meetings/{id}` ran the access union with its workspace branch missing, so a member got a 404
+# on a meeting their own LIST had just shown them. Everything that decides access by calling this
+# route inherited the hole: the meeting page, the live SSE, /api/meeting/note and /api/meeting/terms.
+
+def _get_meeting(client, mid, uid, workspaces=None):
+    headers = {"x-user-id": str(uid)}
+    if workspaces is not None:
+        headers["x-user-workspaces"] = ",".join(workspaces)
+    return client.get(f"/meetings/{mid}", headers=headers)
+
+
+def test_member_of_the_bound_workspace_may_open_the_meeting():
+    client, mid = _client()
+    client.post(f"/meetings/{PLAT}/{NID}/workspace", json={"workspace_id": "team-notes"},
+                headers={"x-user-id": str(OWNER)})
+
+    assert _get_meeting(client, mid, OWNER).status_code == 200          # owner, unchanged
+
+    member = _get_meeting(client, mid, MEMBER, ["team-notes", "other-ws"])
+    assert member.status_code == 200, member.text
+    # It is the OWNER's row reaching them through the workspace, and the projection says so — a
+    # member must be able to tell a colleague's meeting from one of their own.
+    assert member.json()["shared"] is True
+
+    # a non-member is refused, and so is a member of a DIFFERENT workspace: the bind is the boundary
+    assert _get_meeting(client, mid, STRANGER, []).status_code == 404
+    assert _get_meeting(client, mid, STRANGER, ["some-other-ws"]).status_code == 404
+
+
+def test_an_unbound_meeting_stays_private_to_its_owner():
+    """The bind is the whole trigger. Without one, membership grants nothing — which is what keeps
+    every meeting that exists today behaving exactly as it does today."""
+    client, mid = _client()                                            # never bound
+    assert _get_meeting(client, mid, OWNER).status_code == 200
+    assert _get_meeting(client, mid, MEMBER, ["team-notes"]).status_code == 404

--- a/deploy/dogfood/rig/vexa_control_mcp.py
+++ b/deploy/dogfood/rig/vexa_control_mcp.py
@@ -812,6 +812,27 @@ _TARGET_DEFAULTING = frozenset({"workspace_write", "workspace_delete", "workspac
 _DESK_ALIASES = frozenset({"personal", "desk"})
 
 
+def _meeting_workspace(explicit: str = "") -> str:
+    """WHICH WORKSPACE A BOT THIS CONVERSATION SENDS BELONGS TO — a slug, or "" for the person's own
+    desk.
+
+    The same rule `_TARGET_DEFAULTING` applies to a write verb's `slug`, and for the same reason: a
+    bot sent with no workspace named is the model saying "wherever this conversation is working". A
+    meeting is not a file, but requesting one IS a write — it creates a row, a live transcript and a
+    write-up — and before this the row was always the requester's private one, so a member of the
+    workspace the chat was working in could not see the call they were in.
+
+    Applied HERE rather than in the shared decorator because these verbs have no `slug`: on
+    `bot_send` the parameter is `workspace`, and `slug` already means "the workspace to write a file
+    into" everywhere else. Two names for one idea in one signature is worse than this small
+    duplication. `personal`/`desk` keep the meeting private exactly as they keep a write on the
+    desk."""
+    asked = (explicit or "").strip()
+    if asked in _DESK_ALIASES:
+        return ""
+    return asked or CALL_TARGET.get()
+
+
 class _DelegationRefused(Exception):
     """A delegated token was offered and is not acceptable. ``reason`` is safe to hand a caller."""
 
@@ -3990,17 +4011,31 @@ def _bot_conflict_state(uid: str, platform: str, mid: str):
 
 @mcp.tool()
 @_anon_guard
-def bot_send(meeting_url: str, bot_name: str = "") -> str:
+def bot_send(meeting_url: str, bot_name: str = "", workspace: str = "") -> str:
     """Send a Vexa bot into a live meeting NOW. THE main verb — when your person hands you a
     meeting link, this is the call.
 
     The bot knocks within ~30 seconds; someone in the call admits it. From then on
     meeting_transcript(meeting_url) returns the words as they are spoken — read them into this
-    conversation and work with them directly. The workspace machinery is optional."""
+    conversation and work with them directly. The workspace machinery is optional.
+
+    A BOT SENT FROM A WORKSPACE MAKES THAT WORKSPACE'S MEETING, and this conversation's workspace is
+    used automatically — there is nothing to pass. Every member then sees it in their own terminal
+    while it runs: in their meeting list, on the meeting page, in the live transcript, and the bot's
+    status as it changes. Say so when you send it, in one line: it is the answer to *"can we issue a
+    bot that belongs to the group?"*, and the person cannot see the binding otherwise.
+
+    `workspace` overrides that for one call — a slug to bind elsewhere, or "personal" to keep the
+    meeting on their own desk, visible to them alone."""
     uid = me()
     platform, mid = _meeting_ref(meeting_url)
     if not platform:
         return json.dumps({"error": mid})
+    # WHICH WORKSPACE THIS MEETING BELONGS TO. Same rule as a write verb's slug (`_TARGET_DEFAULTING`):
+    # the conversation's target unless this call named one, and `personal` names the desk. Sending a
+    # bot IS a write — it creates a meeting row — so the founder's *"the thing knew the workspace of
+    # writing, if it's specified"* applies to it exactly as to a file.
+    ws = _meeting_workspace(workspace)
     # THE URL TRAVELS. Parsing gives a platform and a stable id to key on, but it is a
     # derivation and not a replacement: a Zoom link carries its passcode in ?pwd=, which no
     # downstream can reconstruct from the numeric id. Dropping it produced a refusal that asked
@@ -4020,7 +4055,8 @@ def bot_send(meeting_url: str, bot_name: str = "") -> str:
     said_name = bot_name or _bot_default_name(uid) or "Vexa"
     body = {"platform": platform, "native_meeting_id": mid,
             "meeting_url": meeting_url.strip(),
-            **({"bot_name": bot_name} if bot_name else {})}
+            **({"bot_name": bot_name} if bot_name else {}),
+            **({"workspace_id": ws} if ws else {})}
     st, r = _gw_http(uid, "POST", "/bots", body)
     if st == 409:
         # F193/F194. A 409 used to mean ONE thing to the caller — `already_there: true` — for a
@@ -4995,7 +5031,7 @@ def _scheduled_joins(mid: str):
 @_anon_guard
 def bot_schedule(meeting_url: str, in_minutes: int = 0, at_epoch: float = 0,
                  at_local: str = "", tz: str = "",
-                 title: str = "", cancel: bool = False) -> str:
+                 title: str = "", cancel: bool = False, workspace: str = "") -> str:
     """Book the bot to join a meeting LATER, or call that booking off with cancel=True.
 
     ALWAYS PASS tz — the person's IANA zone ("Europe/Lisbon"), which you know from their
@@ -5008,7 +5044,12 @@ def bot_schedule(meeting_url: str, in_minutes: int = 0, at_epoch: float = 0,
     alive. The person gets an acknowledgment email; after the call the write-up runs on its own.
 
     cancel=True with the same meeting_url calls off whatever was booked for that meeting —
-    no id to find, no queue to read."""
+    no id to find, no queue to read.
+
+    A BOOKING MADE FROM A WORKSPACE BELONGS TO THAT WORKSPACE, automatically — the meeting is the
+    group's when it runs, and its write-up lands on the group's desk rather than only the booker's.
+    Say so in the same line that confirms the time. `workspace` overrides it for one call;
+    "personal" keeps the booking private."""
     uid = me()
     platform, mid = _meeting_ref(meeting_url)
     if not platform:
@@ -5086,11 +5127,16 @@ def bot_schedule(meeting_url: str, in_minutes: int = 0, at_epoch: float = 0,
                   "not ask your person for their email; they are already signed in.",
         })
     sid_ev = f"sched-{mid}-{int(start)}"
+    # `group` IS THE WORKSPACE THIS BOOKING BELONGS TO — the ref the production flow already reads to
+    # decide whether a meeting's knowledge is a group's or one person's. It was hard-coded `None`
+    # here, so every bot booked from a chat was private no matter which workspace the chat was
+    # working in; `""` and `None` are both "no group" downstream, so a personal booking is unchanged.
+    ws = _meeting_workspace(workspace)
     res = json.loads(fact_emit(
         event_type="invite.received", source_event_id=sid_ev,
         subject_refs={"organizer": email, "url": meeting_url, "start": start,
                       "ics_uid": sid_ev, "title": title or f"Scheduled: {mid}",
-                      "group": None}))
+                      "group": ws or None}))
     if not res.get("admitted"):
         return json.dumps({"error": "the schedule could not be filed",
                            "detail": str(res)[:200], "do": "report_friction() with this"})

--- a/docs/changelog.d/1648-group-meeting-binding.md
+++ b/docs/changelog.d/1648-group-meeting-binding.md
@@ -1,0 +1,10 @@
+- **A bot requested inside a workspace is the workspace's meeting, live for every member (#1648).**
+  `POST /bots` takes an optional `workspace_id`, authorized against the caller's own resolved
+  memberships, and writes it to `data.workspace_id` at spawn; the chat's `bot_send` / `bot_schedule`
+  send the workspace the conversation is working in, so *"assign it to the group"* binds instead of
+  being refused. Every member of the bound workspace then sees the meeting while it runs — in the
+  list (already), on the meeting page, in the live transcript, in `/api/meeting/note` and
+  `/api/meeting/terms`, and in the bot's status, which is now published to a per-workspace channel
+  each member's socket joins at connect. A workspace's front page lists its meetings, live ones
+  first, and the write-up mail reaches the workspace's members rather than the requester alone.
+  Unbound meetings are untouched: no bind, no widening, no extra mail.


### PR DESCRIPTION
Refs Vexa-ai/vexa#1648.

A bot requested from inside a workspace was spawned on the requester's own account and belonged to
nobody else, so the other members could not see the meeting they were in and its write-up was mailed
to one person. This binds the meeting to the workspace **at spawn** and widens every member-facing
surface to the access union meeting-api already evaluates.

`data.workspace_id` is the single fact all of it turns on. **Unbound meetings are untouched** — no
bind, no widening, no extra mail — so every meeting that exists today behaves exactly as it does
today.

## What changed, per surface

**The bind** — `core/meetings/services/meeting-api/…/bot_spawn/{router,service}.py`
`POST /bots` takes an optional `workspace_id` and writes it into `data` on the fresh-insert path.
The body cannot forge membership: it is authorized against `x-user-workspaces`, which the gateway
injects from the resolved identity — a workspace the caller is not in is `403`, a non-string or
blank one is `422`. `continue_meeting` is deliberately excluded; it reopens a row that already
carries its own bind, and re-binding there would let a later spawn move someone else's meeting
between workspaces on a path that never asked about membership.

**Who sends it** — `deploy/dogfood/rig/vexa_control_mcp.py`
`bot_send` and `bot_schedule` bind to the workspace the conversation is working in
(`CALL_TARGET`, the same value a write verb's `slug` defaults to), with a `workspace` argument to
override for one call and `"personal"` to keep a meeting private. `bot_schedule`'s `group` ref was
hard-coded `None`, so every booking made from a chat was private regardless of where the chat was
working.

**The meeting page** — `…/collector/app.py`
`GET /meetings/{id}` now reads `x-user-workspaces` and passes it to `list_meetings`, which already
supports it. Without this a member got a `404` on a meeting their own **list** had just shown them.

**The live surfaces** — `core/agent/control_plane/{api_shared.py,routers/meetings.py}`
`_http_meeting_owner_lookup` forwards the caller's workspaces as `X-User-Workspaces`, so the SSE
stream, `/api/meeting/note` and `/api/meeting/terms` all widen through the one seam their own
comment named ("the clean seam", left unhonoured). Memberships are read from `policy/members.json`,
**not** from a request header: agent-api is reachable directly in the dev/self-host topology where
identity headers are spoofable, and this value decides who may read a live transcript. The lookup is
an injected seam that five test modules fake with a two-argument callable, so the router asks the
callable its arity once rather than rescuing `TypeError` — which would also swallow a genuine
`TypeError` from inside a lookup and silently downgrade it to "not authorized".

**The bot status** — `…/meeting_api/{app.py,collector/app.py}`, `core/gateway/…/gateway/app.py`
A bound meeting's status frames also publish to `w:{workspace_id}:meetings`, and the gateway
subscribes each socket to that channel for every workspace in the identity it resolved at connect.
**This is the smaller change** of the two available: fanning out to each member's own user channel
would need the publisher to hold the roster (it lives in the agent's `policy/members.json`, not in
meeting-api), would add a membership read to a hot best-effort path, and would silently miss anyone
added mid-meeting. One channel per workspace has none of that — the socket subscribes from the
member's own identity, so the fan-out follows membership for free.

**The terminal** — `clients/terminal/src/minutes/{workspaceReadme.ts,WorkspaceReadmePanel.tsx}`
`workspaceMeetings()` lists the workspace's meetings with live ones first, rendered as a Meetings
section on a group's front page. The live lift is its own sort key, not a time comparison: an
upcoming meeting's `start_time` is in the future and would outrank a live one on any pure time sort.

**The write-up** — `core/flows/src/flows_defs/production.py`
`_mail_group_members` sends the minutes to the other members of the bound workspace, after the
organiser's mail and never in place of it. Each member gets their **own** scaffold link — the link
signs its reader in, so a shared one would hand every member the organiser's session. A member whose
`mail_minutes` is off is skipped, and no member copy is registered as a mail thread (a reply would
otherwise thread onto the organiser's meeting conversation).

**The asks** — `behavior/asks/{minutes-review-invite,first-visit}.md`
Worth stating plainly: **no ask ever said a bot cannot belong to a group.** I grepped the corpus for
it; the denial was the chat's own inference from possessive framing ("the meetings *you* run",
"their own meetings, or a colleague's"). So the fix is to state the affirmative — that `bot_send`
binds, that the chat should say which workspace, and that a group's meetings are a real answer on a
first visit.

## (B) — what "it was mailed to the wrong person" actually was

Both candidate causes are disproven by evidence, and the finding is in the issue in full. The
address was typed by the founder himself at 18:13:42; both invite mails carry the member in the `To`
header **and** the SMTP envelope. What arrived ten seconds before the complaint was the
`Minutes: <workspace>` mail — the meeting write-up — addressed to one person by
`_organizer_address`. **(B) is (A) one surface further on**, and the write-up change above is its
fix. The invite path is sound and was already defended in prose; a test now pins it.

## Tests

Unit and contract only — no containers were run on this machine.

| Suite | Added |
|---|---|
| `core/meetings/…/tests/test_bot_spawn.py` | bind persisted at spawn · absent when not asked for · `403` for a workspace the caller is not in (and with no membership header at all) · `422` for five non-slug values |
| `core/meetings/…/tests/test_meeting_workspace_bind.py` | `GET /meetings/{id}` for owner · member (and `shared: true`) · non-member · member of a different workspace · unbound stays owner-only |
| `core/agent/tests/test_meeting_workspace_access.py` (new) | `X-User-Workspaces` forwarded, and omitted when there is nothing to send · the four note/terms routes for owner, member and a **reader** · the SSE refusal · membership read from disk, not from a header |
| `core/flows/tests/test_group_minutes_mail.py` (new) | unbound → organiser alone · bound → every member, one link each · organiser mailed once · `mail_minutes` off skipped · unreadable roster (3 shapes) and a failing send still deliver the organiser's mail |
| `core/flows/tests/test_workspace_invite_mail.py` | the invite tracks `email` while `uid`/`inviter` move under it |
| `clients/terminal/…/__tests__/workspaceReadme.test.tsx` | live-first ordering against a further-future scheduled row · `shared` marking · every live phase · empty slug returns nothing |

Green: meeting-api 1437 · agent 2499 · flows 1038 · gateway 373 · rig 128 · terminal 1784.

Two notes on existing tests. `workspaceStrip.test.tsx` asserted exactly three sections and now
asserts four on a group — the rule it encodes is *nothing that repeats the header*, not a count, and
Meetings repeats nothing. `behavior/global/flows/post_meeting.md` is regenerated by `make
flow-pages`; `gate:python` compares it against the registry.

**36 pre-existing failures** in `canvas/__tests__/{minutesLiveView,transcriptExtend,transcriptTerms}.test.tsx`
fail identically on `origin/minutes-mcp-viewer` — confirmed in a clean throwaway worktree. Untouched
here.

## Not done

- **The dogfood is not swapped.** Not mine to swap.
- **The live ask presets are not edited.** `behavior/asks/` is the source; the copies a click reads
  live at `/workspaces/_global/asks/<name>.md` on a running stack and pick this up on the swap.
- **No container gate was run** — no `gate:stack`, no compose. Everything above is unit/contract.
- **`workspace_id` is not in the sealed `api.v1` `MeetingCreate` schema.** That object has no
  `additionalProperties: false`, so the field validates and works on the wire; publishing it as a
  documented public field is a `lane:contract` change, the same treatment `continue_meeting` already
  carries.
- **`GET /bots` is still owner-only.** It is the dashboard's list and takes no `x-user-workspaces`;
  `GET /meetings` is the union-aware twin and is what the terminal reads.
- **`/api/meeting/note` and `/api/meeting/terms` still write under the caller's own desk.** A member
  is no longer refused, but they get *their* note for the meeting, not the owner's. Widening the
  entitlement was the bug; sharing one desk between members is a separate design question.
- **Membership on a websocket is evaluated per connection.** Someone added to a workspace mid-meeting
  picks up its channel on their next connect — the same freshness the rest of that socket's identity
  already has.
- **Not verified against a running deployment.** Every claim here rests on unit tests plus the
  dogfood evidence in the issue.

<!-- vexa-agent -->


---

## Contribution rights
<!-- Select exactly ONE. This is a legal certification: an agent may explain the choices but
     must not select one for you. See CONTRIBUTOR_RIGHTS.md. -->

- [ ] **Independent:** I created this contribution, or otherwise have the right to submit it
  under Apache-2.0, and it is not owned or controlled by an employer, client, or other entity.
  <!-- rights:independent -->
- [ ] **Employer/client authorization required:** an employer, client, or other entity owns or
  may control this contribution. I am requesting Vexa's private corporate-authorization process.
  <!-- rights:corporate -->
- [ ] **Unsure:** I need a private rights review before merge.
  <!-- rights:uncertain -->

**Left unticked deliberately.** The `contribution-rights` check is red because nothing is selected,
and that is correct: the section says an agent may explain the choices but must not select one, so
this one did not. `DCO` is red for the same reason — the commits carry no `Signed-off-by`, and that
trailer is the contributor's own certification, not something to add on their behalf. Both are
one-line human acts:

```
git commit --amend -s --no-edit && git rebase --signoff origin/minutes-mcp-viewer   # if you want the DCO trailer
```

<!-- vexa-agent -->
