### PR TITLE
feat(identity): calendar connections can carry an OAuth refresh token, encrypted at rest

### DIFF
--- a/core/identity/services/admin-api/src/admin_api/app/calendars.py
+++ b/core/identity/services/admin-api/src/admin_api/app/calendars.py
@@ -1,7 +1,14 @@
 """Calendar connection value object stored inside the identity-owned user document.
 
-Feed URLs are credentials.  Only ``internal_connections`` includes them; every
+Feed URLs and refresh tokens are credentials.  Only ``internal_connections`` includes them; every
 user-facing representation goes through ``masked_connection``.
+
+A connection names its ``provider``.  ``ics`` is the original: the user pastes a secret feed URL.
+``google`` and ``microsoft`` are OAuth-backed and carry a refresh token instead — **encrypted at
+rest** through ``field_crypto``, never stored in the clear.  The two kinds differ in exactly one
+more place than you would expect: an ICS connection is mirrored into the legacy singular
+``calendar_ics_url`` keys for old clients, and an OAuth one is not, because those keys mean "a feed
+URL" to every reader that predates this.
 """
 from __future__ import annotations
 
@@ -12,6 +19,10 @@ from uuid import NAMESPACE_URL, uuid4, uuid5
 from fastapi import HTTPException, status
 
 MAX_CALENDAR_CONNECTIONS = 10
+
+PROVIDER_ICS = "ics"
+OAUTH_PROVIDERS = frozenset({"google", "microsoft"})
+REFRESH_TOKEN_FIELD = "calendar_refresh_token"
 
 
 def validate_bot_name(value: str) -> str:
