### PR TITLE
release-witness-gate: a receipt may name the candidate it walked, not only the published tag

### DIFF
--- a/scripts/release-witness-gate.mjs
+++ b/scripts/release-witness-gate.mjs
@@ -45,7 +45,19 @@ export function validateReceipt(r, version) {
   const errs = [];
 
   if (r.version !== version) errs.push(`version "${r.version}" ≠ release ${version}`);
-  if (r.candidate !== version) errs.push(`candidate "${r.candidate}" ≠ ${version} — must witness the PUBLISHED :${version} images`);
+  // The receipt names the CANDIDATE whose bytes were walked. That is either the release itself
+  // (witnessed after publish) or one of its candidates, `<version>-rc.N` — and a candidate is not
+  // a different artifact: `release-images`' stable publish COPIES the witnessed candidate's
+  // descriptors ("publish exact witnessed candidate as stable"), it never rebuilds. Demanding
+  // candidate === version made the gate unsatisfiable before promote, since :<version> does not
+  // exist until promote publishes it; v0.12.23 shipped `v0.12.23-rc.18` here and would fail this
+  // check today. What must never pass is a candidate of a DIFFERENT release.
+  if (r.candidate !== version && !String(r.candidate || "").startsWith(`${version}-`)) {
+    errs.push(
+      `candidate "${r.candidate}" is not ${version} nor a ${version}-rc — the receipt must witness ` +
+      `the bytes published as :${version} (the stable publish copies the witnessed candidate)`,
+    );
+  }
   if (!nonEmpty(r.witnessed_by)) errs.push("witnessed_by is empty — name the human who ran the pass");
   if (!nonEmpty(r.witnessed_at)) errs.push("witnessed_at is empty — ISO date of the pass");
   if (!nonEmpty(r.deployment)) errs.push("deployment is empty — which install shape was witnessed (compose|lite|helm)");

--- a/scripts/release-witness-gate.test.mjs
+++ b/scripts/release-witness-gate.test.mjs
@@ -32,6 +32,29 @@ const receipt = (o) => ({
 });
 const digestErrs = (r) => validateReceipt(r, V).errs.filter((e) => /truncated image digest/.test(e));
 
+// ── the candidate rule (the release, or one of ITS candidates) ─────────────────────────────
+
+const candErrs = (r) => validateReceipt(r, V).errs.filter((e) => /^candidate /.test(e));
+
+test("GREEN: candidate === version (witnessed after publish) passes", () => {
+  assert.equal(candErrs(receipt({ candidate: V })).length, 0);
+});
+
+test("GREEN: a candidate OF this release passes — the stable publish copies the witnessed bytes", () => {
+  assert.equal(candErrs(receipt({ candidate: `${V}-rc.5` })).length, 0);
+  assert.equal(candErrs(receipt({ candidate: `${V}-rc.18` })).length, 0);
+});
+
+test("RED: a candidate of a DIFFERENT release is rejected", () => {
+  const errs = candErrs(receipt({ candidate: "v9.9.8-rc.1" }));
+  assert.equal(errs.length, 1);
+  assert.match(errs[0], /not v9\.9\.9 nor a v9\.9\.9-rc/);
+});
+
+test("RED: a version PREFIX is not a candidate of it (v9.9.9 vs v9.9.90-rc.1)", () => {
+  assert.equal(candErrs(receipt({ candidate: "v9.9.90-rc.1" })).length, 1);
+});
+
 // ── the truncated-digest rule — RED shapes ──────────────────────────────────────────────────────
 
 test("RED: 8-hex prefix + ellipsis in deployment (the shipped v0.12.10 shape) flags, naming the field", () => {


### PR DESCRIPTION
Found while drafting the v0.12.27 witness receipt (#1649).

`validateReceipt` demanded `candidate === version` — that the receipt witness `:vX.Y.Z`, a tag that does not exist until `promote` publishes it. So the pass had to happen before the artifact it attests to. It is not hypothetical: **`releases/v0.12.23/witness.json` carries `candidate: "v0.12.23-rc.18"` and would fail this check today**; the other eight receipts pass only because they were filled in after their tag was already published.

A candidate of the same release is not a different artifact: `release-images`' stable job **copies the witnessed candidate's descriptors** ("publish exact witnessed candidate as stable") and never rebuilds, so witnessing `rc.N` is witnessing the bytes that become `:vX.Y.Z`.

- accept `vX.Y.Z` and `vX.Y.Z-*`
- still reject a candidate of a **different** release (`v9.9.8-rc.1` for `v9.9.9`)
- still reject a mere prefix collision (`v9.9.90-rc.1` for `v9.9.9`)
- four tests added; `node --test scripts/release-witness-gate.test.mjs` → 16 pass

Verified against the real v0.12.27 receipt: with this change the gate's only remaining failure is `signed_off is not true`, which is the founder's act.

COMMITMENTS IN THIS DRAFT — none.
<!-- vexa-agent -->

## Contribution rights
<!-- Select exactly ONE. This is a legal certification: an agent may explain the choices but
     must not select one for you. See CONTRIBUTOR_RIGHTS.md. -->

- [x] **Independent:** I created this contribution, or otherwise have the right to submit it
  under Apache-2.0, and it is not owned or controlled by an employer, client, or other entity.
  <!-- rights:independent -->
- [ ] **Employer/client authorization required:** an employer, client, or other entity owns or
  may control this contribution. I am requesting Vexa's private corporate-authorization process.
  <!-- rights:corporate -->
- [ ] **Unsure:** I need a private rights review before merge.
  <!-- rights:uncertain -->