### PR TITLE
release: pin the v0.12.27 stable-promotion map identity

### DIFF
--- a/.github/workflows/release-validate.yml
+++ b/.github/workflows/release-validate.yml
@@ -1028,6 +1028,9 @@ jobs:
             v0.12.23)
               EXPECTED_MAP_SHA256=c5a310465b9005573c9fef79534e34a7822447d6c7004f24271ed59df61fe2a6
               ;;
+            v0.12.27)
+              EXPECTED_MAP_SHA256=5dfc6f51c2b2cde6ba0f152b06de0ae35624c09e8ad159b3555cd92c6674178d
+              ;;
             *)
               echo "::error ::$VERSION has no reviewed stable-promotion map identity"
               exit 1


### PR DESCRIPTION
Blocks the v0.12.27 release. Run [34094971517](https://github.com/Vexa-ai/vexa/actions/runs/34094971517): all nine validate legs green on the published `:v0.12.27` images, image-identity green, **guarantee line 7 green on the founder's signed receipt**, guarantee line 8 green, the owner's `release-promote` Environment approval given — and `promote` then refused with `v0.12.27 has no reviewed stable-promotion map identity`.

`promote` carries its **own** map table, independent of the resolve table, so the moving tag never moves on a map nobody re-pinned there. Only `v0.12.18` and `v0.12.23` have arms; 0.12.24, 0.12.25 and 0.12.26 were published by tag push and never took this path.

This adds `v0.12.27) EXPECTED_MAP_SHA256=5dfc6f51c2b2cde6ba0f152b06de0ae35624c09e8ad159b3555cd92c6674178d` — the frozen packet on main (rc.5, validate run [34059966981](https://github.com/Vexa-ai/vexa/actions/runs/34059966981), nine legs green). It is the same hash the resolve table pins, re-stated because this table is a second review rather than a copy.

`release/*.test.mjs` 33 pass; the workflow parses.

After merge: re-dispatch `release-validate` with `promote: true` from main; the moving tag `:v012` then moves to the witnessed digests and the release is complete.

COMMITMENTS IN THIS DRAFT — none.
<!-- vexa-agent -->

## Contribution rights
<!-- Select exactly ONE. This is a legal certification: an agent may explain the choices but
     must not select one for you. See CONTRIBUTOR_RIGHTS.md. -->

- [x] **Independent:** I created this contribution, or otherwise have the right to submit it
  under Apache-2.0, and it is not owned or controlled by an employer, client, or other entity.
  <!-- rights:independent -->
- [ ] **Employer/client authorization required:** an employer, client, or other entity owns or
  may control this contribution. I am requesting Vexa's private corporate-authorization process.
  <!-- rights:corporate -->
- [ ] **Unsure:** I need a private rights review before merge.
  <!-- rights:uncertain -->