@@ -64,17 +75,58 @@ def connections_from_data(data: dict, user_id: int, *, include_deleted: bool = F
     return connections if include_deleted else [c for c in connections if not c.get("deleted")]
 
 
-def new_connection(*, name: str, ics_url: str, auto_join: bool = True,
-                   bot_name: str = "Vexa") -> dict:
+def _validate_name(name: str) -> str:
     cleaned_name = name.strip()
     if not cleaned_name:
         raise HTTPException(status.HTTP_422_UNPROCESSABLE_ENTITY, detail="name is required")
     if len(cleaned_name) > 100:
         raise HTTPException(status.HTTP_422_UNPROCESSABLE_ENTITY, detail="name too long")
+    return cleaned_name
+
+
+def new_connection(*, name: str, ics_url: str, auto_join: bool = True,
+                   bot_name: str = "Vexa") -> dict:
     return {
         "id": str(uuid4()),
-        "name": cleaned_name,
+        "name": _validate_name(name),
+        "provider": PROVIDER_ICS,
         "ics_url": validate_ics_url(ics_url),
+        "auto_join": bool(auto_join),
+        "bot_name": validate_bot_name(bot_name),
+        "enabled": True,
+    }
+
+
+def new_oauth_connection(*, name: str, provider: str, refresh_token: str,
+                         account_email: str = "", provider_calendar_id: str = "primary",
+                         auto_join: bool = True, bot_name: str = "Vexa",
+                         box=None) -> dict:
+    """An OAuth-backed connection. The refresh token is encrypted HERE, or the call is refused.
+
+    ``box`` is the user's ``field_crypto.UserSecretBox``. It is optional in the signature only so
+    this module stays importable on a deployment with no KEK — but a missing box while creating an
+    OAuth connection is a **hard stop**, never a fallback to plaintext. A feed URL in the clear
+    exposes one calendar's contents; a refresh token in the clear is ongoing, silent read access
+    until somebody revokes it, and the two do not deserve the same treatment.
+    """
+    if provider not in OAUTH_PROVIDERS:
+        raise HTTPException(status.HTTP_422_UNPROCESSABLE_ENTITY,
+                            detail=f"provider must be one of {', '.join(sorted(OAUTH_PROVIDERS))}")
+    if not (refresh_token or "").strip():
+        raise HTTPException(status.HTTP_422_UNPROCESSABLE_ENTITY, detail="refresh_token is required")
+    if box is None:
+        raise HTTPException(
+            status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=("calendar sign-in is unavailable on this deployment: no secret-encryption key "
+                    "is configured, and a refresh token is never stored unencrypted"),
+        )
+    return {
+        "id": str(uuid4()),
+        "name": _validate_name(name),
+        "provider": provider,
+        "refresh_token": box.encrypt(REFRESH_TOKEN_FIELD, refresh_token.strip()),
+        "account_email": (account_email or "").strip().lower() or None,
+        "provider_calendar_id": (provider_calendar_id or "primary").strip(),
         "auto_join": bool(auto_join),
         "bot_name": validate_bot_name(bot_name),
         "enabled": True,
@@ -96,17 +148,34 @@ def store_connections(data: dict, connections: list[dict]) -> dict:
 
 
 def masked_connection(connection: dict) -> dict:
+    """The user-facing shape. Built by ALLOWLIST, never by deleting secrets from a copy.
+
+    A denylist ("copy the connection, pop the token") leaks by default: the next field anyone adds
+    is exposed until somebody remembers to remove it. This returns only named keys, so a new secret
+    is invisible until it is deliberately published — and there is a test that a refresh token
+    cannot appear here.
+    """
     url = connection.get("ics_url") or ""
     host = urlparse(url).hostname or ""
-    return {
+    provider = connection.get("provider") or PROVIDER_ICS
+    masked = {
         "id": connection["id"],
         "name": connection.get("name") or "Calendar",
+        "provider": provider,
         "ics_url_set": bool(url),
         "ics_url_masked": f"{host}/…{url[-4:]}" if url else None,
         "auto_join": bool(connection.get("auto_join", True)),
         "bot_name": connection.get("bot_name") or "Vexa",
         "enabled": bool(connection.get("enabled", True)),
     }
+    if provider in OAUTH_PROVIDERS:
+        # Which account is connected is the useful thing to show — it is how a user with two Google
+        # accounts tells the connections apart. The token itself has no masked form: unlike a feed
+        # URL there is no recognisable tail worth showing, so nothing about it is published beyond
+        # whether the connection is authorised at all.
+        masked["account_email"] = connection.get("account_email")
+        masked["connected"] = bool(connection.get("refresh_token"))
+    return masked
 
 
 def legacy_connection_id(connections: list[dict], user_id: int) -> Optional[str]:
@@ -123,14 +192,28 @@ def legacy_connection_id(connections: list[dict], user_id: int) -> Optional[str]
     return connections[0]["id"] if connections else None
 
 
-def internal_connections(data: dict, user_id: int) -> list[dict]:
+def internal_connections(data: dict, user_id: int, *, cipher=None) -> list[dict]:
     """Flatten one user's connections for the secret-gated meeting-api edge.
 
-    Three shapes cross the hop.  A LIVE connection carries its feed URL and syncs normally.  A
-    DELETED one is a tombstone: no URL, and the sweep parses it as an empty feed so its managed
-    rows retire.  A DISABLED one (``enabled: false``) is a tombstone too — a paused calendar must
-    leave no meeting armed — and re-enabling re-imports on the next sweep.
+    Three shapes cross the hop.  A LIVE connection carries its credential and syncs normally.  A
+    DELETED one is a tombstone: no credential, and the sweep parses it as an empty feed so its
+    managed rows retire.  A DISABLED one (``enabled: false``) is a tombstone too — a paused calendar
+    must leave no meeting armed — and re-enabling re-imports on the next sweep.
+
+    An OAuth connection's refresh token is **decrypted here**, on the way out, and crosses only this
+    internal hop — exactly as the secret feed URL already does.  Decryption stays on this side of
+    the wall so the whole decrypt-then-use path is one grep in one service.
+
+    A connection whose token will not decrypt is skipped, not raised on.  This function takes the
+    CIPHER rather than an already-opened box on purpose: opening the box is itself a decrypt (it
+    unwraps the user's data key) and so is itself a place that throws.  Taking the box would have
+    moved that failure to the caller — the config sweep — where one user's rotated KEK blanks the
+    whole list and stops every other user's calendar.  The unreadable connection surfaces as
+    ``unreadable`` so the caller can say "reconnect" instead of silently syncing nothing.
     """
+    from .field_crypto import SecretCryptoError
+
+    box = cipher.open_user(user_id, data) if cipher is not None else None
     connections = connections_from_data(data, user_id, include_deleted=True)
     legacy_id = legacy_connection_id(connections, user_id)
     out = []
@@ -150,7 +233,25 @@ def internal_connections(data: dict, user_id: int) -> list[dict]:
         elif connection.get("ics_url"):
             out.append({
                 **entry,
+                "provider": PROVIDER_ICS,
                 "ics_url": connection["ics_url"],
+                "auto_join": bool(connection.get("auto_join", True)),
+            })
+        elif connection.get("provider") in OAUTH_PROVIDERS and connection.get("refresh_token"):
+            try:
+                token = (box.decrypt(REFRESH_TOKEN_FIELD, connection["refresh_token"])
+                         if box is not None else None)
+            except SecretCryptoError:
+                token = None
+            if not token:
+                out.append({**entry, "provider": connection["provider"], "unreadable": True})
+                continue
+            out.append({
+                **entry,
+                "provider": connection["provider"],
+                "refresh_token": token,
+                "provider_calendar_id": connection.get("provider_calendar_id") or "primary",
+                "account_email": connection.get("account_email"),
                 "auto_join": bool(connection.get("auto_join", True)),
             })
     return out

--- a/core/identity/services/admin-api/src/admin_api/app/field_crypto.py
+++ b/core/identity/services/admin-api/src/admin_api/app/field_crypto.py
@@ -198,6 +198,24 @@ class SecretCipher:
         data[DEK_FIELD] = self.wrap_dek(dek, user_id)
         return UserSecretBox(dek, user_id)
 
+    def open_user(self, user_id: int | str, data: Mapping[str, Any]) -> Optional[UserSecretBox]:
+        """This user's box for READING — ``None`` when there is nothing readable. Never mints.
+
+        ``for_user`` is the write path: it creates a DEK when none exists and mutates ``data``. A
+        read path must do neither, and it must not raise on one bad row. A sweep that reads many
+        users' secrets should skip the user whose DEK will not unwrap — a rotated KEK, a row
+        restored from an older backup — rather than fail the whole pass and take every other user's
+        sync down with it. The caller can tell ``None`` from an empty result and surface "reconnect"
+        for that one user.
+        """
+        wrapped = data.get(DEK_FIELD)
+        if not (isinstance(wrapped, str) and wrapped.startswith(DEK_PREFIX)):
+            return None
+        try:
+            return UserSecretBox(self.unwrap_dek(wrapped, user_id), user_id)
+        except SecretCryptoError:
+            return None
+
 
 def require_readable(cipher: Optional[SecretCipher], data: Mapping[str, Any],
                      fields: tuple[str, ...]) -> None:

--- a/core/identity/services/admin-api/tests/test_calendar_config.py
+++ b/core/identity/services/admin-api/tests/test_calendar_config.py
@@ -163,9 +163,12 @@ def test_plural_calendars_are_independent_and_never_echo_secret_urls(client):
     internal = client.get("/internal/calendar-configs",
                           headers={"X-Internal-Secret": INTERNAL_SECRET}).json()["configs"]
     active = next(c for c in internal if c.get("calendar_id") == personal.json()["id"])
+    # `provider` is new: a LIVE config now names how it is read, so the sweep never has to infer
+    # "no provider means a feed URL". Tombstones are unchanged — a retired connection retires the
+    # same way whatever it was read from.
     assert active == {
         "user_id": uid, "calendar_id": personal.json()["id"], "calendar_name": "Family",
-        "ics_url": ICS_2, "auto_join": True, "bot_name": "Family Notes",
+        "provider": "ics", "ics_url": ICS_2, "auto_join": True, "bot_name": "Family Notes",
     }
     retired = next(c for c in internal if c.get("calendar_id") == work.json()["id"])
     # The first connection is the legacy claimant even as a tombstone: its sweep

--- a/core/identity/services/admin-api/tests/test_calendar_oauth_connections.py
+++ b/core/identity/services/admin-api/tests/test_calendar_oauth_connections.py
@@ -1,0 +1,191 @@
+"""Calendar connections that carry an OAuth refresh token instead of a secret feed URL.
+
+The tests that matter are the leak tests. A refresh token is ongoing, silent read access to a
+customer's whole calendar, so the interesting questions are: can it be stored in the clear (no),
+can it reach a user-facing response (no), and does one unreadable token take down everybody else's
+sync (no).
+"""
+from __future__ import annotations
+
+import base64
+
+import pytest
+from fastapi import HTTPException
+
+from admin_api.app.calendars import (
+    OAUTH_PROVIDERS,
+    PROVIDER_ICS,
+    REFRESH_TOKEN_FIELD,
+    connections_from_data,
+    internal_connections,
+    masked_connection,
+    new_connection,
+    new_oauth_connection,
+    store_connections,
+)
+from admin_api.app.field_crypto import KEK_ENV, SecretCipher
+
+TOKEN = "1//0g-a-real-looking-refresh-token"
+KEK = base64.urlsafe_b64encode(b"k" * 32).decode()
+OTHER_KEK = base64.urlsafe_b64encode(b"j" * 32).decode()
+
+
+def box_for(user_id: int, data: dict, kek: str = KEK):
+    return SecretCipher.from_env({KEK_ENV: kek}).for_user(user_id, data)
+
+
+def google(data: dict, user_id: int = 7, **over) -> dict:
+    kwargs = dict(name="Work", provider="google", refresh_token=TOKEN,
+                  account_email="Ann@Example.com", box=box_for(user_id, data))
+    kwargs.update(over)
+    return new_oauth_connection(**kwargs)
+
+
+# ------------------------------------------------------------------------------------ at rest
+
+def test_the_refresh_token_is_never_stored_in_the_clear():
+    data: dict = {}
+    connection = google(data)
+
+    assert TOKEN not in repr(connection)
+    assert connection["refresh_token"].startswith("enc:v1:")
+
+
+def test_a_deployment_with_no_encryption_key_refuses_to_create_the_connection():
+    """The whole point of doing #876 before this: no KEK means no OAuth calendar, not a plaintext
+    token. A feed URL in the clear is one calendar's contents; this is ongoing access."""
+    with pytest.raises(HTTPException) as exc:
+        new_oauth_connection(name="Work", provider="google", refresh_token=TOKEN, box=None)
+
+    assert exc.value.status_code == 503
+    assert "never stored unencrypted" in exc.value.detail
+
+
+def test_an_empty_or_unknown_provider_is_refused():
+    data: dict = {}
+    for provider in ("", "ics", "yahoo", "GOOGLE"):
+        with pytest.raises(HTTPException):
+            google(data, provider=provider)
+
+
+def test_an_empty_refresh_token_is_refused():
+    data: dict = {}
+    with pytest.raises(HTTPException):
+        google(data, refresh_token="   ")
+
+
+# ------------------------------------------------------------------------------ the user-facing shape
+
+def test_the_masked_shape_cannot_carry_the_token():
+    data: dict = {}
+    masked = masked_connection(google(data))
+
+    assert "refresh_token" not in masked
+    assert TOKEN not in repr(masked)
+    assert masked["provider"] == "google"
+    assert masked["connected"] is True
+    assert masked["account_email"] == "ann@example.com"
+
+
+def test_masking_is_an_allowlist_so_a_future_secret_is_invisible_by_default():
+    """A denylist leaks whatever anybody adds next. This is the regression that matters more than
+    any single field."""
+    data: dict = {}
+    connection = google(data)
+    connection["some_new_credential_nobody_thought_about"] = "leak-me"
+
+    assert "leak-me" not in repr(masked_connection(connection))
+
+
+def test_an_ics_connection_still_masks_exactly_as_before():
+    connection = new_connection(name="Work", ics_url="https://calendar.google.com/x/private-a/basic.ics")
+    masked = masked_connection(connection)
+
+    assert masked["provider"] == PROVIDER_ICS
+    assert masked["ics_url_set"] is True
+    assert masked["ics_url_masked"].startswith("calendar.google.com/")
+    assert "account_email" not in masked and "connected" not in masked
+
+
+# --------------------------------------------------------------------------------- the internal hop
+
+def test_the_internal_edge_hands_over_a_decrypted_token():
+    data: dict = {}
+    data = store_connections(data, [google(data)])
+
+    (entry,) = internal_connections(data, 7, cipher=SecretCipher.from_env({KEK_ENV: KEK}))
+
+    assert entry["provider"] == "google"
+    assert entry["refresh_token"] == TOKEN
+    assert entry["provider_calendar_id"] == "primary"
+    assert entry["auto_join"] is True
+
+
+def test_an_unreadable_token_skips_that_calendar_and_never_stalls_the_others():
+    """A rotated KEK or a restored-from-backup row must not blank the whole config list — that
+    would stop every other user's calendar in the same sweep."""
+    data: dict = {}
+    good = new_connection(name="Feed", ics_url="https://calendar.google.com/x/private-a/basic.ics")
+    data = store_connections(data, [google(data), good])
+
+    entries = internal_connections(data, 7, cipher=SecretCipher.from_env({KEK_ENV: OTHER_KEK}))
+
+    oauth = next(e for e in entries if e.get("provider") == "google")
+    assert oauth["unreadable"] is True
+    assert "refresh_token" not in oauth
+    assert any(e.get("ics_url") for e in entries), "the healthy feed still syncs"
+
+
+def test_no_box_at_all_marks_the_connection_unreadable_rather_than_syncing_nothing_silently():
+    data: dict = {}
+    data = store_connections(data, [google(data)])
+
+    (entry,) = internal_connections(data, 7, cipher=None)
+
+    assert entry["unreadable"] is True
+
+
+def test_a_paused_oauth_connection_is_a_tombstone_like_any_other():
+    data: dict = {}
+    connection = google(data)
+    connection["enabled"] = False
+    data = store_connections(data, [connection])
+
+    (entry,) = internal_connections(data, 7, cipher=SecretCipher.from_env({KEK_ENV: KEK}))
+
+    assert entry["paused"] is True
+    assert "refresh_token" not in entry
+
+
+# ------------------------------------------------------------------------------- legacy mirroring
+
+def test_an_oauth_connection_never_writes_the_legacy_feed_url_keys():
+    """`calendar_ics_url` means 'a feed URL' to every reader that predates OAuth. Mirroring an
+    OAuth connection into it would hand them something they cannot fetch."""
+    data: dict = {}
+    out = store_connections({}, [google(data)])
+
+    assert "calendar_ics_url" not in out
+
+
+def test_an_ics_connection_alongside_an_oauth_one_still_mirrors():
+    data: dict = {}
+    feed = new_connection(name="Feed", ics_url="https://calendar.google.com/x/private-a/basic.ics")
+    out = store_connections({}, [google(data), feed])
+
+    assert out["calendar_ics_url"] == feed["ics_url"]
+
+
+def test_existing_connections_without_a_provider_still_load():
+    """Every row written before this change has no `provider` key."""
+    legacy = {"id": "abc", "name": "Calendar", "ics_url": "https://x/basic.ics", "enabled": True}
+    (loaded,) = connections_from_data({"calendar_connections": [legacy]}, 7)
+
+    assert masked_connection(loaded)["provider"] == PROVIDER_ICS
+
+
+def test_the_field_name_is_shared_with_the_cipher_so_aad_matches():
+    """field_crypto binds ciphertext to (user, field). Encrypting under one field name and
+    decrypting under another fails authentication — so both sides must use this constant."""
+    assert REFRESH_TOKEN_FIELD == "calendar_refresh_token"
+    assert OAUTH_PROVIDERS == {"google", "microsoft"}


### PR DESCRIPTION
**Stacked on [#1644](https://github.com/Vexa-ai/vexa/pull/1644)** (the secret envelope) — base that
first, or the diff here reads as two changes. Together with
[#1636](https://github.com/Vexa-ai/vexa/pull/1636) this is the storage half of calendar OAuth; the
browser-facing authorize/callback endpoint is still unwritten.

## COMMITMENTS IN THIS PR

**None.** No published terms, no dates, no rights, no spend. One internal-contract change is
described below.

## What changes

A calendar connection now names its `provider`:

| provider | credential | mirrored into the legacy `calendar_ics_url` keys |
|---|---|---|
| `ics` (default, unchanged) | a pasted secret feed URL | yes |
| `google` / `microsoft` | an OAuth refresh token, **encrypted at rest** | no |

OAuth connections are deliberately not mirrored: `calendar_ics_url` means *a feed URL* to every
reader that predates this, and handing them a token they cannot fetch would be worse than absence.

## Three decisions worth review

**No KEK means no OAuth calendar — a 503, never a plaintext fallback.** This is why #876 came first.
A feed URL in the clear exposes one calendar's contents; a refresh token in the clear is ongoing,
silent read access until somebody revokes it. The two do not deserve the same treatment, so the
create path refuses rather than degrades.

**`masked_connection` is now an allowlist, not copy-and-delete.** A denylist leaks by default: the
next field anyone adds is published until somebody remembers to remove it. There is a test that adds
an unknown credential to a connection and asserts it cannot reach the user-facing shape — that
regression matters more than any single field.

**`internal_connections` takes the cipher, not an already-opened box** — and this is the one I got
wrong first. Opening the box unwraps the user's data key, which is itself a decrypt and so is itself
a place that throws. Taking a box would have moved that failure up into the config sweep, where
**one** user's rotated KEK blanks the whole list and stops **every** user's calendar. The test that
asserts otherwise failed on the first shape and is what found it. Caught inside the function, that
one connection surfaces as `unreadable` and everyone else syncs.

Also adds `SecretCipher.open_user`: the read path — never mints a DEK, returns `None` instead of
raising. `for_user` remains the write path.

## Contract change

A **live** `/internal/calendar-configs` entry now carries `provider`, so the consuming sweep never
has to infer "no provider means a feed URL". `test_calendar_config.py`'s exact-shape assertion is
updated to match. Tombstones are unchanged — a retired connection retires the same way whatever it
was read from. The extra key is additive for existing consumers.

## Tests

14 new in `tests/test_calendar_oauth_connections.py`, weighted toward the leak questions: can the
token be stored in the clear (no), reach a user-facing response (no), or take down everybody else's
sync when unreadable (no).

```
41 passed — the container-free admin-api tests
  test_calendar_oauth_connections.py · test_field_crypto.py · test_calendar_internal_connections.py
```

**Not run:** `test_calendar_config.py`. Its conftest starts Postgres and Redis through
testcontainers, and container workloads do not run on the founder's laptop. I read its assertions
statically instead, which is how the exact-shape break above was found before CI rather than after.
CI is the check on that file.


---

## Contribution rights
<!-- Select exactly ONE. This is a legal certification: an agent may explain the choices but
     must not select one for you. See CONTRIBUTOR_RIGHTS.md. -->

- [ ] **Independent:** I created this contribution, or otherwise have the right to submit it
  under Apache-2.0, and it is not owned or controlled by an employer, client, or other entity.
  <!-- rights:independent -->
- [ ] **Employer/client authorization required:** an employer, client, or other entity owns or
  may control this contribution. I am requesting Vexa's private corporate-authorization process.
  <!-- rights:corporate -->
- [ ] **Unsure:** I need a private rights review before merge.
  <!-- rights:uncertain -->

Every commit must also carry the contributor's own DCO `Signed-off-by` line.

> Nothing is ticked and nothing will be — an agent may explain the choices but must not select one.
> The commits also need sign-off: `git rebase --signoff feat/secret-field-crypto && git push --force-with-lease`
